### PR TITLE
print header and print_trailer

### DIFF
--- a/activity_log.php
+++ b/activity_log.php
@@ -30,9 +30,6 @@ $startid = getValue ( 'startid', '-?[0-9]+', true );
 $sys = ( $is_admin && getGetValue ( 'system' ) != '' );
 
 print_header();
-
-ob_start();
-
 echo generate_activity_log( '', $sys, $startid ) . '
     <div class="navigation">'
 // Go BACK in time.
@@ -58,9 +55,6 @@ if ( ! empty ( $startid ) ) {
     dbi_free_result ( $res );
   }
 }
-
-ob_end_flush();
-
 echo '
     </div>' . print_trailer();
 

--- a/admin.php
+++ b/admin.php
@@ -173,9 +173,7 @@ if ( is_dir ( $dir ) ) {
 $currenttab = getPostValue ( 'currenttab', 'settings' );
 $currenttab = ( empty( $currenttab ) ? 'settings' : $currenttab );
 
-print_header( array( 'js/translate.js.php' ),
-  '<script type="text/javascript" src="includes/js/admin.js"></script>
-    <script type="text/javascript" src="includes/js/visible.js"></script>',
+print_header ( ['js/translate.js.php','js/admin.js','js/visible.js'], '',
   'onload="init_admin();showTab( \'' . $currenttab . '\' );"' );
 
 if ( ! $error ) {
@@ -338,7 +336,6 @@ if ( ! $error ) {
   }
 
   set_today ( date ( 'Ymd' ) );
-  ob_start();
 
   echo '
     <h2>' . translate ( 'System Settings' )
@@ -928,7 +925,6 @@ if ( ! $error ) {
         <input type="submit" value="' . $saveStr . '" name="" />
       </div>
     </form>';
-  ob_end_flush();
 } else // if $error
   echo print_error ( $error, true );
 

--- a/adminhome.php
+++ b/adminhome.php
@@ -129,19 +129,8 @@ if ( $is_nonuser_admin ) {
 
 @session_start();
 $_SESSION['webcal_tmp_login'] = 'SheIsA1Fine!';
-ob_start();
-print_header( '',
-/*
-  '<style type="text/css">
-      #adminhome table,
-      #adminhome td a {
-        background:' . $CELLBG . '
-      }
-    </style>
- If this is the proper way to call css_cacher.php from here?
- */
-    '<link type="text/css" href="css_cacher.php" rel="stylesheet" />
-    <link type="text/css" href="includes/css/styles.css" rel="stylesheet" />' );
+
+print_header ();
 
 echo '
     <h2>' . translate( 'Administrative Tools' ) . '</h2>
@@ -167,6 +156,5 @@ echo '
       </tr>
     </table>
     ' . print_trailer();
-ob_end_flush();
 
 ?>

--- a/assistant_edit.php
+++ b/assistant_edit.php
@@ -10,11 +10,7 @@ if ( empty ( $login ) || $login == '__public__' ) {
 if ( $user != $login )
   $user = ( ( $is_admin || $is_nonuser_admin ) && $user ) ? $user : $login;
 
-print_header( '', ! $GROUPS_ENABLED == 'Y' ? '' :
-  '<script type="text/javascript" src="includes/js/assistant_edit.js"></script>' );
-
-ob_start();
-
+print_header ( $GROUPS_ENABLED !== 'Y' ? [] : ['js/assistant_edit.js'] );
 echo '
     <form action="assistant_edit_handler.php" method="post" '
  . 'name="assistanteditform">' . ( $user ? '
@@ -74,10 +70,6 @@ echo '
         </tr>
       </table>
     </form>
-    ';
-
-ob_end_flush();
-
-echo print_trailer();
+    ' . print_trailer();
 
 ?>

--- a/availability.php
+++ b/availability.php
@@ -43,8 +43,8 @@ if ( empty ( $users ) ) {
 }
 
 print_header (
-  array ( 'js/availability.php/false/' . "$month/$day/$year/"
-   . getGetValue ( 'form' ) ), '', 'onload="focus();"', true, false, true );
+  ['js/availability.php/false/' . "$month/$day/$year/"
+   . getGetValue ( 'form' )], '', 'onload="focus();"', 1, 0, 1 );
 
 $next_url = $prev_url = '?users=' . $users;
 $time = mktime ( 0, 0, 0, $month, $day, $year );
@@ -76,6 +76,6 @@ echo '</span><br />
     <form action="availability.php" method="post">
       ' . daily_matrix ( $date, $users ) . '
     </form>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/category.php
+++ b/category.php
@@ -48,10 +48,7 @@ if ( ! empty ( $id ) ) {
 $showIconStyle = ( ! empty ( $catIcon ) && file_exists ( $catIcon )
   ? '' : 'display: none;' );
 
-print_header ( array ( 'js/visible.php' ) );
-
-ob_start();
-
+print_header ( ['js/visible.php'] );
 echo '
     <h2>' . translate ( 'Categories' ) . '</h2>
     ' . display_admin_link( false );
@@ -174,7 +171,6 @@ if ( empty ( $error ) ) {
     <p><a href="category.php?add=1">' . translate ( 'Make New Category' )
    . '</a></p><br />';
 }
-ob_end_flush();
 echo ( ! empty ( $error ) ? print_error ( $error ) : '' ) . print_trailer();
 
 ?>

--- a/catsel.php
+++ b/catsel.php
@@ -24,12 +24,8 @@ $entryCatFiller = str_repeat( '&nbsp;', ( 30 - strlen ( $entryCatStr ) ) / 2 );
 if ( strlen ( $entryCatStr ) < 30 )
   $entryCatStr = $entryCatFiller . $entryCatStr . $entryCatFiller;
 
-print_header( array( 'js/catsel.php/false/' . $form ),
-  '<script type=text/javascript" src="includes/js/catsel.js"></script>',
-  '', true, false, true );
-
-ob_start();
-
+print_header( ['js/catsel.php/false/' . $form, 'js/catsel.js'],
+  '', '', 1, 0, 1 );
 echo '
     <table align="center" border="0" width="90%" summary="">
       <tr>
@@ -82,9 +78,6 @@ if ( strlen ( $cats ) ) {
      . htmlentities ( $categories[abs ( $K )]['cat_name'] ) . $show_ast . '</option>';
   }
 }
-
-ob_end_flush();
-
 echo '
           </select>
           <input type="button" value="' . translate ( 'Remove' )
@@ -100,6 +93,6 @@ echo '
       </tr>
       </form>
     </table>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/colors.php
+++ b/colors.php
@@ -12,9 +12,7 @@ $customStr = translate ( 'Custom Colors' );
 $oldStr = translate ( 'Old Color' );
 $okStr = '&nbsp;&nbsp;&nbsp;' . translate ( 'OK' ). '&nbsp;&nbsp;&nbsp;';
 
-print_header( '',
-  '<script type="text/javascript" src="includes/js/colors.js"></script>',
-  'onload="fillhtml(); setInit();"', true, false, true );
+print_header ( ['js/colors.js'], '', 'onload="fillhtml(); setInit();"', 1, 0, 1 );
 
 /*
   HTML Color Editor v1.2 (c) 2000 by Sebastian Weber <webersebastian@yahoo.de>

--- a/combo.php
+++ b/combo.php
@@ -109,11 +109,8 @@ media="screen" />
 <script type="text/javascript" src="includes/js/autocomplete.js"></script>
 ';
 
-print_header(
-  array( 'js/popups.js/true', 'js/visible.php', 'js/datesel.php' ),
+print_header ( ['js/popups.js/true', 'js/visible.php', 'js/datesel.php'],
   $headExtras, $bodyExtras );
-
-//ob_start();
 
 ?>
 
@@ -1985,9 +1982,6 @@ function format_description ( desc )
 </script>
 
 <?php
-
-//ob_end_flush();
-
 echo print_trailer();
 
 ?>

--- a/datesel.php
+++ b/datesel.php
@@ -32,7 +32,7 @@ $wkstart = get_weekday_before ( $thisyear, $thismonth );
 $monthstartYmd = date ( 'Ymd', mktime ( 0, 0, 0, $thismonth, 1, $thisyear ) );
 $monthendYmd = date ( 'Ymd', mktime ( 23, 59, 59, $thismonth + 1, 0, $thisyear ) );
 
-print_header ( '','', '', true, false, true, true, true );
+print_header ( [], '', '', 1, 0, 1, 1, 1 );
 
 //build weekday names
 $wkdys = '';
@@ -115,6 +115,6 @@ echo <<<EOT
   </script>
 EOT;
 
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/day.php
+++ b/day.php
@@ -63,8 +63,7 @@ if ( empty ( $friendly ) ) {
 }
 $eventinfo = ( empty ( $eventinfo ) ? '' : $eventinfo );
 $trailerStr = print_trailer();
-print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ),
-  generate_refresh_meta(), '', false, false, false, false );
+print_header ( ['js/popups.js/true', 'js/dblclick_add.js/true'], generate_refresh_meta() );
 
 echo <<<EOT
 

--- a/edit_entry.php
+++ b/edit_entry.php
@@ -188,10 +188,7 @@ $wkst = 'MO';
 $real_user = ( ( ! empty ( $user ) && strlen ( $user ) ) &&
   ( $is_assistant || $is_admin ) ) ? $user : $login;
 
-//print_header ( $INC, $HEAD, $BodyX, false, false, false, true );
 print_header ( $INC, $HEAD, $BodyX );
-
-ob_start();
 
 if ( $readonly == 'Y' || $is_nonuser )
   $can_edit = false;
@@ -1731,8 +1728,6 @@ if ( $can_edit ) {
 } else
   etranslate( 'You are not authorized to edit this entry.' );
 // end if ( $can_edit )
-
-ob_end_flush();
 
 // Create a hidden div tag for editing categories...
 ?>

--- a/edit_entry_handler.php
+++ b/edit_entry_handler.php
@@ -1227,7 +1227,6 @@ if( empty( $error ) && empty( $mailerError ) ) {
 
 if( ! empty( $conflicts ) ) {
   print_header();
-  ob_start();
   echo '
     <h2>' . translate( 'Scheduling Conflict' ) . '</h2>
     ' . translate( 'Your suggested time of' ) . '

--- a/edit_nonusers.php
+++ b/edit_nonusers.php
@@ -1,8 +1,6 @@
 <?php // $Id: edit_nonusers.php,v 1.29 2009/11/22 16:47:45 bbannon Exp $
 include_once 'includes/init.php';
-print_header( array( 'js/translate.js.php' ),
-  '<script type="text/javascript" src="includes/js/edit_nonusers.js"></script>',
-  '', true, '', true, false );
+print_header ( ['js/translate.js.php', 'js/edit_nonusers.js'], '', '', 1, 0, 1 );
 
 if ( ! $is_admin ) {
   echo print_not_auth ( true ) . '
@@ -39,8 +37,6 @@ if ( ( ( $add == '1' ) || ( ! empty ( $nid ) ) ) && empty ( $error ) ) {
       <input type="text" name="nid" id="calid" size="20" '
      . 'onchange="check_name();" maxlength="20" /> '
      . translate ( 'word characters only' );
-
-  ob_start();
 
   echo '
     <form action="edit_nonusers_handler.php" name="editnonuser" method="post" '
@@ -126,9 +122,6 @@ if ( ( ( $add == '1' ) || ( ! empty ( $nid ) ) ) && empty ( $error ) ) {
     </form>
     ';
 }
-
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/edit_remotes.php
+++ b/edit_remotes.php
@@ -16,8 +16,8 @@
  * if UAC is enabled, then the user must be allowed to ACCESS_IMPORT.
 */
 include_once 'includes/init.php';
-print_header ( array ( 'js/edit_remotes.php/false', 'js/visible.php' ),
-  '', '', true );
+print_header ( ['js/edit_remotes.php/false', 'js/visible.php'],
+  '', '', 1 );
 
 $error = '';
 
@@ -137,6 +137,6 @@ EOT;
   echo '
     </form>';
 }
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/edit_remotes_handler.php
+++ b/edit_remotes_handler.php
@@ -131,7 +131,7 @@ if ( ! empty ( $reload ) ) {
   $errorStr = '<br /><br />
     <b>' . translate ( 'Error' ) . ':</b> ';
 
-  print_header ( '', '', '', true, false, true );
+  print_header ( [], '', '', 1, 0, 1 );
   if ( count ( $data ) && empty ( $errormsg ) ) {
     // Delete existing events.
     delete_events ( $nid );
@@ -160,7 +160,7 @@ if ( ! empty ( $reload ) ) {
     translate( 'There was an error parsing the import file or no events were returned.' )
      . '<br />';
   }
-  echo print_trailer ( false, true, true );
+  echo print_trailer ( 0, 1, 1 );
 }
 
 function delete_events ( $nid ) {

--- a/edit_report.php
+++ b/edit_report.php
@@ -199,12 +199,9 @@ if ( empty ( $error ) && $report_id >= 0 ) {
 print_header();
 
 if ( ! empty ( $error ) ) {
-  echo $error . print_trailer ( false );
+  echo $error . print_trailer ( 0 );
   exit;
 }
-
-ob_start();
-
 echo '
     <h2>'
  . ( $updating_public ? translate ( $PUBLIC_ACCESS_FULLNAME ) . ' ' : '' )
@@ -394,8 +391,6 @@ echo '
    . translate ( 'Delete' ) . '" onclick="return confirm( \''
    . translate( 'Are you sure you want to delete this report?' )
    . '\');" />' );
-
-ob_end_flush();
 
 ?>
           </td>

--- a/edit_template.php
+++ b/edit_template.php
@@ -100,7 +100,7 @@ if ( $REQUEST_METHOD == 'POST' ) {
   }
 }
 
-print_header ( '', '', '', true );
+print_header ( [], '', '', 1 );
 /*
 echo 'report_id: ' . $report_id . '<br />
 report_name: ' . $report_name . '<br />
@@ -137,6 +137,6 @@ echo '</h2>' . ( ! empty ( $error ) ? print_error ( $error ) : '
      . '" onclick="return confirm( \''
      . translate( 'Are you sure you want to delete this entry?' ) . '\');" />'
     : '' ) . '
-    </form>' ) . "\n" . print_trailer ( false, true, true );
+    </form>' ) . "\n" . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/edit_user.php
+++ b/edit_user.php
@@ -28,10 +28,7 @@ if ( empty ( $user ) ) {
   if ( ! access_can_access_function ( ACCESS_ACCOUNT_INFO ) )
     $error = print_not_auth();
 }
-
-$disableCustom = true;
-$INC = array ('js/edit_user.php/false');
-print_header ( $INC, '', '', $disableCustom, '', true, false );
+print_header ( ['js/edit_user.php/false'], '', '', 1, 0, 1 );
 
 if ( ! empty ( $error ) ) {
   echo print_error ( $error );
@@ -173,5 +170,5 @@ if ( $is_admin && ( empty( $user ) || $user != $login ) ) { ?>
 <?php } ?>
 </td></tr></table>
 <?php }
-echo print_trailer ( false, true, true ); ?>
+echo print_trailer ( 0, 1, 1 ); ?>
 

--- a/export.php
+++ b/export.php
@@ -21,10 +21,7 @@ $datem = date ( 'm' );
 $dateY = date ( 'Y' );
 $selected = ' selected="selected" ';
 
-print_header ( array ( 'js/export_import.php', 'js/visible.php' ) );
-
-ob_start();
-
+print_header ( ['js/export_import.php', 'js/visible.php'] );
 echo '
     <h2>' . translate ( 'Export' ) . '</h2>
     <form action="export_handler.php" method="post" name="exportform" id="exportform">
@@ -113,10 +110,6 @@ echo ( ! empty ( $LAYERS_STATUS ) && $LAYERS_STATUS == 'Y' ? '
         </tr>
       </table>
     </form>
-    ';
-
-ob_end_flush();
-
-echo print_trailer();
+    ' . print_trailer();
 
 ?>

--- a/group_edit.php
+++ b/group_edit.php
@@ -22,10 +22,7 @@ else {
   }
 }
 
-print_header ( '', '', '', true );
-
-ob_start();
-
+print_header ( [], '', '', 1 );
 echo '
     <form action="group_edit_handler.php" method="post">
       <h2>';
@@ -104,10 +101,6 @@ echo '
         </tr>
       </table>
     </form>
-    ';
-
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_admin.php
+++ b/help_admin.php
@@ -2,8 +2,7 @@
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
 
-print_header ( '', '', '', true );
-ob_start();
+print_header ( [], '', '', 1 );
 echo $helpListStr . '
     <h2>' . translate ( 'Help' ) . ': ' . translate ( 'System Settings' )
  . '</h2>
@@ -161,10 +160,10 @@ $tmp_arr = array (
   translate ( 'Manually entering color values' ) => translate ( 'colors-help' ),
   );
 list_help ( $tmp_arr );
-ob_end_flush();
+
 echo '
       </div>
     </div>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_bug.php
+++ b/help_bug.php
@@ -9,10 +9,7 @@ if ( empty ( $SERVER_SOFTWARE ) )
 if ( empty ( $HTTP_USER_AGENT ) )
   $HTTP_USER_AGENT = $_SERVER['HTTP_USER_AGENT'];
 
-  print_header ( '', '', '', true );
-
-  ob_start ();
-
+  print_header ( [], '', '', 1 );
   echo $helpListStr . '
     <h2>' . translate ( 'Report Bug' ) . '</h2>
     <p>' .
@@ -48,9 +45,9 @@ if ( empty ( $HTTP_USER_AGENT ) )
   }
 
   list_help ( $tmp_arr );
-  ob_end_flush ();
+
   echo '
     </div>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
   ?>

--- a/help_docs.php
+++ b/help_docs.php
@@ -8,7 +8,7 @@ if ( empty ( $SERVER_SOFTWARE ) )
 if ( empty ( $HTTP_USER_AGENT ) )
   $HTTP_USER_AGENT = $_SERVER['HTTP_USER_AGENT'];
 
-print_header ( '', '', '', true );
+print_header ( [], '', '', 1 );
 
 echo $helpListStr . '
     <h2>' . translate ( 'WebCalendar Documentation' ) . '</h2>
@@ -23,6 +23,6 @@ echo $helpListStr . '
       <li><a href="http://www.k5n.us/wiki/">WebCalendar Wiki</a></li>
     </ul>';
 
-print_trailer ( false, true, true );
+print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_edit_entry.php
+++ b/help_edit_entry.php
@@ -2,10 +2,7 @@
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
 
-print_header ( '', '', '', true );
-
-ob_start();
-
+print_header ( [], '', '', 1 );
 echo $helpListStr . '
     <h2>' . translate ( 'Help' ) . ': '
  . translate ( 'Adding/Editing Calendar Entries' ) . '</h2>';
@@ -45,9 +42,6 @@ if ( $DISABLE_REPEATING_FIELD != 'Y' ) {
     );
   list_help ( $tmp_arr );
 }
-
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_import.php
+++ b/help_import.php
@@ -2,10 +2,7 @@
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
 
-print_header ( '', '', '', true );
-
-ob_start();
-
+print_header ( [], '', '', 1 );
 echo $helpListStr . '
     <h2>' . translate ( 'Help' ) . ': ' . translate ( 'Import' ) . '</h2>
     <h3>' . translate ( 'Palm Desktop' ) . '</h3>
@@ -28,10 +25,6 @@ echo $helpListStr . '
     <h3>iCalendar</h3>
     <p>' . translate ( 'This form will import iCalendar (.ics) events.' ) . ' '
  . translate ( 'Enabling' ) . ' <b>' . translate ( 'Overwrite Prior Import' )
- . '</b>, ' . translate ( 'will cause events imported previously...' ) . '</p>';
-
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+ . '</b>, ' . translate ( 'will cause events imported previously...' ) . '</p>' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_index.php
+++ b/help_index.php
@@ -1,7 +1,7 @@
 <?php // $Id: help_index.php,v 1.29 2009/11/22 16:47:45 bbannon Exp $
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
-print_header ( '', '', '', true );
+print_header ( [], '', '', 1 );
 echo '
     <h2>' . translate ( 'Help Index' ) . '</h2>
     <ul>';
@@ -20,6 +20,6 @@ foreach ( $help_list as $key => $val ) {
 }
 echo '
     </ul>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_layers.php
+++ b/help_layers.php
@@ -1,7 +1,7 @@
 <?php // $Id: help_layers.php,v 1.24 2009/11/22 16:47:45 bbannon Exp $
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
-print_header ( '', '', '', true );
+print_header ( [], '', '', 1 );
 echo $helpListStr . '
     <h2>' . translate ( 'Help' ) . ': ' . translate ( 'Layers' ) . '</h2>
     <p>' .
@@ -27,6 +27,6 @@ if ( $ALLOW_COLOR_CUSTOMIZATION )
     <h3>' . translate ( 'Colors' ) . '</h3>
     <p>' . translate ( 'colors-help' ) . '</p>';
 
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_pref.php
+++ b/help_pref.php
@@ -2,10 +2,7 @@
 include_once 'includes/init.php';
 include_once 'includes/help_list.php';
 
-print_header ( '', '', '', true );
-
-ob_start();
-
+print_header ( [], '', '', 1 );
 echo $helpListStr . '
     <h2>' . translate ( 'Help' ) . ': ' . translate ( 'Preferences' ) . '</h2>
     <h3>' . translate ( 'Settings' ) . '</h3>
@@ -107,10 +104,6 @@ if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' )
       <p>' . translate ( 'colors-help' ) . '</p>';
 
 echo '
-    </div>';
-
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+    </div>' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/help_uac.php
+++ b/help_uac.php
@@ -5,7 +5,7 @@ include_once 'includes/help_list.php';
 $descStr =
 translate ( 'Allows for fine control of user access and permissions. Users can also grant default and per individual permission if authorized by the administrator.' );
 
-print_header ( '', '', '', true, false, true );
+print_header ( [], '', '', 1, 0, 1 );
 echo $helpListStr . '
     <div class="helpbody">
       <h2>' . translate ( 'Help' ) . ': '
@@ -22,6 +22,6 @@ $tmp_arr = array (
 list_help ( $tmp_arr );
 echo '
     </div>
-    ' . print_trailer ( false, true, true );
+    ' . print_trailer ( 0, 1, 1 );
 
 ?>

--- a/icons.php
+++ b/icons.php
@@ -8,7 +8,7 @@ $can_edit = ( is_dir ( $icon_path ) &&
 if ( ! $can_edit )
   do_redirect ( 'category.php' );
 
-print_header ( array ( 'js/visible.php' ), '', '', true );
+print_header ( ['js/visible.php'], '', '', 1 );
 
 $icons = array();
 
@@ -52,7 +52,6 @@ if ( $d = dir ( $icon_path ) ) {
   </script>
 
 <?php
-  ob_start();
   echo '
     <table align="center" border="0" summary="">
       <tr>
@@ -77,8 +76,6 @@ if ( $d = dir ( $icon_path ) ) {
     </table>
   </body>
 </html>';
-
-  ob_end_flush();
 }
 
 ?>

--- a/import.php
+++ b/import.php
@@ -103,9 +103,7 @@ $upload = ini_get ( 'file_uploads' );
 $upload_enabled = ( ! empty( $upload )
    && preg_match( '/(On|1|true|yes)/i', $upload ) );
 
-ob_start();
-
-print_header ( array ( 'js/export_import.php', 'js/visible.php' ),
+print_header ( ['js/export_import.php', 'js/visible.php'],
   '', 'onload="toggle_import();"' );
 echo '
     <h2>' . translate ( 'Import' ) . '&nbsp;<img src="images/help.gif" alt="'
@@ -180,6 +178,5 @@ else {
     </form>';
 }
 echo print_trailer();
-ob_end_flush();
 
 ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1834,7 +1834,7 @@ function error_check ( $nextURL, $redirect = true ) {
 
   $ret = '';
   if ( ! empty ( $error ) ) {
-    print_header ( '', '', '', true );
+    print_header ( '', '', '', 1 );
     $ret .= '
     <h2>' . print_error ( $error ) . '</h2>';
   } else {

--- a/includes/init.php
+++ b/includes/init.php
@@ -96,6 +96,8 @@ function print_header( $includes = '', $HeadX = '', $BodyX = '',
   $POPUP_FG, $PUBLIC_ACCESS, $PUBLIC_ACCESS_FULLNAME, $REQUEST_URI, $SCRIPT,
   $self, $TABLECELLFG, $TEXTCOLOR, $THBG, $THFG, $TODAYCELLBG, $WEEKENDBG;
 
+  ob_start ();
+
   $cs_ret = $lang = $menuHtml = $menuScript = '';
 
   // Remember this view if the file is a view_x.php script.
@@ -345,7 +347,7 @@ function print_trailer( $include_nav_links = true, $closeDb = true,
 
     unset( $c );
   }
-
+  ob_end_flush ();
   return $ret . '
 <!-- ' . $GLOBALS['PROGRAM_NAME'] . '     ' . $GLOBALS['PROGRAM_URL'] . ' -->
 ' // Adds an easy link to validate the pages.

--- a/layers.php
+++ b/layers.php
@@ -50,8 +50,6 @@ $LOADING = '<center><img src="images/loading_animation.gif" alt="" /></center>';
 $public_link = str_replace( 'XXX', $PUBLIC_ACCESS_FULLNAME,
   translate( 'Click to modify layers settings for XXX' ) );
 
-ob_start();
-
 // Add ModalBox javascript/CSS & Tab code
 $headExtras = '
 <script type="text/javascript" src="includes/tabcontent/tabcontent.js"></script>
@@ -61,7 +59,7 @@ $headExtras = '
 media="screen" />
 ';
 
-print_header( array( 'js/translate.js.php', 'js/visible.js/true' ),
+print_header ( ['js/translate.js.php', 'js/visible.js/true'],
   $headExtras, 'onload="load_layers();"' );
 
 if ( $ALLOW_VIEW_OTHER != 'Y' )
@@ -369,6 +367,5 @@ function edit_layer (id)
 
 <?php
 echo print_trailer();
-ob_end_flush();
 
 ?>

--- a/list_unapproved.php
+++ b/list_unapproved.php
@@ -175,10 +175,7 @@ function list_unapproved ( $user ) {
 
   return $ret;
 } //end list_unapproved()
-print_header( array( 'js/popups.js/true' ), generate_refresh_meta() );
-
-ob_start();
-
+print_header ( ['js/popups.js/true'], generate_refresh_meta() );
 echo '
     <h2>' . translate ( 'Unapproved Entries' ) . '</h2>';
 
@@ -312,8 +309,6 @@ echo '
       }
 //]]> -->
     </script>
-    ';
-ob_end_flush();
-echo print_trailer();
+    ' . print_trailer ();
 
 ?>

--- a/minical.php
+++ b/minical.php
@@ -105,7 +105,7 @@ $startdate = mktime ( 0, 0, 0, $thismonth, 1, $thisyear );
 $enddate = mktime ( 23, 59, 59, $thismonth + 1, 0, $thisyear );
 
 // Don't display custom header.
-print_header ( '', generate_refresh_meta(), '', true );
+print_header ( [], generate_refresh_meta(), '', 1 );
 
 /* Pre-Load the repeated events for quicker access. */
 $repeated_events = read_repeated_events ( $user, $startdate, $enddate, $cat_id );

--- a/month.php
+++ b/month.php
@@ -86,13 +86,7 @@ if ( empty ( $friendly ) ) {
 }
 $trailerStr = print_trailer();
 
-$HeadX = generate_refresh_meta()
-  . '<script type="text/javascript" src="includes/js/weekHover.js?'
-  . filemtime( 'includes/js/weekHover.js' ) . '"></script>';
-
-print_header(
-  array( 'js/popups.js/true', 'js/visible.php', 'js/dblclick_add.js/true' ),
-  $HeadX, '', false, false, false, false );
+print_header ( ['js/popups.js/true', 'js/visible.php', 'js/dblclick_add.js/true','js/weekHover.js'], generate_refresh_meta() );
 
 echo <<<EOT
     <table border="0" width="100%" cellpadding="1" summary="">

--- a/search.php
+++ b/search.php
@@ -43,7 +43,6 @@ if( $show_advanced ) {
 if( $show_others )
   $INC[] = 'js/search.js/true';
 
-ob_start();
 print_header( $INC );
 
 echo '    <h2>' . ( $show_advanced ? $advSearchStr : $searchStr ) . '</h2>
@@ -167,8 +166,6 @@ if( $show_others ) {
           </td>
         </tr>';
 }
-ob_end_flush();
-
 echo '</table></form>';
 ?>
 <script language="JavaScript">

--- a/search_handler.php
+++ b/search_handler.php
@@ -241,8 +241,6 @@ if ( substr ( $keywords, 0, $plen ) == $phrasedelim &&
     dbi_free_result ( $res );
   }
 }
-
-ob_start();
 echo '
     <p><strong>';
 if ( $matches > 0 ) {
@@ -275,8 +273,7 @@ echo '
       <form action="search.php' . ( ! empty ( $advanced ) ? '?adv=1' : '' )
         . '"  style="margin-left: 13px;" method="post">
        <input type="submit" value="'
-        . translate ( 'New Search' ) . '" /></form>';
-ob_end_flush();
-echo print_trailer();
+        . translate ( 'New Search' ) . '" /></form>' .
+  print_trailer();
 
 ?>

--- a/security_audit.php
+++ b/security_audit.php
@@ -20,14 +20,13 @@ if ( ! $is_admin || ( access_is_enabled()
 
 $phpinfo = getGetValue( 'phpinfo' );
 if ( $phpinfo == '1' ) {
-  print_header( '', '', '', true );
+  print_header ( [], '', '', 1 );
   phpinfo();
-  print_trailer( false, true, true );
+  print_trailer ( 0, 1, 1 );
   exit;
 }
 clearstatcache();
 print_header();
-ob_start();
 echo '
     <h2>' . translate( 'Security Audit' ) . '</h2>
     <ul id="securityAuditNotes">
@@ -165,7 +164,6 @@ echo '
     </table>
 ' . print_trailer() . '
 <!-- done -->';
-ob_end_flush();
 exit;
 
 /* functions ... */

--- a/select_user.php
+++ b/select_user.php
@@ -26,9 +26,6 @@ if ( ( $ALLOW_VIEW_OTHER != 'Y' && ! $is_admin ) ||
     if ( $url == 'month' || $url == 'day' || $url == 'week' || $url == 'year' )
       $url .= '.php';
   }
-
-  ob_start();
-
   echo '
     <form action="' . $url . '" method="get" name="SelectUser">
       <select name="user" onchange="document.SelectUser.submit()">';
@@ -46,8 +43,6 @@ if ( ( $ALLOW_VIEW_OTHER != 'Y' && ! $is_admin ) ||
       </select>
       <input type="submit" value="' . translate ( 'Go' ) . '" />
     </form>';
-
-  ob_end_flush();
 }
 
 echo '<br /><br />

--- a/set_entry_cat.php
+++ b/set_entry_cat.php
@@ -110,7 +110,7 @@ $globalNoteStr = ( $globals_found
   ? translate ( 'Global Categories cannot be changed.' ) : '' );
 $saveStr = translate ( 'Save' );
 
-print_header ( array ( 'js/set_entry_cat.php/true' ) );
+print_header ( ['js/set_entry_cat.php/true'] );
 
 if ( ! empty ( $error ) )
   echo print_error ( $error );

--- a/users.php
+++ b/users.php
@@ -40,12 +40,10 @@ if ( $is_admin ) {
 $currenttab = getValue ( 'tab', '^(users|groups|nonusers|remotes||)$', true );
 
 $BodyX = 'onload="showTab(\''. $currenttab . '\');"';
-print_header ( array ( 'js/visible.php', 'js/users.php/true' ), '',
-  $BodyX, '', '', true );
+print_header ( ['js/visible.php', 'js/users.php/true'], '', $BodyX, '', '', 1 );
 
 $taborder = array ( 'tabfor', 'tabbak','tabbak','tabbak','tabbak');
 $i=0;
-ob_start();
 
 echo display_admin_link() . '
 <!-- TABS -->
@@ -117,8 +115,6 @@ if ( $doUsers && $doNUCS )
 
 if ( $doRemotes )
   include_once 'remotes.php';
-
-ob_end_flush();
 
 echo '
     </div>

--- a/usersel.php
+++ b/usersel.php
@@ -28,8 +28,7 @@ for ( $i = 0, $cnt = count ( $exp ); $i < $cnt; $i++ ) {
 
 $groups = get_groups( $user );
 
-ob_start();
-print_header( '', '', '', true, false, true );
+print_header ( [], '', '', 1, 0, 1 );
 
 echo '
     <script type="text/javascript">';
@@ -82,8 +81,6 @@ echo '
       </form
     </center>';
 
-ob_end_flush();
-
-echo print_trailer ( false, true, true );
+echo print_trailer ( 0, 1, 1 );
 
 ?>

--- a/view_d.php
+++ b/view_d.php
@@ -30,7 +30,7 @@ view_init ( $id );
 $printerStr = generate_printer_friendly ( 'view_d.php' );
 set_today ( $date );
 
-print_header ( array ( 'js/view_d.php/true' ) );
+print_header ( ['js/view_d.php/true'] );
 
 // get users in this view
 $participants = view_get_user_list ( $id );

--- a/view_l.php
+++ b/view_l.php
@@ -33,9 +33,7 @@ if ( empty ( $friendly ) ) {
   $printerStr = generate_printer_friendly ( 'month.php' );
 }
 set_today ( $date );
-print_header( array( 'js/popups.php/true' ),
-  '<script type="text/javascript" src="includes/js/weekHover.js?'
- . filemtime( 'includes/js/weekHover.js' ) . '"></script>' );
+print_header ( ['js/popups.php/true','js/weekHover.js'] );
 $trailerStr = print_trailer();
 
 $next = mktime ( 3, 0, 0, $thismonth + 1, 1, $thisyear );

--- a/view_m.php
+++ b/view_m.php
@@ -45,7 +45,7 @@ $thisdate = date ( 'Ymd', $startdate );
 $nextStr = translate ( 'Next' );
 $prevStr = translate ( 'Previous' );
 
-print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ) );
+print_header ( ['js/popups.js/true', 'js/dblclick_add.js/true'] );
 
 echo '
     <div style="width:99%;">

--- a/view_r.php
+++ b/view_r.php
@@ -89,7 +89,7 @@ $show_time = ( $is_day_view ? $show_time_day : $show_time_week );
 $printerStr = generate_printer_friendly ( 'view_r.php' );
 set_today ( $date );
 
-print_header( array( 'js/popups.js/true' ) );
+print_header ( ['js/popups.js/true'] );
 
 $thisdate = sprintf ( "%04d%02d%02d", $thisyear, $thismonth, $thisday );
 

--- a/view_t.php
+++ b/view_t.php
@@ -285,7 +285,7 @@ if ( $viewusercnt == 0 )
 
 $printerStr = generate_printer_friendly ( 'view_t.php' );
 
-print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ) );
+print_header ( ['js/popups.js/true', 'js/dblclick_add.js/true'] );
 
 if ( ! empty ( $error ) ) {
   echo print_error( $error ) . print_trailer();
@@ -294,8 +294,6 @@ if ( ! empty ( $error ) ) {
 
 $nextStr = translate ( 'Next' );
 $prevStr = translate ( 'Previous' );
-
-ob_start();
 
 echo '
     <div style="width:99%;">
@@ -359,8 +357,6 @@ for ( $date = $wkstart; $date <= $wkend; $date += 86400 ) {
 }
 
 $user = ''; // reset
-
-ob_end_flush();
 
 echo '
     </table>'

--- a/view_v.php
+++ b/view_v.php
@@ -43,8 +43,7 @@ $prevStr = translate ( 'Previous' );
 
 $can_add = ( empty ( $ADD_LINK_IN_VIEWS ) || $ADD_LINK_IN_VIEWS != 'N' );
 
-ob_start();
-print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ) );
+print_header ( ['js/popups.js/true', 'js/dblclick_add.js/true'] );
 echo '
     <div style="width:99%;">
       <a title="' . $prevStr . '" class="prev" href="view_v.php?id=' . $id
@@ -155,6 +154,5 @@ for ( $j = 0; $j < 7; $j += $DAYS_PER_TABLE ) {
 $user = ''; // reset
 
 echo ( empty ( $eventinfo ) ? '' : $eventinfo ) .$printerStr . print_trailer();
-ob_end_flush();
 
 ?>

--- a/view_w.php
+++ b/view_w.php
@@ -41,7 +41,7 @@ $prevStr = translate ( 'Previous' );
 
 $can_add = ( empty ( $ADD_LINK_IN_VIEWS ) || $ADD_LINK_IN_VIEWS != 'N' );
 
-print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ) );
+print_header ( ['js/popups.js/true', 'js/dblclick_add.js/true'] );
 
 // Get users in this view.
 $viewusers = view_get_user_list ( $id );
@@ -55,9 +55,6 @@ if ( ! empty ( $error ) ) {
   echo print_error( $error ) . print_trailer();
   exit;
 }
-
-ob_start();
-
 echo '
     <div style="width:99%;">
       <a title="' . $prevStr . '" class="prev" href="view_w.php?id=' . $id
@@ -167,9 +164,6 @@ for ( $j = 0; $j < $viewusercnt; $j += $USERS_PER_TABLE ) {
   echo '
     </table>';
 }
-
-ob_end_flush();
-
 $user = ''; // reset
 
 echo ( empty( $eventinfo ) ? '' : $eventinfo ) . $printerStr . print_trailer();

--- a/views.php
+++ b/views.php
@@ -4,8 +4,7 @@ include_once 'includes/init.php';
 if ( ! $is_admin )
   $user = $login;
 
-ob_start();
-print_header( array( 'js/visible.php' ) );
+print_header ( ['js/visible.php'] );
 
 echo display_admin_link() . '
 <!-- TABS -->
@@ -48,7 +47,5 @@ echo '
       </div>
     </div>
     ' . print_trailer();
-
-ob_end_flush();
 
 ?>

--- a/views_edit.php
+++ b/views_edit.php
@@ -19,7 +19,8 @@ if ( ! $is_admin )
   $user = $login;
 
 $BodyX = 'onload="usermode_handler();"';
-$INC = array ( 'js/visible.php');
+$INC = ['js/visible.php'];
+
 if ( $GROUPS_ENABLED == 'Y' )
   $INC[] = 'js/views_edit.php/true';
 
@@ -176,5 +177,5 @@ echo '<tr><td><label>'
 
 </form>
 
-<?php echo print_trailer ( false, true, true ); ?>
+<?php echo print_trailer ( 0, 1, 1 ); ?>
 

--- a/week.php
+++ b/week.php
@@ -242,9 +242,7 @@ if ( $DISPLAY_TASKS == 'Y' ) {
         </td>';
 }
 
-print_header(
-  array( 'js/popups.js/true', 'js/dblclick_add.js/true' ),
-  generate_refresh_meta(), '', false, false, false, false );
+print_header (['js/popups.js/true', 'js/dblclick_add.js/true' ], generate_refresh_meta() );
 
 echo <<<EOT
     <table width="100%" cellpadding="1" summary="">

--- a/week_details.php
+++ b/week_details.php
@@ -48,10 +48,7 @@ $nextStr = translate ( 'Next' );
 $newEntryStr = translate ( 'New Entry' );
 $prevStr = translate ( 'Previous' );
 
-print_header( array( 'js/popups.js/true' ), generate_refresh_meta() );
-
-ob_start();
-
+print_header ( ['js/popups.js/true'], generate_refresh_meta() );
 echo '
     <div class="title">
       <a title="' . $prevStr . '" class="prev" href="week_details.php?' . $u_url
@@ -110,11 +107,8 @@ for ( $d = 0; $d < 7; $d++ ) {
 echo '
       </table>
     </center>
-    ' . ( empty ( $eventinfo ) ? '' : $eventinfo ) . '<br />';
-
-ob_end_flush();
-
-echo $printerStr . print_trailer();
+    ' . ( empty ( $eventinfo ) ? '' : $eventinfo ) .
+  '<br />' . $printerStr . print_trailer();
 
 /**
  * Prints the HTML for one event in detailed view.


### PR DESCRIPTION
When calling print_header with parameters, always make $includes an array; even if it's empty.
When the parameters in either are just tested for truthy, use 0 or 1.
Where ever print_header and ob_start were called together,
or print_trailer and ob_end_flush were called together,
move those calls into the functions.

Clean up a couple of places where js files were called in $headx.
Clean up a couple of places where things were called incorrectly.