### PR TITLE
Creating event causes log, which breaks redirect

### DIFF
--- a/includes/classes/WebCalMailer.class
+++ b/includes/classes/WebCalMailer.class
@@ -40,7 +40,7 @@ class WebCalMailer extends phpmailer{
     // Turn on SMTP authentication.
     $this->SMTPAuth = ( $SMTP_AUTH == 'Y' );
     $this->SMTPSecure = "tls";
-    $this->SMTPDebug = 2;
+    $this->SMTPDebug = 0;
     $this->Username = $SMTP_USERNAME; // SMTP username.
     $this->Password = $SMTP_PASSWORD; // SMTP password.
   }


### PR DESCRIPTION
When creating a new event, and activate the mailing for yourself ("Event that I create => YES"), then a log is created when $this->SMTPDebug = 2.
This breaks the redirect of the HTML page, and gives the user "confusing" feedback.  Everything works, but the user receives a weird email log, and a tiny link to click to get back to the expected page.

Disabling error logging fixes this.