### PR TITLE
Bugfix for issue #256: "Invalid referring URL"

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $credits = getPostValue( 'Credits' );
 static $data;

--- a/access.php
+++ b/access.php
@@ -17,7 +17,6 @@
  *             includes/access.php. Each should be either 'Y' or 'N'.
  */
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $allow_view_other =
   ( ! empty( $ALLOW_VIEW_OTHER ) && $ALLOW_VIEW_OTHER == 'Y' );

--- a/admin.php
+++ b/admin.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 include_once 'includes/date_formats.php';
 if ( file_exists ( 'install/default_config.php' ) )
   include_once 'install/default_config.php';

--- a/ajax.php
+++ b/ajax.php
@@ -12,7 +12,6 @@ include 'includes/config.php';
 include 'includes/dbi4php.php';
 include 'includes/formvars.php';
 include 'includes/functions.php';
-require_valid_referring_url ();
 
 $WebCalendar->initializeFirstPhase();
 

--- a/approve_entry.php
+++ b/approve_entry.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 require ( 'includes/classes/WebCalMailer.php' );
 
 $error = '';

--- a/assistant_edit_handler.php
+++ b/assistant_edit_handler.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $user = getPostValue ( 'user' );
 $users = getPostValue ( 'users' );

--- a/category_handler.php
+++ b/category_handler.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url();
 
 $icon_max_size = '6000';
 $icon_path = 'wc-icons/';

--- a/edit_entry_handler.php
+++ b/edit_entry_handler.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 require 'includes/classes/WebCalMailer.php';
 $mail = new WebCalMailer;
 

--- a/edit_remotes_handler.php
+++ b/edit_remotes_handler.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 include_once 'includes/xcal.php';
 
 // Only available in php 5.x Used for hCalendar parsing.

--- a/edit_report_handler.php
+++ b/edit_report_handler.php
@@ -32,7 +32,6 @@
  * or you are an admin user.
  */
 include_once 'includes/init.php';
-require_valid_referring_url ();
 load_user_categories();
 
 $error = ( empty( $REPORTS_ENABLED ) || $REPORTS_ENABLED != 'Y'

--- a/edit_template.php
+++ b/edit_template.php
@@ -13,7 +13,6 @@
  * Admin permissions are checked by the WebCalendar class.
  */
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $cur = $error = '';
 $found = $foundOld = false;

--- a/events_ajax.php
+++ b/events_ajax.php
@@ -22,7 +22,6 @@ include 'includes/config.php';
 include 'includes/dbi4php.php';
 include 'includes/formvars.php';
 include 'includes/functions.php';
-require_valid_referring_url ();
 
 $WebCalendar->initializeFirstPhase();
 

--- a/export_handler.php
+++ b/export_handler.php
@@ -13,7 +13,6 @@
  *
  *********************************************************************/
 include_once 'includes/init.php';
-require_valid_referring_url ();
 include_once 'includes/xcal.php';
 
 $user = getPostValue ( 'user' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -6441,46 +6441,6 @@ function rgb2html($r, $g=-1, $b=-1)
 }
 
 /**
-  * Require a valid HTT_REFERER value in the HTTP header.  This will
-  * prevent XSRF (cross-site request forgery).
-  *
-  * For example, suppose a * a "bad guy" sends an email with a link that
-  * would delete an event in webcalendar to the admin.  If the admin user
-  * clicks on that link we don't want to actually delete the event.
-  */
-  // TODO: This function might not be needed anymore with the addition
-  // of the CSRF tokens in all POST forms (new in WebCalendar 1.9.0).
-function require_valid_referring_url ()
-{
-  global $SERVER_URL, $settings;
-
-  // Allow value in settings.php to disable this.  If you run PHP
-  // inside a docker container, you will need to do this since the IP
-  // address will be different.
-  if ( isset ( $settings['disable_referer_check'] ) &&
-    $settings['disable_referer_check'] == 'true' ) {
-    return;
-  }
-
-  if ( empty( $_SERVER['HTTP_REFERER'] ) ) {
-    // Missing the REFERER value
-    //die_miserable_death ( translate ( 'Invalid referring URL' ) );
-    // Unfortunately, some version of MSIE do not send this info.
-    return;
-  }
-  if (strpos($SERVER_URL, $_SERVER['HTTP_REFERER']) != 0) {
-    // Gotcha.  URL of referring page is not the same as our server.
-    // This can be an instance of XSRF.
-    // (This may also happen when more than address is used for your server.
-    // However, you're not supposed to do that with this version of
-    // WebCalendar anyhow...)
-    // You can disable this check by adding the following in your includes/settings.php file:
-    //   disable_referer_check: true
-    die_miserable_death ( translate ( 'Invalid referring URL' ) );
-  }
-}
-
-/**
   * Is the current connection using HTTPS rather than HTTP?
   */
 function isSecure() {

--- a/layers_ajax.php
+++ b/layers_ajax.php
@@ -12,7 +12,6 @@ include 'includes/config.php';
 include 'includes/dbi4php.php';
 include 'includes/formvars.php';
 include 'includes/functions.php';
-require_valid_referring_url ();
 
 $WebCalendar->initializeFirstPhase();
 

--- a/list_unapproved.php
+++ b/list_unapproved.php
@@ -16,7 +16,6 @@
  */
 
 include_once 'includes/init.php';
-require_valid_referring_url ();
 send_no_cache_header();
 
 if ( empty ( $user ) )

--- a/pref.php
+++ b/pref.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 // Force the CSS cache to clear by incrementing webcalendar_csscache cookie.
 $webcalendar_csscache = 1;

--- a/purge.php
+++ b/purge.php
@@ -13,7 +13,6 @@
  * create) will remain unchanged.
  */
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 // Set this to true do show the SQL at the bottom of the page
 $purgeDebug = false;

--- a/reject_entry.php
+++ b/reject_entry.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 require ( 'includes/classes/WebCalMailer.php' );
 $mail = new WebCalMailer;
 

--- a/search_handler.php
+++ b/search_handler.php
@@ -11,7 +11,6 @@
  * @package WebCalendar
  */
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $error = '';
 

--- a/users_ajax.php
+++ b/users_ajax.php
@@ -13,7 +13,6 @@ include 'includes/config.php';
 include 'includes/dbi4php.php';
 include 'includes/formvars.php';
 include 'includes/functions.php';
-require_valid_referring_url();
 
 $WebCalendar->initializeFirstPhase();
 

--- a/view_entry.php
+++ b/view_entry.php
@@ -76,7 +76,6 @@ dbi_free_result ( $res );
 
 // Update the task percentage for this user.
 if ( ! empty ( $_POST ) && $is_my_event ) {
-require_valid_referring_url ();
 $upercent = getPostValue ( 'upercent' );
 if ( $upercent >= 0 && $upercent <= 100 ) {
 dbi_execute ( 'UPDATE webcal_entry_user SET cal_percent = ?

--- a/views_edit_handler.php
+++ b/views_edit_handler.php
@@ -1,6 +1,5 @@
 <?php
 include_once 'includes/init.php';
-require_valid_referring_url ();
 
 $error = '';
 


### PR DESCRIPTION
- New CSRF code makes the old require_valid_referring_url function no longer needed.
  The new method includes a CSRF token in every request that would invoke
  a change (typically but not always a HTTP POST).  This token expires after
  a short time period making CSRF impossible outside the time window.
- See the functions csrf_form_key and getFormKey in includes/formvars.php.