### PR TITLE
Shortform array

### DIFF
--- a/access.php
+++ b/access.php
@@ -50,11 +50,11 @@ if( getPostValue( 'auser' ) != '' && getPostValue( 'submit' ) == $saveStr ) {
     $perm .= ( getPostValue( 'access_' . $i ) == 'Y' ? 'Y' : 'N' );
   }
 
-  dbi_execute( 'DELETE FROM webcal_access_function WHERE cal_login = ?',
-    array( $auser ) );
+  dbi_execute( 'DELETE FROM webcal_access_function
+  WHERE cal_login = ?', [$auser] );
 
   if( ! dbi_execute( 'INSERT INTO webcal_access_function( cal_login,
-      cal_permissions ) VALUES ( ?, ? )', array( $auser, $perm ) ) )
+      cal_permissions ) VALUES ( ?, ? )', [$auser, $perm] ) )
     die_miserable_death( str_replace( 'XXX', dbi_error(), $dbErrStr ) );
 
   $saved = true;
@@ -70,10 +70,10 @@ if( getPostValue( 'otheruser' ) != '' && getPostValue( 'submit' ) == $saveStr ) 
     // If user is not admin,
     // reverse values so they are granting access to their own calendar.
     if( ! $is_admin )
-      list( $puser, $pouser ) = array( $pouser, $puser );
+      list( $puser, $pouser ) = [$pouser, $puser];
 
     dbi_execute( 'DELETE FROM webcal_access_user WHERE cal_login = ?
-      AND cal_other_user = ?', array( $puser, $pouser ) );
+    AND cal_other_user = ?', [$puser, $pouser] );
 
     if( empty( $pouser ) )
       break;
@@ -94,7 +94,7 @@ if( getPostValue( 'otheruser' ) != '' && getPostValue( 'submit' ) == $saveStr ) 
         cal_other_user, cal_can_view, cal_can_edit, cal_can_approve,
         cal_can_invite, cal_can_email, cal_see_time_only )
         VALUES ( ?, ?, ?, ?, ?, ?, ?, ? )',
-        array(
+        [
           $puser,
           $pouser,
           ( $view_total > 0 ? $view_total : 0 ),
@@ -102,7 +102,7 @@ if( getPostValue( 'otheruser' ) != '' && getPostValue( 'submit' ) == $saveStr ) 
           ( $approve_total > 0 && $puser != '__public__' ? $approve_total : 0 ),
           ( strlen( $invite ) ? $invite : 'N' ),
           ( strlen( $email ) ? $email : 'N' ),
-          ( strlen( $time ) ? $time : 'N' ) ) ) )
+          ( strlen( $time ) ? $time : 'N' )] ) )
       die_miserable_death( str_replace( 'XXX', dbi_error(), $dbErrStr ) );
 
     $saved = true;
@@ -211,9 +211,9 @@ if( ! empty( $guser ) || ! $is_admin ) {
     $div = ceil( ACCESS_NUMBER_FUNCTIONS / 4 );
 
     // We can reorder the display of user rights here.
-    $order = array(
+    $order = [
       1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 27,
-      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26];
     // Make sure that we have defined all the types of access
     // defined in access.php.
     assert( count( $order ) == ACCESS_NUMBER_FUNCTIONS );
@@ -250,9 +250,9 @@ if( ! empty( $guser ) || ! $is_admin ) {
         }
       }
       if( $show )
-        echo print_checkbox( array( 'access_' . $order[$i], 'Y',
+        echo print_checkbox ( ['access_' . $order[$i], 'Y',
             access_get_function_description( $order[$i] ),
-            substr( $access, $order[$i], 1 ) ), 'dito' ) . '<br />';
+            substr( $access, $order[$i], 1 )], 'dito' ) . '<br />';
 
       if( ( $i + 1 ) % $div == 0 )
         echo '
@@ -279,7 +279,7 @@ if( ! empty( $guser ) || ! $is_admin ) {
   }
 
   if( $guser == '__default__' ) {
-    $userlist = array( '__default__' );
+    $userlist = ['__default__'];
     $otheruser = $otheruser_login = '__default__';
     $otheruser_fullname = $defConfigStr;
   } else
@@ -334,13 +334,12 @@ if( ! empty( $otheruser ) ) {
        . translate( 'Approve/Reject' ) ) . '</th>
           </tr>';
 
-    $access_type = array(
+    $access_type = [
       '',
       translate( 'Events' ),
       translate( 'Tasks' ),
       '',
-      translate( 'Journals' )
-      );
+      translate( 'Journals' )];
 
     for( $j = 1; $j < 5; $j++ ) {
       $bottomedge = '';

--- a/assistant_edit.php
+++ b/assistant_edit.php
@@ -24,8 +24,8 @@ echo '
 $assistStr = translate ( 'Assistants' );
 if ( $is_nonuser_admin ) {
   nonuser_load_variables ( $user, 'nonuser' );
-  echo $nonuserfullname . ' ' . $assistStr . '<br />
-      -- ' . translate ( 'Admin mode' ) . ' --';
+  echo $nonuserfullname . ' ' . $assistStr . '<br /><span class="dblHyphens">
+      ' . translate ( 'Admin mode' ) . '</span>';
 } else
   echo translate ( 'Your assistants' );
 
@@ -33,8 +33,7 @@ echo '</h2>
       ' . display_admin_link() . '
       <table summary="">
         <tr>
-          <td class="aligntop"><label for="users">'
- . $assistStr . ':</label></td>
+          <td class="aligntop colon"><label for="users">' . $assistStr . '</label></td>
           <td>
             <select name="users[]" id="users" size="10" multiple="multiple">';
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -201,7 +201,7 @@ function build_entry_label ( $event, $popupid,
   if ( $not_my_entry && $tmpAccess == 'R' && !
     ( $can_access &PRIVATE_WT ) ) {
     if ( $time_only != 'Y' )
-      $ret = '(' . translate ( 'Private' ) . ')';
+      $ret = '<span class="parentheses">' . translate ( 'Private' ) . '</span>';
 
     $eventinfo .= build_entry_popup ( $popupid, $tmpLogin,
       str_replace ( 'XXX', translate ( 'private' ),

--- a/pref.php
+++ b/pref.php
@@ -41,7 +41,7 @@ function save_pref( $prefs, $src) {
           '( ?, ?, ? )';
         if ( ! dbi_execute ( $sql, array ( $prefuser, $setting, $value ) ) ) {
           $error = 'Unable to update preference: ' . dbi_error() .
-   '<br /><br /><span class="bold">SQL:</span>' . $sql;
+   '<br /><br /><span class="bold colon">SQL</span>' . $sql;
           break;
         }
       }
@@ -285,7 +285,7 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
  <legend><?php etranslate ('Language')?></legend>
 <table cellspacing="1" cellpadding="2" border="0" summary="">
 <tr><td class="tooltipselect" title="<?php etooltip ("language-help");?>">
- <label for="pref_lang"><?php etranslate ( 'Language' )?>:</label></td><td>
+ <label for="pref_lang" class="colon"><?php etranslate ( 'Language' )?></label></td><td>
  <select name="pref_LANGUAGE" id="pref_lang">
 <?php
  define_languages(); //load the language list
@@ -315,15 +315,15 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
 <table cellspacing="1" cellpadding="2" border="0" summary="">
 <?php if ( $can_set_timezone == true ) { ?>
 <tr><td class="tooltipselect" title="<?php etooltip ( 'tz-help' )?>">
-  <label for="pref_TIMEZONE"><?php etranslate ( 'Timezone Selection' )?>:</label></td><td>
+  <label for="pref_TIMEZONE" class="colon"><?php etranslate ( 'Timezone Selection' )?></label></td><td>
   <?php
    if ( empty ( $prefarray['TIMEZONE'] ) ) $prefarray['TIMEZONE'] = $SERVER_TIMEZONE;
    echo print_timezone_select_html ( 'pref_', $prefarray['TIMEZONE']);
   ?>
 </td></tr>
  <?php } //end $can_set_timezone ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'date-format-help' );?>">
- <?php etranslate ( 'Date format' )?>:</td><td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'date-format-help' );?>">
+ <?php etranslate ( 'Date format' )?></td><td>
  <select name="pref_DATE_FORMAT">
   <?php
   for ( $i = 0, $cnt = count ( $datestyles ); $i < $cnt; $i += 2 ) {
@@ -373,13 +373,13 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
   date_to_str( $dateYmd, $DATE_FORMAT_TASK, false, false );?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'time-format-help' )?>">
- <?php etranslate ( 'Time format' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'time-format-help' )?>">
+ <?php etranslate ( 'Time format' )?></td><td>
  <?php echo print_radio ( 'TIME_FORMAT',
    array ( '12'=>translate ( '12 hour' ), '24'=>translate ( '24 hour' ) ) ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-week-starts-on' )?>">
- <?php etranslate ( 'Week starts on' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-week-starts-on' )?>">
+ <?php etranslate ( 'Week starts on' )?></td><td>
  <select name="pref_WEEK_START" id="pref_WEEK_START">
 <?php
  for ( $i = 0; $i < 7; $i++ ) {
@@ -390,8 +390,8 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
 ?>
  </select>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-weekend-starts-on' )?>">
- <?php etranslate ( 'Weekend starts on' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-weekend-starts-on' )?>">
+ <?php etranslate ( 'Weekend starts on' )?></td><td>
  <select name="pref_WEEKEND_START" id="pref_WEEKEND_START">
 <?php
  for ( $i = -1; $i < 6; $i++ ) {
@@ -403,8 +403,8 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
 ?>
  </select>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'work-hours-help' )?>">
- <?php etranslate ( 'Work hours' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'work-hours-help' )?>">
+ <?php etranslate ( 'Work hours' )?></td><td>
  <label for="pref_starthr"><?php etranslate ( 'From' )?></label>
  <select name="pref_WORK_DAY_START_HOUR" id="pref_starthr">
 <?php
@@ -432,8 +432,8 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
 <fieldset>
  <legend><?php etranslate ('Appearance')?></legend>
 <table cellspacing="1" cellpadding="2" border="0" summary="">
-<tr><td class="tooltip" title="<?php etooltip ( 'preferred-view-help' );?>"><?php
-etranslate ( 'Preferred view' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'preferred-view-help' );?>"><?php
+etranslate ( 'Preferred view' )?></td><td>
 <select name="pref_STARTVIEW">
 <?php
 // For backwards compatibility. We used to store without the .php extension
@@ -483,51 +483,51 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
 </select>
 </td></tr>
 
-<tr><td class="tooltipselect" title="<?php etooltip ( 'fonts-help' )?>">
- <label for="pref_font"><?php etranslate ( 'Fonts')?>:</label></td><td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'fonts-help' )?>">
+ <label for="pref_font"><?php etranslate ( 'Fonts')?></label></td><td>
  <input type="text" size="40" name="pref_FONTS" id="pref_font" value="<?php echo htmlspecialchars ( $prefarray['FONTS'] );?>" />
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'display-sm_month-help' );?>">
- <?php etranslate ( 'Display small months' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-sm_month-help' );?>">
+ <?php etranslate ( 'Display small months' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_SM_MONTH' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'display-weekends-help' );?>">
- <?php etranslate ( 'Display weekends' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-weekends-help' );?>">
+ <?php etranslate ( 'Display weekends' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_WEEKENDS' ) ?>
 </td></tr>
- <tr><td class="tooltip" title="<?php etooltip ( 'display-long-daynames-help' );?>">
-  <?php etranslate ( 'Display long day names' )?>:</td><td>
+ <tr><td class="tooltip colon" title="<?php etooltip ( 'display-long-daynames-help' );?>">
+  <?php etranslate ( 'Display long day names' )?></td><td>
   <?php echo print_radio ( 'DISPLAY_LONG_DAYS' ) ?>
  </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ("display-minutes-help")?>">
- <?php etranslate ( 'Display 00 minutes always' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ("display-minutes-help")?>">
+ <?php etranslate ( 'Display 00 minutes always' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_MINUTES' ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ("display-end-times-help")?>">
- <?php etranslate ( 'Display end times on calendars' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ("display-end-times-help")?>">
+ <?php etranslate ( 'Display end times on calendars' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_END_TIMES' ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-alldays-help' );?>">
-  <?php etranslate ( 'Display all days in month view' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-alldays-help' );?>">
+  <?php etranslate ( 'Display all days in month view' )?></td><td>
   <?php echo print_radio ( 'DISPLAY_ALL_DAYS_IN_MONTH' ) ?>
  </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-week-number-help' )?>">
- <?php etranslate ( 'Display week number' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-week-number-help' )?>">
+ <?php etranslate ( 'Display week number' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_WEEKNUMBER' ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-tasks-help' )?>">
- <?php etranslate ( 'Display small task list' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-tasks-help' )?>">
+ <?php etranslate ( 'Display small task list' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_TASKS' ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-tasks-in-grid-help' )?>">
- <?php etranslate ( 'Display tasks in Calendars' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-tasks-in-grid-help' )?>">
+ <?php etranslate ( 'Display tasks in Calendars' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_TASKS_IN_GRID' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'lunar-help' )?>">
- <?php etranslate ( 'Display Lunar Phases in month view' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'lunar-help' )?>">
+ <?php etranslate ( 'Display Lunar Phases in month view' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_MOON_PHASES' ) ?>
 </td></tr>
 
@@ -537,20 +537,20 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
  <legend><?php etranslate ('Events')?></legend>
 <table cellspacing="1" cellpadding="2" border="0" summary="">
 
-<tr><td class="tooltip" title="<?php etooltip ( 'display-unapproved-help' );?>">
- <?php etranslate ( 'Display unapproved' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-unapproved-help' );?>">
+ <?php etranslate ( 'Display unapproved' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_UNAPPROVED' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'timed-evt-len-help' );?>">
- <?php etranslate ( 'Specify timed event length by' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'timed-evt-len-help' );?>">
+ <?php etranslate ( 'Specify timed event length by' )?></td><td>
  <?php echo print_radio ( 'TIMED_EVT_LEN',
    array ( 'D'=>translate ( 'Duration' ), 'E'=>translate ( 'End Time' ) ) ) ?>
 </td></tr>
 
 <?php if ( ! empty ( $categories ) ) { ?>
 <tr><td>
- <label for="pref_cat"><?php etranslate ( 'Default Category' )?>:</label></td><td>
+ <label for="pref_cat" class="colon"><?php etranslate ( 'Default Category' )?></label></td><td>
  <select name="pref_CATEGORY_VIEW" id="pref_cat">
 <?php
  if ( ! empty ( $categories ) ) {
@@ -565,17 +565,17 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
  </select>
 </td></tr>
 <?php } //end if (! empty ($categories ) ) ?>
-<tr><td class="tooltip" title="<?php etooltip ( 'crossday-help' )?>">
- <?php etranslate ( 'Disable Cross-Day Events' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'crossday-help' )?>">
+ <?php etranslate ( 'Disable Cross-Day Events' )?></td><td>
  <?php echo print_radio ( 'DISABLE_CROSSDAY_EVENTS' ) ?>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'display-desc-print-day-help' );?>">
- <?php etranslate ( 'Display description in printer day view' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display-desc-print-day-help' );?>">
+ <?php etranslate ( 'Display description in printer day view' )?></td><td>
  <?php echo print_radio ( 'DISPLAY_DESC_PRINT_DAY' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'entry-interval-help' )?>">
- <?php etranslate ( 'Entry interval' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'entry-interval-help' )?>">
+ <?php etranslate ( 'Entry interval' )?></td><td>
  <select name="pref_ENTRY_SLOTS">
   <option value="24" <?php if ( $prefarray['ENTRY_SLOTS'] == "24" )
     echo $selected?>>1 <?php etranslate ( 'hour' )?></option>
@@ -593,8 +593,8 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
     echo $selected?>>1 <?php etranslate ( 'minute' )?></option>
  </select>
 </td></tr>
-<tr><td class="tooltip" title="<?php etooltip ( 'time-interval-help' )?>">
- <?php etranslate ( 'Time interval' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'time-interval-help' )?>">
+ <?php etranslate ( 'Time interval' )?></td><td>
  <select name="pref_TIME_SLOTS">
   <option value="24" <?php if ( $prefarray['TIME_SLOTS'] == "24" )
   echo $selected?>>1 <?php etranslate ( 'hour' )?></option>
@@ -614,13 +614,13 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
  <legend><?php etranslate ('Miscellaneous')?></legend>
 <table cellspacing="1" cellpadding="2" border="0" summary="">
 
-<tr><td class="tooltip" title="<?php etooltip ( 'auto-refresh-help' );?>">
- <?php etranslate ( 'Auto-refresh calendars' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'auto-refresh-help' );?>">
+ <?php etranslate ( 'Auto-refresh calendars' )?></td><td>
  <?php echo print_radio ( 'AUTO_REFRESH' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'auto-refresh-time-help' );?>">
- &nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'Auto-refresh time' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'auto-refresh-time-help' );?>">
+ &nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'Auto-refresh time' )?></td><td>
  <input type="text" name="pref_AUTO_REFRESH_TIME" size="4" value="<?php echo ( empty ( $prefarray['AUTO_REFRESH_TIME'] ) ? 0 : $prefarray['AUTO_REFRESH_TIME'] ); ?>" /> <?php etranslate ( 'minutes' )?>
 </td></tr>
 </table>
@@ -633,8 +633,8 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
 <table cellspacing="1" cellpadding="2" border="0" width="35%" summary="">
 <tr><td class="tooltip"  title="<?php etooltip ( 'theme-reload-help' );?>"colspan="3"><?php
 etranslate ( 'Page may need to be reloaded for new Theme to take effect' )?></td></tr>
-<tr><td  class="tooltipselect" title="<?php etooltip ( 'themes-help' );?>">
- <label for="pref_THEME"><?php etranslate ( 'Themes' )?>:</label></td><td>
+<tr><td  class="tooltipselect colon" title="<?php etooltip ( 'themes-help' );?>">
+ <label for="pref_THEME"><?php etranslate ( 'Themes' )?></label></td><td>
  <select name="pref_THEME" id="pref_THEME">
 <?php
   echo "<option value=\"none\" disabled=\"disabled\"  $selected>" .
@@ -649,8 +649,8 @@ etranslate ( 'Page may need to be reloaded for new Theme to take effect' )?></td
  <input type="button" name="preview" value="<?php etranslate ( 'Preview' ) ?>" onclick="return showPreview()" />
 </td></tr>
 <?php if ( $MENU_ENABLED == 'Y' ) { ?>
- <tr><td  class="tooltip" title="<?php etooltip ( 'menu-themes-help' );?>">
- <label for="pref_MENU_THEME"><?php etranslate ( 'Menu theme' )?>:</label></td><td>
+ <tr><td  class="tooltip colon" title="<?php etooltip ( 'menu-themes-help' );?>">
+ <label for="pref_MENU_THEME"><?php etranslate ( 'Menu theme' )?></label></td><td>
  <select name="pref_MENU_THEME" id="pref_MENU_THEME">
 <?php
   echo '<option value="default" ' . ($prefarray['MENU_THEME'] == 'default' ?
@@ -674,44 +674,44 @@ if ( $SEND_EMAIL == 'Y' ) { ?>
 <div id="tabscontent_email">
 <table cellspacing="1" cellpadding="2" summary="">
 <tr><td class="tooltip">
-<tr><td class="tooltip" title="<?php etooltip('email-format');?>">
- <?php etranslate ( 'Email format preference' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-format');?>">
+ <?php etranslate ( 'Email format preference' )?></td><td>
  <?php echo print_radio ( 'EMAIL_HTML',
    array ( 'Y'=> translate ( 'HTML' ), 'N'=>translate ( 'Plain Text' ) ) ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-include-ics');?>">
- <?php etranslate ( 'Include iCalendar attachments' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-include-ics');?>">
+ <?php etranslate ( 'Include iCalendar attachments' )?></td><td>
  <?php echo print_radio ( 'EMAIL_ATTACH_ICS', '', '', 0 ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-reminders-help');?>">
- <?php etranslate ( 'Event reminders' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-reminders-help');?>">
+ <?php etranslate ( 'Event reminders' )?></td><td>
  <?php echo print_radio ( 'EMAIL_REMINDER' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-added');?>">
- <?php etranslate ( 'Events added to my calendar' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-added');?>">
+ <?php etranslate ( 'Events added to my calendar' )?></td><td>
  <?php echo print_radio ( 'EMAIL_EVENT_ADDED' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-updated');?>">
- <?php etranslate ( 'Events updated on my calendar' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-updated');?>">
+ <?php etranslate ( 'Events updated on my calendar' )?></td><td>
  <?php echo print_radio ( 'EMAIL_EVENT_UPDATED' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-deleted');?>">
- <?php etranslate ( 'Events removed from my calendar' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-deleted');?>">
+ <?php etranslate ( 'Events removed from my calendar' )?></td><td>
  <?php echo print_radio ( 'EMAIL_EVENT_DELETED' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-rejected');?>">
- <?php etranslate ( 'Event rejected by participant' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-rejected');?>">
+ <?php etranslate ( 'Event rejected by participant' )?></td><td>
  <?php echo print_radio ( 'EMAIL_EVENT_REJECTED' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip('email-event-create');?>">
- <?php etranslate ( 'Event that I create' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip('email-event-create');?>">
+ <?php etranslate ( 'Event that I create' )?></td><td>
  <?php echo print_radio ( 'EMAIL_EVENT_CREATE' ) ?>
 </td></tr>
 </table>
@@ -722,16 +722,16 @@ if ( $SEND_EMAIL == 'Y' ) { ?>
 <div id="tabscontent_boss">
 <table cellspacing="1" cellpadding="2" summary="">
 <?php if ( $SEND_EMAIL == 'Y' ) { ?>
-<tr><td class="tooltip"><?php etranslate ( 'Email me event notification' )?>:</td><td>
+<tr><td class="tooltip colon"><?php etranslate ( 'Email me event notification' )?></td><td>
  <?php echo print_radio ( 'EMAIL_ASSISTANT_EVENTS' ) ?>
 </td></tr>
 <?php } //end email ?>
-<tr><td class="tooltip"><?php etranslate ( 'I want to approve events' )?>:</td><td>
+<tr><td class="tooltip colon"><?php etranslate ( 'I want to approve events' )?></td><td>
  <?php echo print_radio ( 'APPROVE_ASSISTANT_EVENT' ) ?>
 </td></tr>
 
-<tr><td class="tooltip" title="<?php etooltip ( 'display_byproxy-help' )?>"><?php
-  etranslate ( 'Display if created by Assistant' )?>:</td><td>
+<tr><td class="tooltip colon" title="<?php etooltip ( 'display_byproxy-help' )?>"><?php
+  etranslate ( 'Display if created by Assistant' )?></td><td>
   <?php echo print_radio ( 'DISPLAY_CREATED_BYPROXY' ) ?>
 </td></tr>
 </table>
@@ -742,10 +742,10 @@ if ( $SEND_EMAIL == 'Y' ) { ?>
 <div id="tabscontent_subscribe">
 <table cellspacing="1" cellpadding="2" summary="">
 <?php if ( $PUBLISH_ENABLED == 'Y' || $RSS_ENABLED == 'Y') { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'allow-view-subscriptions-help' )?>"><?php etranslate ( 'Allow remote viewing of' );
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'allow-view-subscriptions-help' )?>"><?php etranslate ( 'Allow remote viewing of' );
 $publish_access = ( empty( $prefarray['USER_REMOTE_ACCESS'] )
    ? 0 : $prefarray['USER_REMOTE_ACCESS'] );
-?>:</td><td>
+?></td><td>
   <select name="pref_USER_REMOTE_ACCESS">
    <option value="0" <?php echo ( $publish_access == '0' ?
      $selected : '' ) . ' >' . translate ( 'Public' ) . ' ' .
@@ -760,11 +760,11 @@ $publish_access = ( empty( $prefarray['USER_REMOTE_ACCESS'] )
   </td></tr>
 <?php }
 if ( $PUBLISH_ENABLED == 'Y' ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'allow-remote-subscriptions-help' )?>"><?php etranslate ( 'Allow remote subscriptions' )?>:</td><td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'allow-remote-subscriptions-help' )?>"><?php etranslate ( 'Allow remote subscriptions' )?></td><td>
   <?php echo print_radio ( 'USER_PUBLISH_ENABLED' ) ?>
 </td></tr>
 <?php if ( ! empty ( $SERVER_URL ) ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'remote-subscriptions-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'remote-subscriptions-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?></td>
   <td>
   <?php
     echo htmlspecialchars ( $SERVER_URL ) .
@@ -775,14 +775,14 @@ if ( $PUBLISH_ENABLED == 'Y' ) { ?>
   ?></td></tr>
 <?php } /* $SERVER_URL */ ?>
 
-<tr><td class="tooltipselect" title="<?php
+<tr><td class="tooltipselect colon" title="<?php
  etooltip ( 'allow-remote-publishing-help' )?>"><?php
- etranslate ( 'Allow remote publishing' )?>:</td>
+ etranslate ( 'Allow remote publishing' )?></td>
   <td>
   <?php echo print_radio ( 'USER_PUBLISH_RW_ENABLED' ) ?>
 </td></tr>
 <?php if ( ! empty ( $SERVER_URL ) ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'remote-publishing-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'remote-publishing-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?></td>
   <td>
   <?php
     echo htmlspecialchars ( $SERVER_URL ) .
@@ -793,13 +793,13 @@ if ( $PUBLISH_ENABLED == 'Y' ) { ?>
 } /* $PUBLISH_ENABLED */
 
 if ( $RSS_ENABLED == 'Y' ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'rss-enabled-help' )?>"><?php
-  etranslate ( 'Enable RSS feed' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'rss-enabled-help' )?>"><?php
+  etranslate ( 'Enable RSS feed' )?></td>
   <td>
   <?php echo print_radio ( 'USER_RSS_ENABLED' ) ?>
 </td></tr>
 <?php if ( ! empty ( $SERVER_URL ) ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'rss-feed-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'rss-feed-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?></td>
   <td>
   <?php
     echo htmlspecialchars ( $SERVER_URL ) .
@@ -808,12 +808,12 @@ if ( $RSS_ENABLED == 'Y' ) { ?>
 <?php } /* $SERVER_URL */
 } /* $RSS_ENABLED */ ?>
 
-<tr><td class="tooltipselect" title="<?php etooltip ( 'freebusy-enabled-help' )?>"><?php etranslate ( 'Enable FreeBusy publishing' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'freebusy-enabled-help' )?>"><?php etranslate ( 'Enable FreeBusy publishing' )?></td>
   <td>
   <?php echo print_radio ( 'FREEBUSY_ENABLED' ) ?>
 </td></tr>
 <?php if ( ! empty ( $SERVER_URL ) ) { ?>
-<tr><td class="tooltipselect" title="<?php etooltip ( 'freebusy-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?>:</td>
+<tr><td class="tooltipselect colon" title="<?php etooltip ( 'freebusy-url-help' )?>">&nbsp;&nbsp;&nbsp;&nbsp;<?php etranslate ( 'URL' )?></td>
   <td>
   <?php
     echo htmlspecialchars ( $SERVER_URL ) .
@@ -831,24 +831,24 @@ if ( $RSS_ENABLED == 'Y' ) { ?>
 <div id="tabscontent_header">
 <table cellspacing="1" cellpadding="2" summary="">
 <?php if ( $CUSTOM_SCRIPT == 'Y' ) { ?>
- <tr><td class="tooltip" title="<?php etooltip ( 'custom-script-help' );?>">
-  <?php etranslate ( 'Custom script/stylesheet' )?>:</td><td>
+ <tr><td class="tooltip colon" title="<?php etooltip ( 'custom-script-help' );?>">
+  <?php etranslate ( 'Custom script/stylesheet' )?></td><td>
   <input type="button" value="<?php etranslate ( 'Edit' );?>..." onclick=<?php
     printf ( $openStr, 'S',$prefuser ) ?> name="" />
  </td></tr>
 <?php }
 
 if ( $CUSTOM_HEADER == 'Y' ) { ?>
- <tr><td class="tooltip" title="<?php etooltip ( 'custom-header-help' );?>">
-  <?php etranslate ( 'Custom header' )?>:</td><td>
+ <tr><td class="tooltip colon" title="<?php etooltip ( 'custom-header-help' );?>">
+  <?php etranslate ( 'Custom header' )?></td><td>
   <input type="button" value="<?php etranslate ( 'Edit' );?>..." onclick=<?php
     printf ( $openStr, 'H',$prefuser ) ?> name="" />
  </td></tr>
 <?php }
 
 if ( $CUSTOM_TRAILER == 'Y' ) { ?>
- <tr><td class="tooltip" title="<?php etooltip ( 'custom-trailer-help' );?>">
-  <?php etranslate ( 'Custom trailer' )?>:</td><td>
+ <tr><td class="tooltip colon" title="<?php etooltip ( 'custom-trailer-help' );?>">
+  <?php etranslate ( 'Custom trailer' )?></td><td>
   <input type="button" value="<?php etranslate ( 'Edit' );?>..." onclick=<?php
     printf ( $openStr, 'T',$prefuser ) ?> name="" />
  </td></tr>

--- a/purge.php
+++ b/purge.php
@@ -118,8 +118,8 @@ onclick="history.back()" /></form
 
 <form action="purge.php" method="post" name="purgeform" id="purgeform">
 <table>
- <tr><td><label for="user">
-  <?php echo translate ( 'User' );?>:</label></td>
+ <tr><td><label for="user" class="colon">
+  <?php echo translate ( 'User' );?></label></td>
  <td><select name="username">
 <?php
   $userlist = get_my_users();
@@ -137,22 +137,22 @@ onclick="history.back()" /></form
 <option value="ALL"><?php echo $allStr ?></option>
   </select>
  </td></tr>
- <tr><td><label for="purge_all">
-  <?php etranslate ( 'Check box to delete ALL events for a user' )?>:</label></td>
+ <tr><td><label for="purge_all" class="colon">
+  <?php etranslate ( 'Check box to delete ALL events for a user' )?></label></td>
   <td valign="bottom">
   <input type="checkbox" name="purge_all" value="Y" id="purge_all" onclick="toggle_datefields( 'dateArea', this );" />
  </td></tr>
- <tr id="dateArea"><td><label>
-  <?php etranslate ( 'Delete all events before' );?>:</label></td><td>
+ <tr id="dateArea"><td><label class="colon">
+  <?php etranslate ( 'Delete all events before' );?></label></td><td>
   <?php echo date_selection ( 'end_', date ( 'Ymd' ) ) ?>
  </td></tr>
- <tr><td><label for="purge_deleted">
-  <?php etranslate ( 'Purge deleted only' )?>:</label></td>
+ <tr><td><label for="purge_deleted" class="colon">
+  <?php etranslate ( 'Purge deleted only' )?></label></td>
   <td valign="bottom">
   <input type="checkbox" name="purge_deleted" value="Y" />
  </td></tr>
- <tr><td><label for="preview">
-  <?php etranslate ( 'Preview delete' )?>:</label></td>
+ <tr><td><label for="preview" class="colon">
+  <?php etranslate ( 'Preview delete' )?></label></td>
   <td valign="bottom">
   <input type="checkbox" name="preview" value="Y" checked="checked" />
  </td></tr>

--- a/register.php
+++ b/register.php
@@ -250,31 +250,31 @@ echo send_doctype( $appStr ) . '
       <table align="center" cellpadding="10" cellspacing="10" summary="">
         <tr>
           <td rowspan="3"><img src="images/register.gif" alt="" /></td>
-          <td align="right"><label>' . translate( 'Username' ) . ':</label></td>
+          <td align="right"><label class="colon">' . translate( 'Username' ) . '</label></td>
           <td align="left"><input type="text" name="user" id="user" value="'
    . $user . '" size="20" maxlength="20" onChange="check_name();" /></td>
         </tr>
         <tr>
-          <td align="right"><label>' . translate( 'First Name' )
-   . ':</label></td>
+          <td align="right"><label class="colon">' . translate( 'First Name' )
+   . '</label></td>
           <td align="left"><input type="text" name="ufirstname" value="'
    . $ufirstname . '" size="25" maxlength="25" /></td>
         </tr>
         <tr>
-          <td align="right"><label>' . translate( 'Last Name' ) . ':</label></td>
+          <td align="right"><label class="colon">' . translate( 'Last Name' ) . '</label></td>
           <td align="left"><input type="text" name="ulastname" value="'
    . $ulastname . '" size="25" maxlength="25" /></td>
         </tr>
         <tr>
-          <td align="right" colspan="2"><label>' . translate( 'E-mail address' )
-   . ':</label></td>
+          <td align="right" colspan="2"><label class="colon">' . translate( 'E-mail address' )
+   . '</label></td>
           <td align="left"><input type="text" name="uemail" id="uemail" value="'
    . $uemail . '" size="40" maxlength="75" onChange="check_uemail();" /></td>
         </tr>
         <tr>
           <td ' . ( $SELF_REGISTRATION_FULL != 'Y'
-    ? 'align="right" colspan="2"><label>' . translate( 'Password' )
-     . ':</label></td>
+    ? 'align="right" colspan="2"><label class="colon">' . translate( 'Password' )
+     . '</label></td>
           <td align="left"><input name="upassword1" value="' . $upassword1
      . '" size="15" type="password" /></td>
         </tr>

--- a/report.php
+++ b/report.php
@@ -304,8 +304,8 @@ if ( empty ( $report_user ) )
 $day_str = $printerStr = '';
 $day_template = '<dt><b>${date}</b></dt><dd><dl>${events}</dl></dd>';
 $event_template = '<dt>${name}</dt>
-<dd><b>' . translate ( 'Date' ) . ':</b> ${date}<br />
-<b>' . translate ( 'Time' ) . ':</b> ${time}<br />
+<dd><b class="colon">' . translate ( 'Date' ) . '</b> ${date}<br />
+<b class="colon">' . translate ( 'Time' ) . '</b> ${time}<br />
 ${description}</dd>';
 $page_template = '<dl>${days}</dl>';
 

--- a/search.php
+++ b/search.php
@@ -62,8 +62,8 @@ if( is_array( $categories ) && $show_advanced ) {
   echo '
         <tr id="catfilter" style="visibility:' . $avdStyle[$show_advanced]
    . ';">
-          <td><label for="cat_filter">' . translate( 'Categories' )
-   . ':</label></td>
+          <td><label for="cat_filter" class="colon">' . translate( 'Categories' )
+   . '</label></td>
           <td>
             <select name="cat_filter" id="cat_filter">
               <option value=""' . $selected . '>' . translate( 'All' )
@@ -84,9 +84,9 @@ if( count( $site_extras ) > 0 ) {
   echo '
         <tr id="extrafilter" style="visibility:' . $avdStyle[$show_advanced]
    . ';">
-          <td><label for="extra_filter">'
+          <td><label for="extra_filter" class="colon">'
    . translate( 'Include' ) . '<br />' . translate( 'Site Extras' )
-   . ':</label></td>
+   . '</label></td>
           <td><input type="checkbox" name="extra_filter" value="Y" />
           </td></tr>';
 }
@@ -95,8 +95,8 @@ if( $show_advanced ) {
   echo '
         <tr id="datefilter" style="visibility:' . $avdStyle[$show_advanced]
    . ';">
-          <td><label for="date_filter">' . translate('Filter by Date')
-   . ':</label></td>
+          <td><label for="date_filter" class="colon">' . translate('Filter by Date')
+   . '</label></td>
           <td>
             <select name="date_filter" id="date_filter" onchange="toggleDateRange()">
               <option value="0"' . $selected . '>' . translate( 'All Dates' )
@@ -108,15 +108,15 @@ if( $show_advanced ) {
           </td>
         </tr>
         <tr id="startDate" style="visibility:hidden">
-          <td>&nbsp;&nbsp;<label>' . translate( 'Start date' )
-   . ':</label></td>
+          <td>&nbsp;&nbsp;<label class="colon">' . translate( 'Start date' )
+   . '</label></td>
           <td>'
    . datesel_Print( 'from_', $dateYmd ) . '
           </td>
         </tr>
         <tr id="endDate" style="visibility:hidden">
-          <td>&nbsp;&nbsp;<label>' . translate( 'End date' )
-   . ':</label></td>
+          <td>&nbsp;&nbsp;<label class="colon">' . translate( 'End date' )
+   . '</label></td>
           <td>'
    . datesel_Print( 'until_', $dateYmd ) . '
           </td>

--- a/set_entry_cat.php
+++ b/set_entry_cat.php
@@ -122,12 +122,12 @@ else {
       <input type="hidden" name="id" value="{$id}" />
       <table border="0" cellpadding="5" summary="">
         <tr class="aligntop">
-          <td class="bold">{$briefStr}:</td>
+          <td class="bold colon">{$briefStr}</td>
           <td>{$event_name}</td>
         </tr>
         <tr>
           <td class="tooltip" title="{$catHelpStr}" valign="top">
-            <label for="entry_categories">{$catStr}:<br /></label>
+            <label for="entry_categories" class="colon">{$catStr}<br /></label>
             <input type="button" value="{$editStr}" onclick="editCats( event )" />
           </td>
           <td valign="top">

--- a/usersel.php
+++ b/usersel.php
@@ -42,8 +42,8 @@ echo '
       <form action="#" name="userselform">
         <table style="border: 0; width: 100%;" summary="">
           <tr>
-            <td class="aligntop">
-              <b>' . translate ( 'Users' ) . ':</b><br />
+            <td class="aligntop colon">
+              <b>' . translate ( 'Users' ) . '</b><br />
               <select name="users" size="15" multiple="multiple">
               </select><br />
               <input type="button" value="' . translate ( 'All' )
@@ -53,7 +53,7 @@ echo '
               <input type="reset" value="' . translate ( 'Reset' ) . '" />
             </td>
             <td valign="top">
-              <b>' . translate ( 'Groups' ) . ':</b><br />
+              <b class="colon">' . translate ( 'Groups' ) . '</b><br />
               <select name="groups" size="15">';
 
 for ( $i = 0, $cnt = count ( $groups ); $i < $cnt; $i++ ) {

--- a/view_entry.php
+++ b/view_entry.php
@@ -394,8 +394,8 @@ echo '
  . '</h2>
     <table width="100%" summary="">
       <tr>
-        <td class="aligntop bold" width="10%">' . translate ( 'Description' )
- . ':</td>
+        <td class="aligntop bold colon" width="10%">' . translate ( 'Description' )
+ . '</td>
         <td>';
 
 if ( ! empty ( $ALLOW_HTML_DESCRIPTION ) && $ALLOW_HTML_DESCRIPTION == 'Y' ) {
@@ -413,18 +413,18 @@ if ( ! empty ( $ALLOW_HTML_DESCRIPTION ) && $ALLOW_HTML_DESCRIPTION == 'Y' ) {
 echo '</td>
       </tr>' . ( $DISABLE_LOCATION_FIELD != 'Y' && ! empty ( $location ) ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Location' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Location' ) . '</td>
         <td>' . $location . '</td>
       </tr>' : '' ) . ( $DISABLE_URL_FIELD != 'Y' && ! empty ( $url ) ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'URL' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'URL' ) . '</td>
         <td>' . activate_urls ( $url ) . '</td>
       </tr>' : '' );
 
 if ( $event_status != 'A' && ! empty ( $event_status ) ) {
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Status' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Status' ) . '</td>
         <td>';
 
   if ( $event_status == 'D' )
@@ -442,36 +442,36 @@ if ( $event_status != 'A' && ! empty ( $event_status ) ) {
 
 echo '
       <tr>
-        <td class="aligntop bold">'
+        <td class="aligntop bold colon">'
  . ( $eType == 'task' ? translate ( 'Start Date' ) : translate ( 'Date' ) )
- . ':</td>
+ . '</td>
         <td>' . date_to_str ( $display_date ) . ( $eType == 'task' ? '</td>
       </tr>' . ( $event_time >= 0 ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Start Time' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Start Time' ) . '</td>
         <td>'
      . display_time ( $display_date . sprintf ( "%06d", $event_time ), 2 )
      . '</td>
       </tr>' : '' ) . '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Due Date' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Due Date' ) . '</td>
         <td>' . date_to_str ( $due_date ) . '</td>
       </tr>
       <tr>
-        <td class="aligntop bold">' . translate ( 'Due Time' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Due Time' ) . '</td>
         <td>' . display_time ( $due_date . sprintf ( "%06d", $due_time ), 2 )
    . '</td>
       </tr>' . ( ! empty ( $cal_completed ) ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Completed' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Completed' ) . '</td>
         <td>' . date_to_str ( $cal_completed ) : '' ) : '' ) . '</td>
       </tr>' . ( $event_repeats ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Repeat Type' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Repeat Type' ) . '</td>
         <td>' . export_recurrence_ical ( $id, true ) . '</td>
       </tr>' : '' ) . ( $eType != 'task' && $event_time >= 0 ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Time' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Time' ) . '</td>
         <td>' . ( $duration == 1440 && $event_time == 0
     ? translate ( 'All day event' )
     : display_time ( $display_date . sprintf ( "%06d", $event_time ),
@@ -485,7 +485,7 @@ if ( $duration > 0 && $duration != 1440 ) {
   $dur_m = $duration - ( $dur_h * 60 );
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Duration' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Duration' ) . '</td>
         <td>' . ( $dur_h > 0 ? $dur_h . ' ' . translate ( 'hour'
        . ( $dur_h == 1 ? '' : 's' ) ) . ' ' : '' )
    . ( $dur_m > 0 ? $dur_m . ' ' . translate ( 'minutes' ) : '' ) . '</td>
@@ -494,11 +494,11 @@ if ( $duration > 0 && $duration != 1440 ) {
 
 echo ( $DISABLE_PRIORITY_FIELD != 'Y' ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Priority' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Priority' ) . '</td>
         <td>' . $cal_priority . '-' . $pri[ceil($cal_priority/3)] .'</td>
       </tr>' : '' ) . ( $DISABLE_ACCESS_FIELD != 'Y' ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Access' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Access' ) . '</td>
         <td>' . ( $cal_access == "P"
     ? translate ( 'Public' )
     : ( $cal_access == 'C'
@@ -506,7 +506,7 @@ echo ( $DISABLE_PRIORITY_FIELD != 'Y' ? '
       : translate ( 'Private' ) ) ) . '</td>
       </tr>' : '' ) . ( $CATEGORIES_ENABLED == 'Y' && ! empty ( $category ) ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Category' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Category' ) . '</td>
         <td>' . $category . '</td>
       </tr>' : '' );
 
@@ -531,7 +531,7 @@ if ( ! empty ( $DISPLAY_CREATED_BYPROXY ) && $DISPLAY_CREATED_BYPROXY == 'Y' ) {
 if ( $single_user == 'N' && ! empty ( $createby_fullname ) ) {
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Created by' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Created by' ) . '</td>
         <td>';
   if ( $is_private && ! access_is_enabled() )
     echo '[' . translate ( 'Private' ) . ']</td>
@@ -558,7 +558,7 @@ if ( $single_user == 'N' && ! empty ( $createby_fullname ) ) {
 
 echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Updated' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Updated' ) . '</td>
         <td>'
  . ( ! empty ( $GENERAL_USE_GMT ) && $GENERAL_USE_GMT == 'Y'
   ? date_to_str ( $mod_date ) . ' ' . display_time ( $mod_date . $mod_time, 3 )
@@ -568,7 +568,7 @@ echo '
 // Display the reminder info if found.
  . ( ! empty ( $reminder ) ? '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Send Reminder' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Send Reminder' ) . '</td>
         <td>' . $reminder . '</td>
       </tr>' : '' );
 
@@ -586,7 +586,7 @@ for ( $i = 0; $i < $site_extracnt; $i++ ) {
   if ( ! empty ( $extras[$extra_name]['cal_name'] )  && ! empty ( $extra_view ) ) {
     echo '
       <tr>
-        <td class="aligntop bold">' . translate ( $site_extras[$i][1] ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( $site_extras[$i][1] ) . '</td>
         <td>';
 
     if ( $extra_type == EXTRA_URL ) {
@@ -627,7 +627,7 @@ if ( $PUBLIC_ACCESS == 'Y' && $login == '__public__' &&
 if ( $single_user == 'N' && $show_participants ) {
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Participants' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Participants' ) . '</td>
         <td>';
 
   $num_app = $num_rej = $num_wait = 0;
@@ -808,7 +808,7 @@ if ( $eType == 'task' ) {
 if ( Doc::attachmentsEnabled() && $rss_view == false ) {
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Attachments' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Attachments' ) . '</td>
         <td>';
 
   $attList = new AttachmentList( $id );
@@ -836,7 +836,7 @@ if ( Doc::attachmentsEnabled() && $rss_view == false ) {
 if ( Doc::commentsEnabled() ) {
   echo '
       <tr>
-        <td class="aligntop bold">' . translate ( 'Comments' ) . ':</td>
+        <td class="aligntop bold colon">' . translate ( 'Comments' ) . '</td>
         <td>';
 
   $comList = new CommentList( $id );

--- a/views_edit.php
+++ b/views_edit.php
@@ -94,11 +94,11 @@ if ( $newview ) {
 
 <table summary="">
 <tr><td>
- <label for="viewname"><?php etranslate ( 'View Name' )?>:</label></td><td colspan="3">
+ <label for="viewname" class="colon"><?php etranslate ( 'View Name' )?></label></td><td colspan="3">
  <input name="viewname" id="viewname" size="20" value="<?php echo htmlspecialchars ( $viewname );?>" />
 </td></tr>
 <tr><td>
- <label for="viewtype"><?php etranslate ( 'View Type' )?>:</label></td><td colspan="3">
+ <label for="viewtype" class="colon"><?php etranslate ( 'View Type' )?></label></td><td colspan="3">
  <select name="viewtype" id="viewtype">
   <option value="D" <?php if ( $viewtype == 'D' )
   echo $selected;?>><?php etranslate ( 'Day' ); ?></option>
@@ -123,15 +123,15 @@ if ( $newview ) {
 
 <?php if ( $is_admin ) {
   $defIdx = ( ! empty ( $viewisglobal ) && $viewisglobal == 'Y' ? 'Y' : 'N' );
-  echo '<tr><td><label>'
-  . translate ( 'Global' ) . ":</label></td>\n<td>"
+  echo '<tr><td><label class="colon">'
+  . translate ( 'Global' ) . "</label></td>\n<td>"
   . print_radio ( 'is_global', '', '', $defIdx, '</td><td>' )
   . "</td></tr>\n";
  }
 
 $defIdx = ( ! empty ( $all_users ) && $all_users == true ? 'Y' : 'N' );
-echo '<tr><td><label>'
-  . translate ( 'Users' ) . ":</label></td>\n<td>"
+echo '<tr><td><label class="colon">'
+  . translate ( 'Users' ) . "</label></td>\n<td>"
   . print_radio ( 'viewuserall', array ( 'N'=>'Selected', 'Y'=>'All'),
     'usermode_handler', $defIdx, '</td><td>' )
   . "</td></tr>\n";

--- a/week_ssi.php
+++ b/week_ssi.php
@@ -23,8 +23,8 @@ if ( strlen ( $login ) == 0 ) {
   if ( strlen ( $webcalendar_login ) > 0 )
     $login = $user = $webcalendar_login;
   else {
-    echo '<span style="color:#F00;"><span style="font-weight: bold;">'
-     . translate ( 'Error' ) . ':</span>'
+    echo '<span style="color:#F00;"><span class="bold colon">' .
+      translate ( 'Error' ) . '</span>'
      . translate( 'No user specified.' ) . '</span>';
     exit;
   }


### PR DESCRIPTION
Converting $a = array()
to $a = [].
Because, 1) it's shorter and therefore faster.
and 2) I read somewhere that, especially in javascript, it's more secure than $a = new Array().
As it's just creating a variable and not calling the "new" process which apparently has been hacked by someone.
This also applies to $o = new Object(). These should also be converted.