### PR TITLE
Fix username bug on groups.php

### DIFF
--- a/groups.php
+++ b/groups.php
@@ -266,7 +266,7 @@ print_header(
             $('#editName').prop("value", group['name']);
             for (var i = 0; i < cnt; i++) {
                 console.log('Selected user: ' + selectedUsers[i]);
-                $('#editUsers option[value=' + selectedUsers[i] + ']').attr('selected',true).change();
+                $('#editUsers option[value="' + selectedUsers[i] + '"]').attr('selected',true).change();
             }
 
         }


### PR DESCRIPTION
If a username has a special character (such as a period, which is common in usernames), it is not possible to edit a group containing that user. This patch fixes that. Now, the username can safely contain anything but a double quote.

For true safety, it may also be beneficial to backslash-escape any double quotes as well, but I don't think that should be strictly required as usernames probably shouldn't contain double quotes anyway, and I don't think the bug is exploitable for XSS in this particular context either.