### PR TITLE
Removed dot ('.') not included in translation keys.

### DIFF
--- a/includes/js/edit_entry.php
+++ b/includes/js/edit_entry.php
@@ -30,7 +30,7 @@ function validate_and_submit() {
     showTab( 'details' );
 <?php } ?>
     form.name.focus();
-    alert ( "<?php etranslate ( 'You have not entered a Brief Description.', true )?>");
+    alert ( "<?php etranslate ( 'You have not entered a Brief Description', true )?>");
     return false;
   }
   if ( form.timetype &&


### PR DESCRIPTION
Just a quick fix so translations with key 'You have not entered a Brief Description' are taken in account.