### PR TITLE
Proposed .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# From: https://www.git-scm.com/docs/gitattributes
+# ident
+# When the attribute ident is set for a path, Git replaces $Id$ in the blob object with $Id:, followed by the 40-character hexadecimal blob object name, followed by a dollar sign $ upon checkout. Any byte sequence that begins with $Id: and ends with $ in the worktree file is replaced with $Id$ upon check-in.
+ident
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to UNIX line endings on checkout.
+*.class text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+#*.inc text eol=lf
+*.php text eol=lf
+*.pl text eol=lf
+#*.tpl text eol=lf
+*.txt text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+#*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.gif binary
+*.ico binary
+*.jpg binary
+*.png binary

--- a/view_w.php
+++ b/view_w.php
@@ -39,7 +39,7 @@ $wkend = $wkstart + ( 86400 * ( $DISPLAY_WEEKENDS == 'N' ? 5 : 7 ) );
 $nextStr = translate ( 'Next' );
 $prevStr = translate ( 'Previous' );
 
-$can_add = ( empty ( $ADD_LINK_IN_VIEWS ) || $ADD_LINK_IN_VIEWS != 'N' );
+$can_add = ( $ADD_LINK_IN_VIEWS === 'Y' );
 
 print_header( array( 'js/popups.js/true', 'js/dblclick_add.js/true' ) );
 


### PR DESCRIPTION
Make all text files end-of-line = LF on check-in and check-out.
Eliminate the need to "remove annoying CR" in the code.

Use ident to identify the file.
Similar to
// $Id: view_w.php,v 1.81 2009/11/22 22:26:18 bbannon Exp $
on SourceForge/CVS.
except it's a just 40 char hash between $id: and ending $.

I don't know why both files show up here when I committed them on different branches.
And git status only showed .gitattributes before add/commit/push.