### PR TITLE
Allow framing on the same origin

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -99,7 +99,7 @@ function send_http_headers () {
 
   // WebCalendar cannot be loaded in a frame
   // Options for this cookie: deny, sameorigin, allow-from
-  Header("X-Frame-Options: deny");
+  Header("X-Frame-Options: sameorigin");
 
   // Marker used by the server to indicate that the MIME types advertised in the
   // Content-Type headers should be followed and not be changed.
@@ -178,7 +178,7 @@ function print_header( $includes = '', $HeadX = '', $BodyX = '',
 
   $ret .= "\n<style id=\"antiClickjack\">\n  body{display:none !important;}\n</style>\n" .
     "<script type=\"text/javascript\">\n" .
-    "  if (self === top) {\n" .
+    "  if (self.location.hostname === top.location.hostname) {\n" .
     "      var antiClickjack = document.getElementById(\"antiClickjack\");\n" .
     "      antiClickjack.parentNode.removeChild(antiClickjack);\n" .
     "  } else {\n" .


### PR DESCRIPTION
After updating to the latest master branch, I noticed that I can no longer use the calendar in an iframe. This commit seems to be the cause: bb7c65163fe1bb06e7f48757cee072594992da1d

While I recognize that this is a security measure, the current approach seems quite heavy-handed. Using the calendar in an iframe is, well, basically my entire use case for the software. At very least, I think it would make sense to enable same-origin framing.

This PR allows framing from the same origin.