### PR TITLE
Remove `abs()` calls from category ID.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3602,7 +3602,7 @@ function html_for_event_day_at_a_glance ( $event, $date ) {
   $can_access = CAN_DOALL;
   $end_timestr = $popup_timestr = '';
   $getCalTypeName = $event->getCalTypeName();
-  $getCat = abs( $event->getCategory() );
+  $getCat = $event->getCategory();
   $getClone = $event->getClone();
   $getDesc = $event->getDescription();
   $getLogin = $event->getLogin();
@@ -3758,7 +3758,7 @@ function html_for_event_week_at_a_glance ( $event, $date,
   $can_access = CAN_DOALL;
   $catAlt = $href = $timestr = '';
   $getCalTypeName = $event->getCalTypeName();
-  $getCat = abs( $event->getCategory() );
+  $getCat = $event->getCategory();
   $getClone = $event->getClone();
   $getDatetime = $event->getDatetime();
   $getLoginStr = $event->getLogin();


### PR DESCRIPTION
Two other people have reported this issue as well: #284 and #302

I personally can't think of any good reason why those `abs()` calls need to be there. I mean, there aren't any negative category IDs, are there? And if there were, why would we want to get the absolute value? I just removed the calls and everything is working well for me, but if there is some weird edge case those calls were meant to solve, let me know.