### PR TITLE
Fix broken install if home directory contains invalid session name characters

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -88,9 +88,23 @@ EOT;
  * Give the PHP session a name unique to this install, allowing multiple WebCalendar installs
  * on the same server.
  */
-function getSessionName()
+function getSessionName(): string
 {
-  return 'WebCalendar-' . __DIR__;
+  return 'WebCalendar-Install-' . str_replace(
+          [
+              '=',
+              ',',
+              ';',
+              '.',
+              '[',
+              "\t",
+              "\r",
+              "\n",
+              "\013",
+              "\014",
+          ],
+          '_',
+          __DIR__);
 }
 
 function db_error($doExit = false, $sql = '')

--- a/install/index.php
+++ b/install/index.php
@@ -40,7 +40,21 @@ require_once 'sql/upgrade_matrix.php';
 
 $debugInstaller = false; // Set to true to get more details on the installer pages (but breaks redirects)
 $includeLogoutButton = false; // Can be helpful testing installer
-$sessionName = 'WebCalendar-Install-' . __DIR__;
+$sessionName = 'WebCalendar-Install-' . str_replace(
+    [
+        '=',
+        ',',
+        ';',
+        '.',
+        '[',
+        "\t",
+        "\r",
+        "\n",
+        "\013",
+        "\014",
+    ],
+    '_',
+    __DIR__);
 
 if ($debugInstaller && isset($_GET['action']) && $_GET['action'] == 'logout') {
     session_name($sessionName);

--- a/install/install_ajax.php
+++ b/install/install_ajax.php
@@ -78,7 +78,24 @@ function testDbConnection($host, $login, $password, $database)
 
 $response = array();
 ini_set('session.cookie_lifetime', 3600);  // 3600 seconds = 1 hour
-session_name('WebCalendar-Install-' . __DIR__);
+
+$sessionName = 'WebCalendar-Install-' . str_replace(
+        [
+            '=',
+            ',',
+            ';',
+            '.',
+            '[',
+            "\t",
+            "\r",
+            "\n",
+            "\013",
+            "\014",
+        ],
+        '_',
+        __DIR__);
+session_name($sessionName);
+
 session_start();
 
 $errorResponse = array();


### PR DESCRIPTION
I couldn't login during the install process because the session name comprised the name of the current directory, which in my case contained dots. This changes all invalid characters to underscore and fixes the problem.