### PR TITLE
Sort untimed events by name, too

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5663,7 +5663,9 @@ function set_today ( $date = '' ) {
  */
 function sort_events ( $a, $b ) {
   // Handle untimed events first.
-  if( $a->isUntimed() || $b->isUntimed() )
+  if( $a->isUntimed() && $b->isUntimed() )
+    return strnatcmp( $a->getName(), $b->getName() );
+  else if( $a->isUntimed() || $b->isUntimed() )
     return strnatcmp( $b->isUntimed(), $a->isUntimed() );
 
   $retval = strnatcmp (


### PR DESCRIPTION
Previously, untimed events were sorted to the top, but otherwise they didn't have any special order. With an additional check, untimed events get also sorted alphabetically (same as events that share the same time).