### PR TITLE
Fix French translations (encoding + some wording)

### DIFF
--- a/translations/French.txt
+++ b/translations/French.txt
@@ -2,14 +2,15 @@
 #
 # Translated by: Yves Moenner <yves.moenner@mailcity.com>
 # Checked by: Romuald Texier <romualdt@free.fr>
-# Updated by : Gérard Delafond
+# Updated by : GÃ©rard Delafond
 # Updated by : Luc Capronnier, Wilfrid Hubert
 # Updated by : Mario Dragone <mario.dragone@reims.iufm.fr>
 # Updated by : erational <http://www.erational.org>
 # Updated by : Ivan Machetto
 # Cleared, finished and polished by:
 #  Emmanuel Rihn <acontrecourant_at_online_fr>
-# Translation last updated on 12-11-2023
+# Cleaned by: Florent Angebault, Easter-Eggs
+# Translation last updated on 2026-02-19
 
 
 ################################################################################
@@ -21,7 +22,7 @@
 
 # Specify a charset (will be sent within meta tag for each page).
 
-charset: =
+charset: UTF-8
 
 # "direction" need only be changed if using a right to left language.
 # Options are: ltr (left to right, default) or rtl (right to left).
@@ -48,13 +49,13 @@ __month__ __yyyy__: =
 ########################################
 # Page: usersel.php
 #
-Program Error No XXX specified!: Erreur dans le programme : pas de N° XXX spécifié !
+Program Error No XXX specified!: Erreur dans le programme : pas de NÂ° XXX spÃ©cifiÃ© !
 form: formulaire
 listid: =
 Users: Utilisateurs
 All: Tout
 None: Aucune
-Reset: Réinitialiser
+Reset: RÃ©initialiser
 Groups: Groupes
 Add: Ajouter
 Remove: Supprimer
@@ -64,17 +65,17 @@ Cancel: Annuler
 ########################################
 # Page: rss_unapproved.php
 #
-Unapproved Entries: Entrées non approuvées
-All day event: événement permanent
+Unapproved Entries: EntrÃ©es non approuvÃ©es
+All day event: Ã©vÃ©nement permanent
 Approve/Confirm: Approuver/Confirmer
-Approve Selected: Approuver les éléments sélectionnés
+Approve Selected: Approuver les Ã©lÃ©ments sÃ©lectionnÃ©s
 Check All: Tout cocher
 Delete: Supprimer
-Emails Will Not Be Sent: Les emails ne seront pas envoyés
-Reject Selected: Rejeter les éléments sélectionnés
+Emails Will Not Be Sent: Les emails ne seront pas envoyÃ©s
+Reject Selected: Rejeter les Ã©lÃ©ments sÃ©lectionnÃ©s
 Reject: Rejeter
-Uncheck All: Tout décocher
-View this entry: Voir cet événement
+Uncheck All: Tout dÃ©cocher
+View this entry: Voir cet Ã©vÃ©nement
 
 ########################################
 # Page: edit_entry.php
@@ -85,74 +86,74 @@ days: jours
 hours: heures
 minutes: =
 Save: Sauvegarder
-You are not authorized to edit this task.: Vous n'êtes pas autorisé à modifier cette tâche.
-is in a different timezone than you are. Currently: est dans un fuseau horaire différent du votre. Actuellement
+You are not authorized to edit this task.: Vous n'Ãªtes pas autorisÃ© Ã  modifier cette tÃ¢che.
+is in a different timezone than you are. Currently: est dans un fuseau horaire diffÃ©rent du votre. Actuellement
 hour ahead of you: heure devant vous
-hour behind you: heure derrière vous
+hour behind you: heure derriÃ¨re vous
 hours ahead of you: heures devant vous
-hours behind you: heures derrière vous
-XXX is in a different timezone (ahead): (XXX est dans un fuseau horaire différent; XXX devant vous<br />&nbsp;XXX)
-XXX is in a different timezone (behind): (XXX est dans un fuseau horaire différent; XXX derrière vous<br />&nbsp;XXX)
-Time entered here is based on your Timezone.: L'heure entrée ici est basée sur votre fuseau horaire
-Edit Entry: Modification de l'événement
-Add Entry: Ajouter un événement
+hours behind you: heures derriÃ¨re vous
+XXX is in a different timezone (ahead): (XXX est dans un fuseau horaire diffÃ©rent; XXX devant vous<br />&nbsp;XXX)
+XXX is in a different timezone (behind): (XXX est dans un fuseau horaire diffÃ©rent; XXX derriÃ¨re vous<br />&nbsp;XXX)
+Time entered here is based on your Timezone.: L'heure entrÃ©e ici est basÃ©e sur votre fuseau horaire
+Edit Entry: Modification de l'Ã©vÃ©nement
+Add Entry: Ajouter un Ã©vÃ©nement
 Help: Aide
-You are not authorized to edit this entry.: Vous n'êtes pas autorisé à modifier cet événement
-Details: Détails
+You are not authorized to edit this entry.: Vous n'Ãªtes pas autorisÃ© Ã  modifier cet Ã©vÃ©nement
+Details: DÃ©tails
 Participants: =
-Repeat: Répétition
+Repeat: RÃ©pÃ©tition
 Reminders: Rappels
-brief-description-help: Ceci doit être un résumé (environ 20 caractères) de l'événement. Cette information représentera l'événement quand vous visualiserez l'agenda.
-Brief Description: Description résumée
-full-description-help: Ceci doit être une description détaillée de l'événement. Cette information sera vue par l'utilisateur quand celui-ci cliquera sur l'événement.
-Full Description: Description détaillée
-access-help: Spécification du niveau d'accès de l'événement.<br /> <i>Public</i>: Tous les utilisateurs peuvent voir les détails de l'événement.<br /><i>Confidentiel</i>: Les utilisateurs peuvent voir que vous avez un événement pour ces date et heure, mais ils ne peuvent pas en consulter les détails.
-Access: Accès
+brief-description-help: Ceci doit Ãªtre un rÃ©sumÃ© (environ 20 caractÃ¨res) de l'Ã©vÃ©nement. Cette information reprÃ©sentera l'Ã©vÃ©nement quand vous visualiserez l'agenda.
+Brief Description: Description rÃ©sumÃ©e
+full-description-help: Ceci doit Ãªtre une description dÃ©taillÃ©e de l'Ã©vÃ©nement. Cette information sera vue par l'utilisateur quand celui-ci cliquera sur l'Ã©vÃ©nement.
+Full Description: Description dÃ©taillÃ©e
+access-help: SpÃ©cification du niveau d'accÃ¨s de l'Ã©vÃ©nement.<br /> <i>Public</i>: Tous les utilisateurs peuvent voir les dÃ©tails de l'Ã©vÃ©nement.<br /><i>Confidentiel</i>: Les utilisateurs peuvent voir que vous avez un Ã©vÃ©nement pour ces date et heure, mais ils ne peuvent pas en consulter les dÃ©tails.
+Access: AccÃ¨s
 Public: =
-Private: Privé
+Private: PrivÃ©
 Confidential: Confidentiel
-priority-help: Spécification de la priorité de l'événement. Une haute priorité sera affichée en gras.
-Priority: Priorité
+priority-help: SpÃ©cification de la prioritÃ© de l'Ã©vÃ©nement. Une haute prioritÃ© sera affichÃ©e en gras.
+Priority: PrioritÃ©
 High: Haute
 Medium: Moyenne
 Low: Basse
-category-help: Définir la catégorie associée à un événement.
-Category: Catégorie
-Edit: Éditer
+category-help: DÃ©finir la catÃ©gorie associÃ©e Ã  un Ã©vÃ©nement.
+Category: CatÃ©gorie
+Edit: Ã‰diter
 completed-help: Date de la tÃ¢che est complÃ©tÃ©e. Seulement activÃ© lorsque le pourcentage de tous les participants Ã©gale Ã  100 %.
-Date Completed: Date d'achèvement
-percent-help: Pourcentage d'achèvement de la tâche pour cet utilisateur
-Percent Complete: Pourcentage effectué
+Date Completed: Date d'achÃ¨vement
+percent-help: Pourcentage d'achÃ¨vement de la tÃ¢che pour cet utilisateur
+Percent Complete: Pourcentage effectuÃ©
 All Percentages: Tous les pourcentages
-location-help: Lieu de l'événement
+location-help: Lieu de l'Ã©vÃ©nement
 Location: Lieu
-url-help: URL de l'événement
+url-help: URL de l'Ã©vÃ©nement
 URL: =
-date-help: Spécification de la date de l'événement.
-Start Date: Date de début
+date-help: SpÃ©cification de la date de l'Ã©vÃ©nement.
+Start Date: Date de dÃ©but
 Date: =
-time-help: Spécification de l'heure de l'événement.<br /><i>Ce champ peut être laissé vide.</i>
+time-help: SpÃ©cification de l'heure de l'Ã©vÃ©nement.<br /><i>Ce champ peut Ãªtre laissÃ© vide.</i>
 Type: =
-Untimed event: événement intemporel
-Timed event: événement temporel
+Untimed event: Ã©vÃ©nement intemporel
+Timed event: Ã©vÃ©nement temporel
 Time entered here is based on your Timezone: L'heure entrÃ©e ici est basÃ©e sur votre fuseau horaire.
-Timezone Offset: Décalage horaire
+Timezone Offset: DÃ©calage horaire
 Time: Heure
-duration-help: Spécification de la durée (en minutes) de l'événement.  <br /><i>Ce champ peut être laissé vide.</i>
-Duration: Durée
-end-time-help: Spécifie l'heure à laquelle l'événement est prévu se terminer
-Start Time: Heure de début
+duration-help: SpÃ©cification de la durÃ©e (en minutes) de l'Ã©vÃ©nement.  <br /><i>Ce champ peut Ãªtre laissÃ© vide.</i>
+Duration: DurÃ©e
+end-time-help: SpÃ©cifie l'heure Ã  laquelle l'Ã©vÃ©nement est prÃ©vu se terminer
+Start Time: Heure de dÃ©but
 Due Date: Date de fin
 Due Time: Heure de fin
 Site Extras: Bonus site
 Find Name: Chercher un nom
 Resources: Ressources
-participants-help: Liste des participants pour cet événement.
+participants-help: Liste des participants pour cet Ã©vÃ©nement.
 Selected Participants: SÃ©lectionnÃ©s Participants
-Availability: Disponibilité
-external-participants-help: Spécifie une liste de participants pour cet événement qui ne font pas partie des utilisateurs de l'agenda. Ces utilisateurs devraient figurer un à un par ligne avec éventuellement leur adresse de couriel. Si une adresse de couriel est spécifiée, l'utilisateur peut recevoir par couriel les notifications et rappels.
-External Participants: Participants extérieurs
-repeat-type-help: Sélectionner la fréquence de répétition de l'événement.<br /><i>Mensuel (par jour)</i> autorise un événement à être répété tous les premiers Lundi du mois, 3ème Jeudi du mois, etc. <br /><i>Mensuel (par date)</i> autorise un événement à être répété le même jour du mois.
+Availability: DisponibilitÃ©
+external-participants-help: SpÃ©cifie une liste de participants pour cet Ã©vÃ©nement qui ne font pas partie des utilisateurs de l'agenda. Ces utilisateurs devraient figurer un Ã  un par ligne avec Ã©ventuellement leur adresse de couriel. Si une adresse de couriel est spÃ©cifiÃ©e, l'utilisateur peut recevoir par couriel les notifications et rappels.
+External Participants: Participants extÃ©rieurs
+repeat-type-help: SÃ©lectionner la frÃ©quence de rÃ©pÃ©tition de l'Ã©vÃ©nement.<br /><i>Mensuel (par jour)</i> autorise un Ã©vÃ©nement Ã  Ãªtre rÃ©pÃ©tÃ© tous les premiers Lundi du mois, 3Ã¨me Jeudi du mois, etc. <br /><i>Mensuel (par date)</i> autorise un Ã©vÃ©nement Ã  Ãªtre rÃ©pÃ©tÃ© le mÃªme jour du mois.
 Daily: Quotidienne
 Weekly: Hebdomadaire
 Monthly: Mensuelle
@@ -165,56 +166,56 @@ Monthly (by position): Mensuelle (par position)
 Yearly: Annuelle
 Manual: Manuelle
 Expert Mode: Mode Expert
-repeat-end-date-help: Spécifie la date de fin de répétition de l'événement.
+repeat-end-date-help: SpÃ©cifie la date de fin de rÃ©pÃ©tition de l'Ã©vÃ©nement.
 Ending: Fin
 Forever: Toujours
 Use end date: Utiliser une date de fin
 Number of times: Nombre de fois
-repeat-frequency-help: Spécifie la fréquence de répétition de l'événement. La valeur par défaut 1 indique que l'événement doit survenir à chaque fois.  Si vous choisissez 2, celà indique que l'événement doit survenir toutes les autres semaines (si <i>Type de répétition</i> est sur <i>Hebdomadaire</i>), tous les autres Mois (si <i>Type de répétition</i> est sur <i>Mensuel</i>), etc.
-Frequency: Fréquence
+repeat-frequency-help: SpÃ©cifie la frÃ©quence de rÃ©pÃ©tition de l'Ã©vÃ©nement. La valeur par dÃ©faut 1 indique que l'Ã©vÃ©nement doit survenir Ã  chaque fois.  Si vous choisissez 2, celÃ  indique que l'Ã©vÃ©nement doit survenir toutes les autres semaines (si <i>Type de rÃ©pÃ©tition</i> est sur <i>Hebdomadaire</i>), tous les autres Mois (si <i>Type de rÃ©pÃ©tition</i> est sur <i>Mensuel</i>), etc.
+Frequency: FrÃ©quence
 Weekdays Only: Week-end seulement
-Week Start: Début de la semaine
-repeat-bydayextended-help: Permet la sélection de date basée sur le jour de la semaine.
+Week Start: DÃ©but de la semaine
+repeat-bydayextended-help: Permet la sÃ©lection de date basÃ©e sur le jour de la semaine.
 ByDay: par jour
-repeat-month-help: Spécifie sur quels mois l'événement doit se répéter.
+repeat-month-help: SpÃ©cifie sur quels mois l'Ã©vÃ©nement doit se rÃ©pÃ©ter.
 ByMonth: par mois
-repeat-bysetpos-help: Permet la sélection de date basée sur la position dans le mois.
-BySetPos: par pos dét
-repeat-bymonthdayextended-help: Permet la sélection de date basée sur la date.
+repeat-bysetpos-help: Permet la sÃ©lection de date basÃ©e sur la position dans le mois.
+BySetPos: par pos dÃ©t
+repeat-bymonthdayextended-help: Permet la sÃ©lection de date basÃ©e sur la date.
 ByMonthDay: par mois-jour
-repeat-byweekno-help: Permet à l'utilisateur de spécifier une liste de semaines pour la répétition des événements (1,2...53,-53,-52...-1).
+repeat-byweekno-help: Permet Ã  l'utilisateur de spÃ©cifier une liste de semaines pour la rÃ©pÃ©tition des Ã©vÃ©nements (1,2...53,-53,-52...-1).
 ByWeekNo: par No. sem.
-repeat-byyearday-help: Permet à l'utilisateur de spécifier une liste d'années pour la répétition des événements(1,2...366,-366,-365...-1).
-ByYearDay: par no. jour année
-repeat-exceptions-help: Jours additionnels sur lequel l'événement peut ou non se produire.
+repeat-byyearday-help: Permet Ã  l'utilisateur de spÃ©cifier une liste d'annÃ©es pour la rÃ©pÃ©tition des Ã©vÃ©nements(1,2...366,-366,-365...-1).
+ByYearDay: par no. jour annÃ©e
+repeat-exceptions-help: Jours additionnels sur lequel l'Ã©vÃ©nement peut ou non se produire.
 Exclusions: =
 Inclusions: =
 Add Exception: Ajouter une exception
 Add Inclusion: Ajouter une inclusion
-Delete Selected: Supprimer l'élément sélectionné
-email-event-reminders-help: Permet de définir si un couriel est adressé ou non pour le rappel d'un événement. 
+Delete Selected: Supprimer l'Ã©lÃ©ment sÃ©lectionnÃ©
+email-event-reminders-help: Permet de dÃ©finir si un couriel est adressÃ© ou non pour le rappel d'un Ã©vÃ©nement. 
 Send Reminder: Envoyer un rappel
 Yes: Oui
 No: Non
 When: Quand
 Use Date/Time: Date/heure
-Use Offset: Délai
+Use Offset: DÃ©lai
 Before: Avant
-After: Après
-Start: Début
+After: AprÃ¨s
+Start: DÃ©but
 End/Due: Fin
 Times: Fois
 Every: Chaque
 CAPTCHA Warning: <b>Attention:</b> Impossible d'utiliser le CAPTCHA sans l'extension GD de PHP !<br />
-Are you sure you want to delete this entry?: Voulez-vous vraiment supprimer cet événement ?
-Delete entry: Supprimer l'événement
+Are you sure you want to delete this entry?: Voulez-vous vraiment supprimer cet Ã©vÃ©nement ?
+Delete entry: Supprimer l'Ã©vÃ©nement
 Edit Categories: Ã‰diter CatÃ©gories
 
 ########################################
 # Page: icalclient.php
 #
-Publishing Disabled (Admin): Publication désactivée (Administrateur)
-Publishing Disabled (User): Publication désactivée (Utilisateur)
+Publishing Disabled (Admin): Publication dÃ©sactivÃ©e (Administrateur)
+Publishing Disabled (User): Publication dÃ©sactivÃ©e (Utilisateur)
 
 ########################################
 # Page: autocomplete_ajax.php
@@ -225,22 +226,22 @@ Error: Erreur
 # Page: set_entry_cat.php
 #
 Invalid entry id.: Id invalide.
-You have not added any categories.: Vous n'avez pas défini de catégories
-Set Category: Choisir la catégorie
-Global Categories cannot be changed.: Les catégories globales ne peuvent pas être modifiées
+You have not added any categories.: Vous n'avez pas dÃ©fini de catÃ©gories
+Set Category: Choisir la catÃ©gorie
+Global Categories cannot be changed.: Les catÃ©gories globales ne peuvent pas Ãªtre modifiÃ©es
 
 ########################################
 # Page: remotecal_mgmt.php
 #
-Your PHP setting for allow_url_fopen will not allow a remote calendar to be loaded.: Votre paramÃ¨tre PHP pour allow_url_fopen ne permettra pas le chargement d'un calendrier distant.
-Are you sure you want to delete this remote calendar?: ÃŠtes-vous sÃ»r de vouloir supprimer ce calendrier distantâ€¯?
+Your PHP setting for allow_url_fopen will not allow a remote calendar to be loaded.: Votre paramÃªtre PHP pour allow_url_fopen ne permettra pas le chargement d'un calendrier distant.
+Are you sure you want to delete this remote calendar?: ÃŠtes-vous sÃ»r de vouloir supprimer ce calendrier distantÃ¢Â€Â¯?
 This will remove all events for this remote calendar.: Ceci va supprimer tous les Ã©vÃ©nements pour ce calendrier distant.
-This action cannot be undone.: Cette action ne peut pas Ãªtre annulÃ©e.
-Username cannot be blank.: Le nom d'utilisateur ne peut être laissé non renseigné
+This action cannot be undone.: Cette action ne peut pas ÃŠtre annulÃ©e.
+Username cannot be blank.: Le nom d'utilisateur ne peut Ãªtre laissÃ© non renseignÃ©
 Name is required: Le nom est requis
 The ID is limited to letters, numbers and underscore only.: L'ID est limitÃ© aux lettres, chiffres et tiret bas uniquement.
 You have not entered a URL.: Vous n'avez pas saisi d'URL.
-This remote calendar does not have a layer.  Add a layer for this calendar to view it in your calendar.: Ce calendrier Ã  distance ne possÃ¨de pas de couche. Ajoutez une couche pour ce calendrier afin de le visualiser dans votre calendrier.
+This remote calendar does not have a layer.  Add a layer for this calendar to view it in your calendar.: Ce calendrier Ã  distance ne possÃªde pas de couche. Ajoutez une couche pour ce calendrier afin de le visualiser dans votre calendrier.
 Source: =
 Color: Couleur
 Duplicates: Duplication
@@ -250,31 +251,31 @@ Calendar ID: ID agenda
 Name: Nom
 Calendar user who created this remote calendar: Utilisateur de calendrier qui a crÃ©Ã© ce calendrier Ã  distance
 Created By: CrÃ©Ã© par
-Enabling allows this remote calendar to be used as a public calendar, and a link directly to it will be displayed on the login page.: Activer ceci permet Ã  ce calendrier distant d'Ãªtre utilisÃ© comme calendrier public, et un lien direct vers celui-ci s'affichera sur la page de connexion.
-Public Access: Accès public 
+Enabling allows this remote calendar to be used as a public calendar, and a link directly to it will be displayed on the login page.: Activer ceci permet Ã  ce calendrier distant d'ÃŠtre utilisÃ© comme calendrier public, et un lien direct vers celui-ci s'affichera sur la page de connexion.
+Public Access: AccÃ¨s public 
 Number of events currently in the remote calendar: Nombre d'Ã©vÃ©nements actuellement dans le calendrier distant
-Events: Événements
+Events: Ã‰vÃ©nements
 Date the remote calendar was last updated: Date Ã  laquelle le calendrier distant a Ã©tÃ© mis Ã  jour en dernier
-Last Updated: DerniÃ¨re mise Ã  jour
-Date the remote calendar was last checked for an update.  The update may have been skipped if it the remote calendar had not changes since the last update.: La date Ã  laquelle le calendrier distant a Ã©tÃ© vÃ©rifiÃ©e la derniÃ¨re fois pour une mise Ã  jour. La mise Ã  jour peut avoir Ã©tÃ© ignorÃ©e si le calendrier distant n'avait pas
-Last Checked: Derniâˆšâ„¢re vâˆšÂ©rifiâˆšÂ©e
+Last Updated: DerniÃªre mise Ã  jour
+Date the remote calendar was last checked for an update.  The update may have been skipped if it the remote calendar had not changes since the last update.: La date Ã  laquelle le calendrier distant a Ã©tÃ© vÃ©rifiÃ©e la derniÃªre fois pour une mise Ã  jour. La mise Ã  jour peut avoir Ã©tÃ© ignorÃ©e si le calendrier distant n'avait pas
+Last Checked: DerniÃ¢ÂˆÂšÃ¢Â„Â¢re vÃ¢ÂˆÂšÃ‚Â©rifiÃ¢ÂˆÂšÃ‚Â©e
 URL for the ICS file used to import events for this remote calendar: URL pour le fichier ICS utilisÃ© pour importer des Ã©vÃ©nements pour ce calendrier distant.
 Calendar URL: URL de calendrier
 Add Remote Calendar: Ajouter un agenda distant
-word characters only: peut contenir uniquement des caractères alphanumériques (a-zA-Z_0-9)
+word characters only: peut contenir uniquement des caractÃ¨res alphanumÃ©riques (a-zA-Z_0-9)
 New ID: Nouvelle ID
 required: requis
 Delete Remote Calendar: Supprimer Calendrier Ã  Distance
 Username: Identifiant utilisateur
 Add Layer: Ajouter un calque
-The text color of the new layer that will be displayed in your calendar.: La couleur à utiliser pour l'affichage du texte d'un nouveau calque dans votre agenda. 
-If checked, events that are duplicates of your events will be shown.: Activé, les événements en double des vôtres seront affichés.
+The text color of the new layer that will be displayed in your calendar.: La couleur Ã  utiliser pour l'affichage du texte d'un nouveau calque dans votre agenda. 
+If checked, events that are duplicates of your events will be shown.: ActivÃ©, les Ã©vÃ©nements en double des vÃ´tres seront affichÃ©s.
 Reload: Recharger
 JSON error: Erreur JSON
-Remote Calendar successfully reloaded: Calendrier Ã  distance rechargÃ© avec succÃ¨s.
-Remote Calendar successfully added. You must add a new layer to your calendar to view the events from this remote calendar on your calendar.: Calendrier distant ajoutÃ© avec succÃ¨s. Vous devez ajouter une nouvelle couche Ã  votre calendrier pour afficher les Ã©vÃ©nements de ce calendrier distant sur votre calendrier.
+Remote Calendar successfully reloaded: Calendrier Ã  distance rechargÃ© avec succÃªs.
+Remote Calendar successfully added. You must add a new layer to your calendar to view the events from this remote calendar on your calendar.: Calendrier distant ajoutÃ© avec succÃªs. Vous devez ajouter une nouvelle couche Ã  votre calendrier pour afficher les Ã©vÃ©nements de ce calendrier distant sur votre calendrier.
 Remote Calendar successfully updated.: Mise Ã  jour rÃ©ussie du calendrier Ã  distance.
-Remote calendar successfully deleted.: Calendrier distant supprimÃ© avec succÃ¨s.
+Remote calendar successfully deleted.: Calendrier distant supprimÃ© avec succÃªs.
 
 ########################################
 # Page: views_edit_handler.php
@@ -284,170 +285,170 @@ You must specify a view name: Vous devez indiquer une vue
 ########################################
 # Page: report.php
 #
-This event is confidential.: Cet événement est confidentiel
-(Private): (Privé)
+This event is confidential.: Cet Ã©vÃ©nement est confidentiel
+(Private): (PrivÃ©)
 (cont.): (suite)
-Approved: Approuvé
-Deleted: Supprimé
-Rejected: Rejeté
+Approved: ApprouvÃ©
+Deleted: SupprimÃ©
+Rejected: RejetÃ©
 Waiting for approval: En attente de validation
 Unknown: Inconnu
 Invalid report id.: Rapport invalide pour id.
-Click here to manage reports for the Public Access calendar.: Cliquez ici pour gérer les rapports pour l'agenda public
+Click here to manage reports for the Public Access calendar.: Cliquez ici pour gÃ©rer les rapports pour l'agenda public
 Add new report: Ajouter un nouveau rapport
 Unnamed Report: sans titre
 Next: Prochains
-Previous: Précédents
-Manage Reports: Gérer les rapports
+Previous: PrÃ©cÃ©dents
+Manage Reports: GÃ©rer les rapports
 
 ########################################
 # Page: category.php
 #
-Category Icon: Icône de la catégorie
+Category Icon: IcÃ´ne de la catÃ©gorie
 Global: Globale
-Invalid entry id XXX.: ID d'entrée invalide : "XXX"
-Categories: Catégories
-Category Name: Nom de la catégorie
-Remove Icon: Supprimer l'icône
-Add Icon to Category: Ajouter l'icône à la catégorie
+Invalid entry id XXX.: ID d'entrÃ©e invalide : "XXX"
+Categories: CatÃ©gories
+Category Name: Nom de la catÃ©gorie
+Remove Icon: Supprimer l'icÃ´ne
+Add Icon to Category: Ajouter l'icÃ´ne Ã  la catÃ©gorie
 GIF or PNG 6kb max: GIF ou PNG 6 kb max
 Search for existing icons...: Rechercher des icÃ´nes existantes...
-Make New Category: Ajouter une nouvelle catégorie
-Current Icons: Courants IcÃ´nes
+Make New Category: Ajouter une nouvelle catÃ©gorie
+Current Icons: IcÃ´nes actuelles
 Close: Fermer
 
 ########################################
 # Page: events_ajax.php
 #
-Not authorized: Non autorisé(e)
-Database error: Erreur de la base de données
+Not authorized: Non autorisÃ©(e)
+Database error: Erreur de la base de donnÃ©es
 Unknown error.: Erreur inconnue.
 
 ########################################
 # Page: layers_ajax.php
 #
-Unable to update preference: Impossible de mettre à jour les préférences
+Unable to update preference: Impossible de mettre Ã  jour les prÃ©fÃ©rences
 Unsupported action: Non pris en charge action
-You cannot create a layer for yourself.: Vous ne pouvez pas créer un calque pour vous.
-You can only create one layer for each user.: Vous pouvez créer un seul calque par utilisateur.
+You cannot create a layer for yourself.: Vous ne pouvez pas crÃ©er un calque pour vous.
+You can only create one layer for each user.: Vous pouvez crÃ©er un seul calque par utilisateur.
 
 ########################################
 # Page: view_entry.php
 #
-Update Task Percentage: Mettre à jour le pourcentage
-Completed: Terminée
+Update Task Percentage: Mettre Ã  jour le pourcentage
+Completed: TerminÃ©e
 Admin mode: Mode administrateur
 Assistant mode: Mode assistant
 Description: =
 Status: Etat
-Declined: Refusée
+Declined: RefusÃ©e
 Needs-Action: Besoin d'une action
-Repeat Type: Type de répétition
+Repeat Type: Type de rÃ©pÃ©tition
 by: par
-Created by: Créé par
-Updated: Mise à jour
+Created by: CrÃ©Ã© par
+Updated: Mise Ã  jour
 Percentage Complete: Pourcentage atteint
-External User: Utilisateur extérieur
-Update: Mettre à jour
-Attachments: PiÃ¨ces jointes
+External User: Utilisateur extÃ©rieur
+Update: Mettre Ã  jour
+Attachments: PiÃªces jointes
 View: Vue
 Comments: Commentaires
-at: à
+at: Ã 
 comments: commentaires
 Show: Voir
 Hide: Cacher
-Approve/Confirm entry: Approuver/Confirmer cet événement
-Approve this entry?: Accepter cet événement ?
-Reject entry: Rejeter l'événement
-Reject this entry?: Rejeter cet événement ?
+Approve/Confirm entry: Approuver/Confirmer cet Ã©vÃ©nement
+Approve this entry?: Accepter cet Ã©vÃ©nement ?
+Reject entry: Rejeter l'Ã©vÃ©nement
+Reject this entry?: Rejeter cet Ã©vÃ©nement ?
 Add Attachment: Ajouter un fichier joint
 Add Comment: Ajouter un commentaire
-Set category: Choisir une catégorie
-Add to My Calendar: Ajouter à mon agenda
-Copy entry: Dupliquer l'événement
-This will delete this entry for all users.: Ceci va supprimer cet événement pour tous les utilisateurs.
-Edit entry: Modification de l'événement
-Edit repeating entry for all dates: Modifier l'événement répétitif pour toutes les dates
-Delete repeating event for all dates: Supprimer l'événement répétitif pour toutes les dates
-Edit entry for this date: Modifier l'événement pour cette date
-Delete entry only for this date: Supprimer l'événement pour cette date
-Delete entry from calendar of XXX: Supprimer l'entrée du calendrier de XXX
-This will delete the entry from your XXX calendar.: Ceci va supprimer l'entrée de votre agenda XXX.
+Set category: Choisir une catÃ©gorie
+Add to My Calendar: Ajouter Ã  mon agenda
+Copy entry: Dupliquer l'Ã©vÃ©nement
+This will delete this entry for all users.: Ceci va supprimer cet Ã©vÃ©nement pour tous les utilisateurs.
+Edit entry: Modification de l'Ã©vÃ©nement
+Edit repeating entry for all dates: Modifier l'Ã©vÃ©nement rÃ©pÃ©titif pour toutes les dates
+Delete repeating event for all dates: Supprimer l'Ã©vÃ©nement rÃ©pÃ©titif pour toutes les dates
+Edit entry for this date: Modifier l'Ã©vÃ©nement pour cette date
+Delete entry only for this date: Supprimer l'Ã©vÃ©nement pour cette date
+Delete entry from calendar of XXX: Supprimer l'entrÃ©e du calendrier de XXX
+This will delete the entry from your XXX calendar.: Ceci va supprimer l'entrÃ©e de votre agenda XXX.
 boss: patron
-This will delete the entry from your boss calendar.: Ceci va supprimer l'entrée de l'agenda de votre patron.
-This will delete the entry from your calendar.: Ceci supprimera un événement de votre agenda.
+This will delete the entry from your boss calendar.: Ceci va supprimer l'entrÃ©e de l'agenda de votre patron.
+This will delete the entry from your calendar.: Ceci supprimera un Ã©vÃ©nement de votre agenda.
 from your boss calendar: de l'agenda de votre patron
-Do you want to add this entry to your calendar?: Voulez-vous ajouter cet événement à votre agenda ?
-This will add the entry to your calendar.: Ceci ajoutera un événement à votre agenda.
-Email all participants: Envoyer un courriel à tous les participants
-Export this entry to: Exporter cet événement au format
+Do you want to add this entry to your calendar?: Voulez-vous ajouter cet Ã©vÃ©nement Ã  votre agenda ?
+This will add the entry to your calendar.: Ceci ajoutera un Ã©vÃ©nement Ã  votre agenda.
+Email all participants: Envoyer un courriel Ã  tous les participants
+Export this entry to: Exporter cet Ã©vÃ©nement au format
 Hide activity log: Masquer le journal de suivi
 Show activity log: Visualiser le journal de suivi
 
 ########################################
 # Page: layers.php
 #
-Are you sure you want to delete this layer?: êtes vous certain de détruire ce calque ? 
-Delete layer: Détruire un calque
-Disabled: désactivés
+Are you sure you want to delete this layer?: Ãªtes vous certain de dÃ©truire ce calque ? 
+Delete layer: DÃ©truire un calque
+Disabled: dÃ©sactivÃ©s
 Edit layer: Modifier un calque
 Layer: Calque
-Layers are currently disabled.: Les calques sont actuellement <strong>désactivés</strong>.
-Layers are currently enabled.: Les calques sont actuellement <strong>activés</strong>.
-Click to modify layers settings for XXX: Cliquez ici pour modifier les paramÃ¨tres des calques pour le calendrier XXX.
+Layers are currently disabled.: Les calques sont actuellement <strong>dÃ©sactivÃ©s</strong>.
+Layers are currently enabled.: Les calques sont actuellement <strong>activÃ©s</strong>.
+Click to modify layers settings for XXX: Cliquez ici pour modifier les paramÃªtres des calques pour le calendrier XXX.
 Layers: Calques
 Enable layers: Activer les calques
-Disable Layers: Désactiver les calques
+Disable Layers: DÃ©sactiver les calques
 Add layer: Ajouter un calque
-Specifies the user that you would like to see displayed in your calendar.: Défini l'utilisateur que vous désirez voir affiché dans votre agenda.
+Specifies the user that you would like to see displayed in your calendar.: DÃ©fini l'utilisateur que vous dÃ©sirez voir affichÃ© dans votre agenda.
 Edit Layer: Modifier un calque
 
 ########################################
 # Page: purge.php
 #
-Preview: Aperçu
-Purging events for: Supprimer les événements de
-Delete Events: Effacer les événements
-Finished: Terminé
+Preview: AperÃ§u
+Purging events for: Supprimer les Ã©vÃ©nements de
+Delete Events: Effacer les Ã©vÃ©nements
+Finished: TerminÃ©
 Back: Retour
 User: Utilisateur
-Check box to delete ALL events for a user: Cocher la case pour supprimer <b>TOUS</b> les événements d'un utilisateur
-Delete all events before: Supprimer les événements antérieurs au
-Purge deleted only: Nettoyer les éléments supprimés seulement
-Preview delete: Aperçu de la suppression
-Are you sure you want to delete events for: Etes-vous certain de vouloir supprimer les événements de
-Records deleted from XXX: Enregistrements détruits "XXX".
+Check box to delete ALL events for a user: Cocher la case pour supprimer <b>TOUS</b> les Ã©vÃ©nements d'un utilisateur
+Delete all events before: Supprimer les Ã©vÃ©nements antÃ©rieurs au
+Purge deleted only: Nettoyer les Ã©lÃ©ments supprimÃ©s seulement
+Preview delete: AperÃ§u de la suppression
+Are you sure you want to delete events for: ÃŠtes-vous certain de vouloir supprimer les Ã©vÃ©nements de
+Records deleted from XXX: Enregistrements dÃ©truits "XXX".
 
 ########################################
 # Page: edit_report_handler.php
 #
 No such report id XXX.: Id de rapport inexistant : "XXX".
 Variable XXX not found.: Variable <tt>XXX</tt> introuvable.
-Page template: Options de présentation
-Day template: Options de présentation pour une journée
-Event template: Options de présentation pour un événement
+Page template: Options de prÃ©sentation
+Day template: Options de prÃ©sentation pour une journÃ©e
+Event template: Options de prÃ©sentation pour un Ã©vÃ©nement
 
 ########################################
 # Page: access.php
 #
-Database error XXX.: Erreur sur la base de données : XXX
+Database error XXX.: Erreur sur la base de donnÃ©es : XXX
 DEFAULT CONFIGURATION: CONFIGURATION PAR DEFAUT
 Go: Afficher
 Undo: Annuler
 Admin: Administration
-User Access Control: Contrôle d'accès Utilisateur
-Allow Access to Other Users Calendar: Autoriser l'accès de l'agenda aux autres utilisateurs
-Grant This User Access to My Calendar: Autoriser l'accès à cet utilisateur
+User Access Control: ContrÃ´le d'accÃ¨s Utilisateur
+Allow Access to Other Users Calendar: Autoriser l'accÃ¨s de l'agenda aux autres utilisateurs
+Grant This User Access to My Calendar: Autoriser l'accÃ¨s Ã  cet utilisateur
 Calendar: Agenda
-View Event: Voir l'événement
+View Event: Voir l'Ã©vÃ©nement
 Approve/Reject: Approuver/Rejeter
-Tasks: Tâches
+Tasks: TÃ¢ches
 Journals: Journaux
 Can Invite: Peut inviter
 Can Email: Peut envoyer un email
 Can See Time Only: Peut voir le temps seulement
 Assistant: =
-Select All: Tout sélectionner
+Select All: Tout sÃ©lectionner
 Clear All: Tout supprimer
 
 ########################################
@@ -459,29 +460,29 @@ No users for this view.: Aucun utilisateur pour cette vue
 # Page: groups.php
 #
 Are you sure you want to delete this group?: ÃŠtes-vous sÃ»r de vouloir supprimer ce groupe ?
-Group Name cannot be blank.: Nom de Groupe ne peut pas Ãªtre vide.
+Group Name cannot be blank.: Nom de Groupe ne peut pas ÃŠtre vide.
 You must selected one or more users.: Vous devez sÃ©lectionner un ou plusieurs utilisateurs.
 Group name: Nom du groupe
 Add Group: Ajouter un groupe
 New group name: Nouveau nom de groupe
 Delete Group: 'Supprimer le groupe' 
 Edit Group: Modifier un groupe
-Group successfully added.: Groupe ajoutÃ© avec succÃ¨s.
-Group successfully updated.: Groupe mis Ã  jour avec succÃ¨s.
-Group successfully deleted.: Groupe supprimÃ© avec succÃ¨s.
+Group successfully added.: Groupe ajoutÃ© avec succÃªs.
+Group successfully updated.: Groupe mis Ã  jour avec succÃªs.
+Group successfully deleted.: Groupe supprimÃ© avec succÃªs.
 
 ########################################
 # Page: help_layers.php
 #
-Layers are useful for displaying...: Les calques sont utiles pour afficher les événements des autres utilisateurs dans votre propre agenda. Vous pouvez spécifier quel utilisateur et la couleur avec laquelle les événements seront affichés.
+Layers are useful for displaying...: Les calques sont utiles pour afficher les Ã©vÃ©nements des autres utilisateurs dans votre propre agenda. Vous pouvez spÃ©cifier quel utilisateur et la couleur avec laquelle les Ã©vÃ©nements seront affichÃ©s.
 Add/Edit/Delete: Ajouter/Modifier/Supprimer
-Clicking the Edit Layers link in the admin section at the bottom of the page will allow you to add/edit/delete layers.: Cliquer sur le lien « Modifier les calques » dans la section administration, au bas de la page, vous permet d'ajouter/modifier/supprimer les calques.
+Clicking the Edit Layers link in the admin section at the bottom of the page will allow you to add/edit/delete layers.: Cliquer sur le lien Â« Modifier les calques Â» dans la section administration, au bas de la page, vous permet d'ajouter/modifier/supprimer les calques.
 Colors: Couleurs
-Disabling: Désactiver
-Press the Disable Layers link in the admin section at the bottom of the page to turn off layers.: Sélectionner le lien « Désactiver » pour supprimer le mode calque.
+Disabling: DÃ©sactiver
+Press the Disable Layers link in the admin section at the bottom of the page to turn off layers.: SÃ©lectionner le lien Â« DÃ©sactiver Â» pour supprimer le mode calque.
 Enabling: Activer
-Press the Enable Layers link in the admin section at the bottom of the page to turn on layers.: Sélectionner le lien « Activer » pour bénéficier du mode calque.
-colors-help: Toutes les couleurs doivent être au format hexadécimal « #RRVVBB » ou « RR » est la valeur hexa pour le rouge, « VV » est la valeur hexa pour le vert, et « BB » est la valeur hexa pour le bleu.
+Press the Enable Layers link in the admin section at the bottom of the page to turn on layers.: SÃ©lectionner le lien Â« Activer Â» pour bÃ©nÃ©ficier du mode calque.
+colors-help: Toutes les couleurs doivent Ãªtre au format hexadÃ©cimal Â« #RRVVBB Â» ou Â« RR Â» est la valeur hexa pour le rouge, Â« VV Â» est la valeur hexa pour le vert, et Â« BB Â» est la valeur hexa pour le bleu.
 
 ########################################
 # Page: minical.php
@@ -495,15 +496,15 @@ This Calendar is not Public.: Cet agenda n'est pas public.
 Additional Comments (optional): Commentaires additionnels (optionnel)
 Approve and Send: Approuver et envoyer
 Approve and Exit: Approuver et sortir
-(Your comments will be emailed to the event creator.): (Votre commentaire sera envoyé par courriel au créateur de l'événement)
+(Your comments will be emailed to the event creator.): (Votre commentaire sera envoyÃ© par courriel au crÃ©ateur de l'Ã©vÃ©nement)
 Hello, XXX.: Bonjour, XXX
-XXX has approved an appointment and added comments.: Un rendez-vous a été approuvé et commenté par XXX.
+XXX has approved an appointment and added comments.: Un rendez-vous a Ã©tÃ© approuvÃ© et commentÃ© par XXX.
 Subject XXX: Sujet : "XXX".
 Description XXX: =
 Date XXX: =
 Time XXX: Heure : XXX
 Comments XXX: Commentaires : XXX
-Approved w/Comments by XXX.: Approuvé avec commentaires par : XXX
+Approved w/Comments by XXX.: ApprouvÃ© avec commentaires par : XXX
 
 ########################################
 # Page: import.php
@@ -511,368 +512,368 @@ Approved w/Comments by XXX.: Approuvé avec commentaires par : XXX
 import from file: importer Ã  partir de fichier
 Import: Importer
 Import format: Format d'importation
-Exclude private records: Exclure les enregistrements privés
-Overwrite Prior Import: Remplacer l'importation précédente
-Repeated items are imported separately. Prior imports are not overwritten.: Les éléments répétés sont importés séparément. Les imports précédents ne sont pas écrasés
-Upload file: Fichier à transférer
+Exclude private records: Exclure les enregistrements privÃ©s
+Overwrite Prior Import: Remplacer l'importation prÃ©cÃ©dente
+Repeated items are imported separately. Prior imports are not overwritten.: Les Ã©lÃ©ments rÃ©pÃ©tÃ©s sont importÃ©s sÃ©parÃ©ment. Les imports prÃ©cÃ©dents ne sont pas Ã©crasÃ©s
+Upload file: Fichier Ã  transfÃ©rer
 
 ########################################
 # Page: login.php
 #
 Fatal Error: Erreur fatale
 Invalid form request: Demande de formulaire non valide
-You have been logged out.: Vous avez été déconnecté(e)
-Illegal characters in login XXX.: Caractères non autorisés dans le nom d'utilisateur "XXX".
+You have been logged out.: Vous avez Ã©tÃ© dÃ©connectÃ©(e)
+Illegal characters in login XXX.: CaractÃ¨res non autorisÃ©s dans le nom d'utilisateur "XXX".
 You must provide a password.: Vous devez fournir un mot de passe.
 Invalid login: Identifiant utilisateur incorrect
 Activity login failure: Utilisateur : "XXX", IP: "YYY".
 Submit: Soumettre
-Access XXX calendar: Accéder à l'agenda de XXX
-Not yet registered? Register here!: Pas encore enregistré(e) ? Enregistrez-vous ici !
+Access XXX calendar: AccÃ©der Ã  l'agenda de XXX
+Not yet registered? Register here!: Pas encore enregistrÃ©(e) ? Enregistrez-vous ici !
 
 ########################################
 # Page: pref.php
 #
-Invalid setting name XXX.: Nom de paramètre "XXX" invalide.
-Preferences reset to system defaults.: Les prÃ©fÃ©rences sont rÃ©initialisÃ©es aux valeurs par dÃ©faut du systÃ¨me.
+Invalid setting name XXX.: Nom de paramÃ¨tre "XXX" invalide.
+Preferences reset to system defaults.: Les prÃ©fÃ©rences sont rÃ©initialisÃ©es aux valeurs par dÃ©faut du systÃªme.
 Document background: Fond
 Document title: Titre du document 
 Document text: Texte du document
-My event text: Texte de mon événement
+My event text: Texte de mon Ã©vÃ©nement
 Table grid color: Couleur de quadrillage de tableau
-Table header background: Fond d'en-tête de tableau
-Table header text: Texte d'en-tête de tableau
+Table header background: Fond d'en-tÃªte de tableau
+Table header text: Texte d'en-tÃªte de tableau
 Table cell background: Fond de cellule
 Table cell background for current day: Fond de cellule pour aujourd'hui
-Table cell background for days with events: Couleur de fond pour les jours avec événements
+Table cell background for days with events: Couleur de fond pour les jours avec Ã©vÃ©nements
 Table cell background for weekends: Couleur de fond pour les week-ends
 Table cell background for other month: Couleur de fond pour les autres mois
-Week number color: Couleur de numéros de semaine
-Event popup background: Fond des détails d'événements
-Event popup text: Texte surgissant des événements
-Preferences: Préférences
+Week number color: Couleur de numÃ©ros de semaine
+Event popup background: Fond des dÃ©tails d'Ã©vÃ©nements
+Event popup text: Texte surgissant des Ã©vÃ©nements
+Preferences: PrÃ©fÃ©rences
 Are you sure you want to reset preferences for XXX?: ÃŠtes-vous sÃ»r de vouloir rÃ©initialiser les prÃ©fÃ©rences pour XXX?
-Save Preferences: Sauvegarder les préférences
+Save Preferences: Sauvegarder les prÃ©fÃ©rences
 Reset Preferences: RÃ©initialiser les prÃ©fÃ©rences
-Public Access calendar: Calendrier à accès public
+Public Access calendar: Calendrier Ã  accÃ¨s public
 Manage Preferences for Resource, Remote and Public Calendars: GÃ©rer les prÃ©fÃ©rences pour les calendriers de ressource, Ã  distance et publics
-Return to My Preferences: Retourner à Mes Préférences
-Settings: Réglages
-Email: Courrier électronique
-When I am the boss: Lorsque je suis le "décideur"
+Return to My Preferences: Retourner Ã  Mes PrÃ©fÃ©rences
+Settings: RÃ©glages
+Email: Courrier Ã©lectronique
+When I am the boss: Lorsque je suis le "dÃ©cideur"
 Subscribe/Publish: S'abonner/Publier
-Custom Scripts: Scripts personnalisés
+Custom Scripts: Scripts personnalisÃ©s
 Language: Langue
-language-help: Spécifie la langue à utiliser.
-Your browser default language is XXX.: La langue par défaut de votre navigateur est XXX.
+language-help: SpÃ©cifie la langue Ã  utiliser.
+Your browser default language is XXX.: La langue par dÃ©faut de votre navigateur est XXX.
 Date and Time: Date et heure
-tz-help: Spécifie le décalage horaire à adopter pour ajuster l'heure du serveur à l'heure locale.
-Timezone Selection: Sélection du fuseau horaire
-date-format-help: Spécifie le format d'affichage des dates.
+tz-help: SpÃ©cifie le dÃ©calage horaire Ã  adopter pour ajuster l'heure du serveur Ã  l'heure locale.
+Timezone Selection: SÃ©lection du fuseau horaire
+date-format-help: SpÃ©cifie le format d'affichage des dates.
 Date format: Format des dates
-Small Task Date: Date courte pour la tâche
-preferred-event-visibility: Visibilité par défaut pour les nouveaux événements
+Small Task Date: Date courte pour la tÃ¢che
+preferred-event-visibility: VisibilitÃ© par dÃ©faut pour les nouveaux Ã©vÃ©nements
 Default Visibility: VisibilitÃ© par dÃ©faut
-time-format-help: Spécifie quel format utiliser pour l'heure : <br /><i>12 heures:</i> Affiche l'heure de cette façon : 3am, 8:30pm, etc.  <br /><i>24 heures:</i> Affiche l'heure de cette façon 3:00, 20:30, etc.
+time-format-help: SpÃ©cifie quel format utiliser pour l'heure : <br /><i>12 heures:</i> Affiche l'heure de cette faÃ§on : 3am, 8:30pm, etc.  <br /><i>24 heures:</i> Affiche l'heure de cette faÃ§on 3:00, 20:30, etc.
 Time format: Format de l'heure
 12 hour: 12 heures
 24 hour: 24 heures
-display-week-starts-on: Spécifie par quel jour commence la semaine. Si Lundi est choisi, les numéros des semaines seront à la norme ISO.
+display-week-starts-on: SpÃ©cifie par quel jour commence la semaine. Si Lundi est choisi, les numÃ©ros des semaines seront Ã  la norme ISO.
 Week starts on: La semaine commence le
-display-weekend-starts-on: Paramètre le jour de la semaine de début de week-end
+display-weekend-starts-on: ParamÃ¨tre le jour de la semaine de dÃ©but de week-end
 Weekend starts on: Le week-end commence un
-work-hours-help: Spécifie les heures de début et de fin de travail.
+work-hours-help: SpÃ©cifie les heures de dÃ©but et de fin de travail.
 Work hours: Heures de travail
 From: de
-to: à
+to: Ã 
 Appearance: Apparence
-preferred-view-help: Spécifie la vue par défaut (par Jour, Semaine, Mois, ou Année).
-Preferred view: Vue préférée
+preferred-view-help: SpÃ©cifie la vue par dÃ©faut (par Jour, Semaine, Mois, ou AnnÃ©e).
+Preferred view: Vue prÃ©fÃ©rÃ©e
 Day: Jour
 Week: Semaine
 Month: Mois
-Year: Année
-fonts-help: Permet de définir une liste de polices pour l'affichage (par exemple "Helvetica, Arial, sans-serif").
+Year: AnnÃ©e
+fonts-help: Permet de dÃ©finir une liste de polices pour l'affichage (par exemple "Helvetica, Arial, sans-serif").
 Fonts: Polices
-display-sm_month-help: Si activé, affiche les mois courts dans la vue mensuelle
+display-sm_month-help: Si activÃ©, affiche les mois courts dans la vue mensuelle
 Display small months: Afficher les mois au format court
 display-weekends-help: Inclure les week-ends lors de la visualisation de la semaine. 
 Display weekends: Afficher les week-ends
-display-long-daynames-help: Si activé, les noms longs pour les jours seront affichés
+display-long-daynames-help: Si activÃ©, les noms longs pour les jours seront affichÃ©s
 Display long day names: affiche les jours au format long
-display-minutes-help: Si activé, les minutes finissant par :00 seront toujours affichées
+display-minutes-help: Si activÃ©, les minutes finissant par :00 seront toujours affichÃ©es
 Display 00 minutes always: Toujours afficher les minutes 00
-display-end-times-help: Afficher la date de fin de l'événement si événements temporel
+display-end-times-help: Afficher la date de fin de l'Ã©vÃ©nement si Ã©vÃ©nements temporel
 Display end times on calendars: Afficher les dates de fin sur les agendas
-display-alldays-help: Afficher les jours du mois précédant et du mois suivant dans la vue par mois, remplissant ainsi toutes les cellules.
+display-alldays-help: Afficher les jours du mois prÃ©cÃ©dant et du mois suivant dans la vue par mois, remplissant ainsi toutes les cellules.
 Display all days in month view: Afficher tous les jours dans la vue mensuelle
-display-week-number-help: Spécifie si le numéro de la semaine (1-52) doit être affiché.
-Display week number: Afficher le numéro de semaine
-display-tasks-help: Affiche une petite fenêtre avec les tâches sur l'agenda mensuel et journalier
-Display small task list: Affiche une petite liste des tâches
-display-tasks-in-grid-help: Affiche les tâches dans les agendas à côté des événements
-Display tasks in Calendars: Afficher les tâches dans les agendas
-lunar-help: Si activé, affiche de petites icônes représentant les phases de lune
+display-week-number-help: SpÃ©cifie si le numÃ©ro de la semaine (1-52) doit Ãªtre affichÃ©.
+Display week number: Afficher le numÃ©ro de semaine
+display-tasks-help: Affiche une petite fenÃªtre avec les tÃ¢ches sur l'agenda mensuel et journalier
+Display small task list: Affiche une petite liste des tÃ¢ches
+display-tasks-in-grid-help: Affiche les tÃ¢ches dans les agendas Ã  cÃ´tÃ© des Ã©vÃ©nements
+Display tasks in Calendars: Afficher les tÃ¢ches dans les agendas
+lunar-help: Si activÃ©, affiche de petites icÃ´nes reprÃ©sentant les phases de lune
 Display Lunar Phases in month view: Afficher les phases de la lune sur la vue mensuelle
-display-unapproved-help: Spécifie si vous voulez afficher dans votre agenda les événements en attente.<br /> Si vous choisissez « Oui », les événements en attente seront affichés dans votre agenda (dans une couleur différente).<br /> Si vous choisissez « Non », les événements en attente seront affichés dans votre agenda seulement quand vous les approuverez.
-Display unapproved: Afficher les événements en attente
-timed-evt-len-help: Spécifie la méthode de saisie pour la durée d'un événement
-Specify timed event length by: Déterminer la fin d'un événement par
+display-unapproved-help: SpÃ©cifie si vous voulez afficher dans votre agenda les Ã©vÃ©nements en attente.<br /> Si vous choisissez Â« Oui Â», les Ã©vÃ©nements en attente seront affichÃ©s dans votre agenda (dans une couleur diffÃ©rente).<br /> Si vous choisissez Â« Non Â», les Ã©vÃ©nements en attente seront affichÃ©s dans votre agenda seulement quand vous les approuverez.
+Display unapproved: Afficher les Ã©vÃ©nements en attente
+timed-evt-len-help: SpÃ©cifie la mÃ©thode de saisie pour la durÃ©e d'un Ã©vÃ©nement
+Specify timed event length by: DÃ©terminer la fin d'un Ã©vÃ©nement par
 End Time: Fin
-Default Category: Catégorie par défaut
-crossday-help: Si activé, les événements de plus d'une journée seronts affichés sur des jours différents
-Disable Cross-Day Events: Desactiver événements interjournalier
-display-desc-print-day-help: Inclure les descriptions d'événements dans la version imprimable de la vue journalière.
-Display description in printer day view: Descriptions dans la version imprimable de la vue journalière
-entry-interval-help: Définit l'intervalle en minutes lors de l'édition du temps d'événements
-Entry interval: Intervalle de l'entrée
+Default Category: CatÃ©gorie par dÃ©faut
+crossday-help: Si activÃ©, les Ã©vÃ©nements de plus d'une journÃ©e seronts affichÃ©s sur des jours diffÃ©rents
+Disable Cross-Day Events: Desactiver Ã©vÃ©nements interjournalier
+display-desc-print-day-help: Inclure les descriptions d'Ã©vÃ©nements dans la version imprimable de la vue journaliÃ¨re.
+Display description in printer day view: Descriptions dans la version imprimable de la vue journaliÃ¨re
+entry-interval-help: DÃ©finit l'intervalle en minutes lors de l'Ã©dition du temps d'Ã©vÃ©nements
+Entry interval: Intervalle de l'entrÃ©e
 hour: heure
 minute: =
-time-interval-help: Spécifie l'intervalle de temps pour l'affichage des vues par semaine et par jour.
+time-interval-help: SpÃ©cifie l'intervalle de temps pour l'affichage des vues par semaine et par jour.
 Time interval: Intervalle de temps (vues semaine et jour)
 Miscellaneous: Divers
-auto-refresh-help: Activé, les pages de visualisation par jour, semaine, mois et la liste des événements en attente seront automatiquement périodiquement rafraichies.
+auto-refresh-help: ActivÃ©, les pages de visualisation par jour, semaine, mois et la liste des Ã©vÃ©nements en attente seront automatiquement pÃ©riodiquement rafraichies.
 Auto-refresh calendars: Rafraichissement automatique de l'agenda
-auto-refresh-time-help: Spécifie la période de rafraichissement des pages.
-Auto-refresh time: Période de rafraichissement
-email-format: Spécifie les préférencespour les messages HTML ou texte
-Email format preference: Préférence de format d'email
+auto-refresh-time-help: SpÃ©cifie la pÃ©riode de rafraichissement des pages.
+Auto-refresh time: PÃ©riode de rafraichissement
+email-format: SpÃ©cifie les prÃ©fÃ©rencespour les messages HTML ou texte
+Email format preference: PrÃ©fÃ©rence de format d'email
 HTML: =
 Plain Text: Texte brut
-email-include-ics: Inclure un fichier ICS à l'Email
+email-include-ics: Inclure un fichier ICS Ã  l'Email
 Include iCalendar attachments: Inclure un attachement iCalendar
-Event reminders: Rappel pour un événement
-email-event-added: Notification par couriel lors de l'ajout d'un événement dans votre agenda.
-Events added to my calendar: Événement ajouté dans votre agenda
-email-event-updated: Notification par couriel lors de la modification d'un événement dans votre agenda.
-Events updated on my calendar: Événement modifié dans votre agenda
-email-event-deleted: Notification par couriel lors de la suppression d'un événement dans votre agenda.
-Events removed from my calendar: Événement supprimé dans votre agenda
-email-event-rejected: Notification par couriel lors du rejet d'un événement par l'un des participants.
-Event rejected by participant: Événement rejeté par un participant
-email-event-create: Spéficie si le créateur des entrées recevra un mail
-Event that I create: Evénement que je crée
-Email me event notification: Envoi d'un email de notification d'événement
-I want to approve events: Je souhaite approuver les événements
-display_byproxy-help: Afficher le créateur réel sur la page "view_entry"
-Display if created by Assistant: Afficher si créé par un assistant
-allow-view-subscriptions-help: Permet de restreindre l'accès distant des entrées privées ou confidentielles
+Event reminders: Rappel pour un Ã©vÃ©nement
+email-event-added: Notification par couriel lors de l'ajout d'un Ã©vÃ©nement dans votre agenda.
+Events added to my calendar: Ã‰vÃ©nement ajoutÃ© dans votre agenda
+email-event-updated: Notification par couriel lors de la modification d'un Ã©vÃ©nement dans votre agenda.
+Events updated on my calendar: Ã‰vÃ©nement modifiÃ© dans votre agenda
+email-event-deleted: Notification par couriel lors de la suppression d'un Ã©vÃ©nement dans votre agenda.
+Events removed from my calendar: Ã‰vÃ©nement supprimÃ© dans votre agenda
+email-event-rejected: Notification par couriel lors du rejet d'un Ã©vÃ©nement par l'un des participants.
+Event rejected by participant: Ã‰vÃ©nement rejetÃ© par un participant
+email-event-create: SpÃ©ficie si le crÃ©ateur des entrÃ©es recevra un mail
+Event that I create: EvÃ©nement que je crÃ©e
+Email me event notification: Envoi d'un email de notification d'Ã©vÃ©nement
+I want to approve events: Je souhaite approuver les Ã©vÃ©nements
+display_byproxy-help: Afficher le crÃ©ateur rÃ©el sur la page "view_entry"
+Display if created by Assistant: Afficher si crÃ©Ã© par un assistant
+allow-view-subscriptions-help: Permet de restreindre l'accÃ¨s distant des entrÃ©es privÃ©es ou confidentielles
 Allow remote viewing of: Permet la visualiation distante de
-entries: entrées
-allow-remote-subscriptions-help: Détermine si les usagers distants peuvent s'abonner à votre agenda, leur permettant de consulter vos événements à l'aide d'une application compatible iCal (Apple iCal ouMozilla Calendar par exemple)
+entries: entrÃ©es
+allow-remote-subscriptions-help: DÃ©termine si les usagers distants peuvent s'abonner Ã  votre agenda, leur permettant de consulter vos Ã©vÃ©nements Ã  l'aide d'une application compatible iCal (Apple iCal ouMozilla Calendar par exemple)
 Allow remote subscriptions: Autoriser les inscriptions distantes
-remote-subscriptions-url-help: Affiche l'URL avec lequel les utilisateurs distants peuvent s'abonner à votre agenda
-allow-remote-publishing-help: Précise si un client iCal distant peut republier ses évènements vers WebCalendar
-Allow remote publishing: Autorise la publication à distance
-remote-publishing-url-help: Affiche l'URL à utiliser dans l'application cliente iCal pour s'abonner et pour publier dans WebCalendar
-rss-enabled-help: Précise si un agenda d'utilisateur peut être récupéré d'un flux RSS
+remote-subscriptions-url-help: Affiche l'URL avec lequel les utilisateurs distants peuvent s'abonner Ã  votre agenda
+allow-remote-publishing-help: PrÃ©cise si un client iCal distant peut republier ses Ã©vÃ¨nements vers WebCalendar
+Allow remote publishing: Autorise la publication Ã  distance
+remote-publishing-url-help: Affiche l'URL Ã  utiliser dans l'application cliente iCal pour s'abonner et pour publier dans WebCalendar
+rss-enabled-help: PrÃ©cise si un agenda d'utilisateur peut Ãªtre rÃ©cupÃ©rÃ© d'un flux RSS
 Enable RSS feed: Autoriser le flux RSS
-rss-feed-url-help: L'URL pour accéder au flux RSS
-freebusy-enabled-help: Spécifie si le temps disponible de l'utilisateur peut être obtenu en utilisant le standard iCal FreeBusy.
+rss-feed-url-help: L'URL pour accÃ©der au flux RSS
+freebusy-enabled-help: SpÃ©cifie si le temps disponible de l'utilisateur peut Ãªtre obtenu en utilisant le standard iCal FreeBusy.
 Enable FreeBusy publishing: Permettre publication FreeBusy
-freebusy-url-help: L'URL pour accéder à la liste FreeBusy de l'utilisateur
-custom-script-help: Autoriser l'utilisation de codes javascript personnalisés ou de feuilles de style qui seront inséré(e)s dans la section HTML "head" de chaque page.
-Custom script/stylesheet: Script/Feuille de style personnalisé(e)
-custom-header-help: Permet d'ajouter un code HTML personnalisé au haut de chaque page
-Custom header: En-tête personnalisé
-custom-trailer-help: Permet d'ajouter un code HTML personnalisé au bas de chaque page
-Custom trailer: Bas de page personnalisé
+freebusy-url-help: L'URL pour accÃ©der Ã  la liste FreeBusy de l'utilisateur
+custom-script-help: Autoriser l'utilisation de codes javascript personnalisÃ©s ou de feuilles de style qui seront insÃ©rÃ©(e)s dans la section HTML "head" de chaque page.
+Custom script/stylesheet: Script/Feuille de style personnalisÃ©(e)
+custom-header-help: Permet d'ajouter un code HTML personnalisÃ© au haut de chaque page
+Custom header: En-tÃªte personnalisÃ©
+custom-trailer-help: Permet d'ajouter un code HTML personnalisÃ© au bas de chaque page
+Custom trailer: Bas de page personnalisÃ©
 Reset Colors: RÃ©initialiser les couleurs
 
 ########################################
 # Page: help_admin.php
 #
-System Settings: Réglages du système
+System Settings: RÃ©glages du systÃ¨me
 Allow HTML in Description: Autoriser l'utilisation de code HTML dans les descriptions
-allow-html-description-help: Si coché, les utilisateurs pourront ajouter du code HTML dans le champ descriptif d'événement.  Sinon, le HTML sera affiché textuellement.  Attention: Activer cette option permet aux utilisateurs d'inclure des images hébergées sur d'autres site web.
+allow-html-description-help: Si cochÃ©, les utilisateurs pourront ajouter du code HTML dans le champ descriptif d'Ã©vÃ©nement.  Sinon, le HTML sera affichÃ© textuellement.  Attention: Activer cette option permet aux utilisateurs d'inclure des images hÃ©bergÃ©es sur d'autres site web.
 Allow users to override conflicts: Permet aux utilisateurs de passer outre les conflits
-conflict-check-override-help: Permet aux utilisateurs de passer outre les conflits d'agenda et de plannifier deux (ou plus) événements au même moment.
+conflict-check-override-help: Permet aux utilisateurs de passer outre les conflits d'agenda et de plannifier deux (ou plus) Ã©vÃ©nements au mÃªme moment.
 Allow viewing other users calendars: Autoriser la visualisation des agendas des autres personnes
-allow-view-other-help: Spécifie si un utilisateur peut visualiser l'agenda d'un autre utilisateur.
+allow-view-other-help: SpÃ©cifie si un utilisateur peut visualiser l'agenda d'un autre utilisateur.
 Application Name: Nom de l'application
-app-name-help: Spécifie le nom de l'application qui apparaîtra dans la barre de titre du navigateur pour toutes les pages (page de connexion incluse). La valeur que vous spécifiez ici sera recherchée dans le fichier de traduction vous permettant de fournir différents titres pour différentes langues. 
-Check for event conflicts: Vérifier les conflits d'événements
-conflict-check-help: Vérifier les conflits d'événements (deux événements prévus au même moment pour la même personne). Si vous positionnez cette valeur à « Oui », vous pourrez introduire deux événements qui se chevauchent après confirmation. Si vous choisissez « Non », il ne sera effectué aucune vérification de conflit. Vous choisirez probablement « Oui » pour activer la vérification des conflits. 
-Conflict checking months: Période de vérification des conflits en mois
-conflict-months-help: Si la vérification des conflits est activée (« Vérifier les conflits pour les événements » est positionné sur « Oui »), ceci spécifie sur combien de mois dans le futur les conflits seront vérifiés. Si vous trouvez que l'ajout d'événements prend trop de temps, réduisez ce nombre. 
-Disable Access field: Désactiver le champ Accès
-disable-access-field-help: En sélectionnant « Oui », vous enlevez le champ « Accès » des pages d'information sur les événements, fournissant une interface plus simple pour les novices.
-Disable Participants field: Désactiver le champ Participants
-disable-participants-field-help: En sélectionnant « Oui », vous enlevez le champ « Participants » des pages d'informations sur les événements, empêchant les utilisateurs d'ajouter d'autres utilisateurs à leurs événements. Si vous activez cette option, vous devriez désactiver aussi le champ « Autoriser la visualisation des agendas des autres utilisateurs ».
-Disable Priority field: Désactiver le champ Priorité
-disable-priority-field-help: En sélectionnant « Oui », vous enlevez le champ « Priorité » des pages d'information sur les événements, fournissant une interface plus simple pour les novices.
-Disable Repeating field: Désactiver le champ de Répétition
-disable-repeating-field-help: En sélectionnant « Oui », vous enlevez le champ « Répétitions » lors de l'ajout d'événements, fournissant une interface plus simple pour les novices.
-Display days with events in bold in year view: Afficher les jours avec événements en gras dans la vue annuelle
-yearly-shows-events-help: Sur la vue par année, affiche les jours contenant des événements en caractères gras
-Display Site Extras in popup: Afficher les extras au site dans les fenêtres d'alerte
-popup-includes-siteextras-help: Si coché, permet aux champs ajoutés dans site_extras.php de s'afficher dans les fenêtres d'alerte d'événements
-Display weekends in week view: Afficher les week-ends dans la représentation de la semaine
+app-name-help: SpÃ©cifie le nom de l'application qui apparaÃ®tra dans la barre de titre du navigateur pour toutes les pages (page de connexion incluse). La valeur que vous spÃ©cifiez ici sera recherchÃ©e dans le fichier de traduction vous permettant de fournir diffÃ©rents titres pour diffÃ©rentes langues. 
+Check for event conflicts: VÃ©rifier les conflits d'Ã©vÃ©nements
+conflict-check-help: VÃ©rifier les conflits d'Ã©vÃ©nements (deux Ã©vÃ©nements prÃ©vus au mÃªme moment pour la mÃªme personne). Si vous positionnez cette valeur Ã  Â« Oui Â», vous pourrez introduire deux Ã©vÃ©nements qui se chevauchent aprÃ¨s confirmation. Si vous choisissez Â« Non Â», il ne sera effectuÃ© aucune vÃ©rification de conflit. Vous choisirez probablement Â« Oui Â» pour activer la vÃ©rification des conflits. 
+Conflict checking months: PÃ©riode de vÃ©rification des conflits en mois
+conflict-months-help: Si la vÃ©rification des conflits est activÃ©e (Â« VÃ©rifier les conflits pour les Ã©vÃ©nements Â» est positionnÃ© sur Â« Oui Â»), ceci spÃ©cifie sur combien de mois dans le futur les conflits seront vÃ©rifiÃ©s. Si vous trouvez que l'ajout d'Ã©vÃ©nements prend trop de temps, rÃ©duisez ce nombre. 
+Disable Access field: DÃ©sactiver le champ AccÃ¨s
+disable-access-field-help: En sÃ©lectionnant Â« Oui Â», vous enlevez le champ Â« AccÃ¨s Â» des pages d'information sur les Ã©vÃ©nements, fournissant une interface plus simple pour les novices.
+Disable Participants field: DÃ©sactiver le champ Participants
+disable-participants-field-help: En sÃ©lectionnant Â« Oui Â», vous enlevez le champ Â« Participants Â» des pages d'informations sur les Ã©vÃ©nements, empÃªchant les utilisateurs d'ajouter d'autres utilisateurs Ã  leurs Ã©vÃ©nements. Si vous activez cette option, vous devriez dÃ©sactiver aussi le champ Â« Autoriser la visualisation des agendas des autres utilisateurs Â».
+Disable Priority field: DÃ©sactiver le champ PrioritÃ©
+disable-priority-field-help: En sÃ©lectionnant Â« Oui Â», vous enlevez le champ Â« PrioritÃ© Â» des pages d'information sur les Ã©vÃ©nements, fournissant une interface plus simple pour les novices.
+Disable Repeating field: DÃ©sactiver le champ de RÃ©pÃ©tition
+disable-repeating-field-help: En sÃ©lectionnant Â« Oui Â», vous enlevez le champ Â« RÃ©pÃ©titions Â» lors de l'ajout d'Ã©vÃ©nements, fournissant une interface plus simple pour les novices.
+Display days with events in bold in year view: Afficher les jours avec Ã©vÃ©nements en gras dans la vue annuelle
+yearly-shows-events-help: Sur la vue par annÃ©e, affiche les jours contenant des Ã©vÃ©nements en caractÃ¨res gras
+Display Site Extras in popup: Afficher les extras au site dans les fenÃªtres d'alerte
+popup-includes-siteextras-help: Si cochÃ©, permet aux champs ajoutÃ©s dans site_extras.php de s'afficher dans les fenÃªtres d'alerte d'Ã©vÃ©nements
+Display weekends in week view: Afficher les week-ends dans la reprÃ©sentation de la semaine
 Home URL: URL racine
-home-url-help: Specifie l'URL racine de l'application. Elle peut être absolue ou relative.
-Include add event link in views: Inclure le lien d'ajout d'événement dans les vues
-allow-view-add-help: L'icone '+' apparaitra dans les vues permettant aux utilisateurs d'ajouter rapidement des événements dans ceux d'autres utilisateurs
-Limit number of timed events per day: Nombre maximum d'événements temporels par jour
-limit-appts-help: Permet à l'administrateur de fixer la limite générale du nombre d'événements par utilisateur et par jour.
-Maximum timed events per day: Nombre maximum d'événements temporels par jour
-limit-appts-number-help: Détermine le nombre maximum d'événements temporels qu'un utilisateur peut avoir dans une journée.
-Remember last login: Se souvenir de la dernière connexion
-remember-last-login-help: Si activé, l'identifiant de l'utilisateur sera rempli pour son compte sur la page de connexion (sans le mot de passe), et les préférences de l'utilisateur seront chargées (y compris les couleurs préférées et la sélection de la langue). 
-Require event approvals: Réclamer l'approbation des événements
-require-approvals-help: Activé, un utilisateur doit approuver un événement avant qu'il ne soit affiché dans l'agenda (à moins que « Afficher les événements en attente » ne soit activé). Notez que le réglage sur « Non » désactivera les approbations pour l'agenda à accès public (si l'accès public à l'agenda est activé).
+home-url-help: Specifie l'URL racine de l'application. Elle peut Ãªtre absolue ou relative.
+Include add event link in views: Inclure le lien d'ajout d'Ã©vÃ©nement dans les vues
+allow-view-add-help: L'icone '+' apparaitra dans les vues permettant aux utilisateurs d'ajouter rapidement des Ã©vÃ©nements dans ceux d'autres utilisateurs
+Limit number of timed events per day: Nombre maximum d'Ã©vÃ©nements temporels par jour
+limit-appts-help: Permet Ã  l'administrateur de fixer la limite gÃ©nÃ©rale du nombre d'Ã©vÃ©nements par utilisateur et par jour.
+Maximum timed events per day: Nombre maximum d'Ã©vÃ©nements temporels par jour
+limit-appts-number-help: DÃ©termine le nombre maximum d'Ã©vÃ©nements temporels qu'un utilisateur peut avoir dans une journÃ©e.
+Remember last login: Se souvenir de la derniÃ¨re connexion
+remember-last-login-help: Si activÃ©, l'identifiant de l'utilisateur sera rempli pour son compte sur la page de connexion (sans le mot de passe), et les prÃ©fÃ©rences de l'utilisateur seront chargÃ©es (y compris les couleurs prÃ©fÃ©rÃ©es et la sÃ©lection de la langue). 
+Require event approvals: RÃ©clamer l'approbation des Ã©vÃ©nements
+require-approvals-help: ActivÃ©, un utilisateur doit approuver un Ã©vÃ©nement avant qu'il ne soit affichÃ© dans l'agenda (Ã  moins que Â« Afficher les Ã©vÃ©nements en attente Â» ne soit activÃ©). Notez que le rÃ©glage sur Â« Non Â» dÃ©sactivera les approbations pour l'agenda Ã  accÃ¨s public (si l'accÃ¨s public Ã  l'agenda est activÃ©).
 Server URL: URL du serveur
-server-url-help: Spécifie l'URL de base pour l'application. Elle sera incluse lors de l'envoi des courriers électroniques ainsi que pour les rappels et les notifications. 
-Allow public access: Autoriser l'accès public
-allow-public-access-help: Activé, l'agenda peut être utilisé comme un agenda public en lecture seule ne requierant pas de connexion par les utilisateurs.
-Public access can add events: Autorise un accès public à ajouter des événements
-public-access-can-add-help: Activé, les utilisateurs qui accédent au système via un accès public pourront ajouter de nouveaux événements, mais ceux-ci ne s'afficheront pas dans l'agenda tant qu'un administrateur ne les aura pas approuvés. 
-Public access can view other users: L'accès public peut visualiser les autres utilisateurs
-public-access-view-others-help: Lors d'un accès en mode « accès public », spécifie si l'utilisateur peut visualiser les agendas des autres utilisateurs.
+server-url-help: SpÃ©cifie l'URL de base pour l'application. Elle sera incluse lors de l'envoi des courriers Ã©lectroniques ainsi que pour les rappels et les notifications. 
+Allow public access: Autoriser l'accÃ¨s public
+allow-public-access-help: ActivÃ©, l'agenda peut Ãªtre utilisÃ© comme un agenda public en lecture seule ne requierant pas de connexion par les utilisateurs.
+Public access can add events: Autorise un accÃ¨s public Ã  ajouter des Ã©vÃ©nements
+public-access-can-add-help: ActivÃ©, les utilisateurs qui accÃ©dent au systÃ¨me via un accÃ¨s public pourront ajouter de nouveaux Ã©vÃ©nements, mais ceux-ci ne s'afficheront pas dans l'agenda tant qu'un administrateur ne les aura pas approuvÃ©s. 
+Public access can view other users: L'accÃ¨s public peut visualiser les autres utilisateurs
+public-access-view-others-help: Lors d'un accÃ¨s en mode Â« accÃ¨s public Â», spÃ©cifie si l'utilisateur peut visualiser les agendas des autres utilisateurs.
 Public access can view participants: Les utilisateurs publiques peuvent afficher les participants
-public-access-sees-participants-help: Si coché, les utilisateurs consultant l'agenda à partir du compte public pourront voir la liste des participants en visualisant les détails d'un événement
-Public access is default participant: L'accès public est le participant par défaut
-public-access-default-selected: À l'ajout d'un événement, l'utilisateur public sera sélectionné par défaut comme participant.
-Public access new events require approval: Les nouveaux événements publiques doivent être approuvés
-public-access-add-requires-approval-help: Indique si les événements ajoutés par l'accès public nécéssitent d'être approuvés avant d'être affichés
-Public access visible by default: Accès public visible par défaut
-public-access-default-visible: Les événements de l'agenda public s'afficheront automatiquement sur les agenda de tous les autres usagers.
-Groups enabled: Groupes activés
-groups-enabled-help: Active le support des groupes, autorisant les utilisateurs à sélectionner les utilisateurs par groupe.
+public-access-sees-participants-help: Si cochÃ©, les utilisateurs consultant l'agenda Ã  partir du compte public pourront voir la liste des participants en visualisant les dÃ©tails d'un Ã©vÃ©nement
+Public access is default participant: L'accÃ¨s public est le participant par dÃ©faut
+public-access-default-selected: Ã€ l'ajout d'un Ã©vÃ©nement, l'utilisateur public sera sÃ©lectionnÃ© par dÃ©faut comme participant.
+Public access new events require approval: Les nouveaux Ã©vÃ©nements publiques doivent Ãªtre approuvÃ©s
+public-access-add-requires-approval-help: Indique si les Ã©vÃ©nements ajoutÃ©s par l'accÃ¨s public nÃ©cÃ©ssitent d'Ãªtre approuvÃ©s avant d'Ãªtre affichÃ©s
+Public access visible by default: AccÃ¨s public visible par dÃ©faut
+public-access-default-visible: Les Ã©vÃ©nements de l'agenda public s'afficheront automatiquement sur les agenda de tous les autres usagers.
+Groups enabled: Groupes activÃ©s
+groups-enabled-help: Active le support des groupes, autorisant les utilisateurs Ã  sÃ©lectionner les utilisateurs par groupe.
 User sees only his groups: L'utilisateur ne visualise que ses groupes
-user-sees-his-group-help: Si activé, les utilisateurs ne visualiseront pas l'agenda des autres utilisateurs n'appartenant pas au moins à leur groupe. 
+user-sees-his-group-help: Si activÃ©, les utilisateurs ne visualiseront pas l'agenda des autres utilisateurs n'appartenant pas au moins Ã  leur groupe. 
 Nonuser: Agenda Non-Utilisateur
-Nonuser enabled: Agenda des non-utilisateurs activé
-nonuser-enabled-help: Si activé, les administrateurs auront la possibilité d'ajouter des agendas non-utilisateurs
+Nonuser enabled: Agenda des non-utilisateurs activÃ©
+nonuser-enabled-help: Si activÃ©, les administrateurs auront la possibilitÃ© d'ajouter des agendas non-utilisateurs
 Nonuser list: Afficher la liste des participants 
-nonuser-list-help: Indique où afficher l'agenda des non-utilisateurs dans la liste des participants
+nonuser-list-help: Indique oÃ¹ afficher l'agenda des non-utilisateurs dans la liste des participants
 Other: Autre
-Allow external users: Autoriser les utilisateurs extérieurs
-allow-external-users-help: Indique si un utilisateur extérieur à l'agenda peut être ajouté à un événement. Celà permet aux utilisateurs extérieurs à l'agenda d'y figurer comme participants.
-subscriptions-enabled-help: Spécifie si l'utilisateur distant peut s'inscrire comme utilisateur de l'agenda partagé WebCalendar, lui permettant ainsi de voir les événements des utilisateurs des applications de type iCal (par exemple l'application iCal d'Apple ou le calendrier Mozilla)
-Categories enabled: Active/Désactive l'utilisation des catégories
-categories-enabled-help: Active le support des catégories, autorisant les utilisateurs à qualifier un événement par une catégorie. 
-External users can receive email notifications: Les utilisateurs extérieurs peuvent recevoir une notification par couriel
-external-can-receive-notification-help: Lorsque des utilisateurs extérieurs bénéficient de la possibilité d'adresser des courriers électroniques, ils peuvent recevoir une notification par couriel lors de l'ajout, de la modification ou de la suppression d'un événement (à condition que l'adresse de couriel de l'utilisateur extérieur soit spécifiée)
-External users can receive email reminders: Les utilisateurs extérieurs peuvent recevoir des rappels par couriel
-external-can-receive-reminder-help: Lorsque des utilisateurs extérieurs bénéficient de la possibilité d'adresser des courriers électroniques, ils peuvent recevoir un rappel (à condition que l'adresse de couriel de l'utilisateur extérieur soit spécifiée)
-Reports enabled: Rapports activés
-reports-enabled-help: Si coché, les utilisateurs verront apparaitre une section « Rapports » au bas de chaque page et pourront créer des rapports personnalisés.  En plus, les administrateurs ont la possibilité de créer des rapports globaux s'affichant au bas de chaque page d'usager.
-Default sender address: Adresse par défaut de l'expéditeur
-email-default-sender: Spécifie l'adresse de courrier électronique à indiquer pour l'expéditeur lors de l'envoi de rappels.
-Email enabled: Courrier électronique activé 
-email-enabled-help: Active/Désactive l'envoi de couriel pour la notification et les rappels. Positionnez-le sur « Non » si votre serveur n'est pas configuré pour l'adressage des courriers électroniques.
-Allow user to customize colors: Autoriser les utilisateurs à personnaliser leurs couleurs 
-user-customize-color: Détermine si les utilisateurs peuvent modifier leurs couleurs d'affichage
-Enable gradient images for background colors: Autoriser les images en dégradés comme images de fond
-enable-gradient-help: Utiliser des dégradés comme couleurs de fond des cellules
-Manually entering color values: Saisie personnalisée des couleurs
+Allow external users: Autoriser les utilisateurs extÃ©rieurs
+allow-external-users-help: Indique si un utilisateur extÃ©rieur Ã  l'agenda peut Ãªtre ajoutÃ© Ã  un Ã©vÃ©nement. CelÃ  permet aux utilisateurs extÃ©rieurs Ã  l'agenda d'y figurer comme participants.
+subscriptions-enabled-help: SpÃ©cifie si l'utilisateur distant peut s'inscrire comme utilisateur de l'agenda partagÃ© WebCalendar, lui permettant ainsi de voir les Ã©vÃ©nements des utilisateurs des applications de type iCal (par exemple l'application iCal d'Apple ou le calendrier Mozilla)
+Categories enabled: Active/DÃ©sactive l'utilisation des catÃ©gories
+categories-enabled-help: Active le support des catÃ©gories, autorisant les utilisateurs Ã  qualifier un Ã©vÃ©nement par une catÃ©gorie. 
+External users can receive email notifications: Les utilisateurs extÃ©rieurs peuvent recevoir une notification par couriel
+external-can-receive-notification-help: Lorsque des utilisateurs extÃ©rieurs bÃ©nÃ©ficient de la possibilitÃ© d'adresser des courriers Ã©lectroniques, ils peuvent recevoir une notification par couriel lors de l'ajout, de la modification ou de la suppression d'un Ã©vÃ©nement (Ã  condition que l'adresse de couriel de l'utilisateur extÃ©rieur soit spÃ©cifiÃ©e)
+External users can receive email reminders: Les utilisateurs extÃ©rieurs peuvent recevoir des rappels par couriel
+external-can-receive-reminder-help: Lorsque des utilisateurs extÃ©rieurs bÃ©nÃ©ficient de la possibilitÃ© d'adresser des courriers Ã©lectroniques, ils peuvent recevoir un rappel (Ã  condition que l'adresse de couriel de l'utilisateur extÃ©rieur soit spÃ©cifiÃ©e)
+Reports enabled: Rapports activÃ©s
+reports-enabled-help: Si cochÃ©, les utilisateurs verront apparaitre une section Â«Â RapportsÂ Â» au bas de chaque page et pourront crÃ©er des rapports personnalisÃ©s.  En plus, les administrateurs ont la possibilitÃ© de crÃ©er des rapports globaux s'affichant au bas de chaque page d'usager.
+Default sender address: Adresse par dÃ©faut de l'expÃ©diteur
+email-default-sender: SpÃ©cifie l'adresse de courrier Ã©lectronique Ã  indiquer pour l'expÃ©diteur lors de l'envoi de rappels.
+Email enabled: Courrier Ã©lectronique activÃ© 
+email-enabled-help: Active/DÃ©sactive l'envoi de couriel pour la notification et les rappels. Positionnez-le sur Â« Non Â» si votre serveur n'est pas configurÃ© pour l'adressage des courriers Ã©lectroniques.
+Allow user to customize colors: Autoriser les utilisateurs Ã  personnaliser leurs couleurs 
+user-customize-color: DÃ©termine si les utilisateurs peuvent modifier leurs couleurs d'affichage
+Enable gradient images for background colors: Autoriser les images en dÃ©gradÃ©s comme images de fond
+enable-gradient-help: Utiliser des dÃ©gradÃ©s comme couleurs de fond des cellules
+Manually entering color values: Saisie personnalisÃ©e des couleurs
 
 ########################################
 # Page: view_m.php
 #
-Double-click on empty cell to add new entry: Double-cliquez sur une cellule vide pour ajouter une nouvelle entrée
+Double-click on empty cell to add new entry: Double-cliquez sur une cellule vide pour ajouter une nouvelle entrÃ©e
 
 ########################################
 # Page: views.php
 #
-Manage Views: Gérer les vues
+Manage Views: GÃ©rer les vues
 Add New View: Ajouter une nouvelle vue
 
 ########################################
 # Page: admin.php
 #
-Select: Sélectionner
+Select: SÃ©lectionner
 Bottom: En bas
 Top: En haut
 Anyone: Tout le monde
 Participant: =
 Resource Calendars: Calendriers de ressources
-System options: Options du système
-Title: Agenda partagé
+System options: Options du systÃ¨me
+Title: Agenda partagÃ©
 Translated Name (XXX): Nom traduit (XXX)
 Site security: SÃ©curitÃ© du site
 Content Security Policy: Politique de sÃ©curitÃ© des contenus
 No site can frame the content: Aucun site ne peut cadrer le contenu
-The same site can frame the content: Le mÃªme site peut cadrer le contenu
+The same site can frame the content: Le mÃŠme site peut cadrer le contenu
 Any site can frame the content: N'importe quel site peut encadrer le contenu
 View explanation at OWASP: Voir l'explication sur OWASP
-enable-external-header-help: Permet de charger le bas de page à partir d'un fichier externe
-Use Cross-Site Request Forgery Protection: Utiliser une protection contre la contrefaÃ§on de requÃªte inter-site
+enable-external-header-help: Permet de charger le bas de page Ã  partir d'un fichier externe
+Use Cross-Site Request Forgery Protection: Utiliser une protection contre la contrefaÃ§on de requÃŠte inter-site
 Site customization: Personnalisation du site
 Allow external file for header/script/trailer: Autoriser l'utilisation de fichier externe pour haut/bas de pages/script
-Allow user to override header/trailer: Autoriser l'utilisateur à écraser le haut et le pied de page
-server-tz-help: Spécifie le décalage horaire à adopter pour ajuster l'heure universelle à l'heure du serveur.
-Server Timezone Selection: Sélection du fuseau horaire du serveur
-Default Client Timezone Selection: Fuseau horaire par défaut du client
-display-general-use-gmt-help: Si activé, les dates et heures standards sont affichées au format GMT
+Allow user to override header/trailer: Autoriser l'utilisateur Ã  Ã©craser le haut et le pied de page
+server-tz-help: SpÃ©cifie le dÃ©calage horaire Ã  adopter pour ajuster l'heure universelle Ã  l'heure du serveur.
+Server Timezone Selection: SÃ©lection du fuseau horaire du serveur
+Default Client Timezone Selection: Fuseau horaire par dÃ©faut du client
+display-general-use-gmt-help: Si activÃ©, les dates et heures standards sont affichÃ©es au format GMT
 Display Common Use Date/Times as GMT: Afficher les dates/heures au format GMT
 Allow top menu: Autoriser le menu du haut
-Date Selectors position: Position du sélecteur de date
-Display days with events in bold in month and year views: Sur les vues par mois et par année, affiche les jours contenant des événements en caractères gras
+Date Selectors position: Position du sÃ©lecteur de date
+Display days with events in bold in month and year views: Sur les vues par mois et par annÃ©e, affiche les jours contenant des Ã©vÃ©nements en caractÃ¨res gras
 Restrictions: =
-disable-location-field-help: Choisir "Oui" supprimera le champ "Lieu" des pages d'information des événements
-Disable Location field: Désactiver le champ "Lieu"
-disable-url-field-help: Choisir "Oui" supprimera le champ "URL" des pages d'information des événements
-Disable URL field: Désactiver le champ "URL"
+disable-location-field-help: Choisir "Oui" supprimera le champ "Lieu" des pages d'information des Ã©vÃ©nements
+Disable Location field: DÃ©sactiver le champ "Lieu"
+disable-url-field-help: Choisir "Oui" supprimera le champ "URL" des pages d'information des Ã©vÃ©nements
+Disable URL field: DÃ©sactiver le champ "URL"
 Popups: Pop-up
-disable-popups-help: Désactiver les pop-ups dans les vues de l'agenda
-Disable Pop-Ups: Désactiver les pop-up
-popup-includes-participants-help: si activé, les participants sont affichés dans les pop-ups de l'événement.
+disable-popups-help: DÃ©sactiver les pop-ups dans les vues de l'agenda
+Disable Pop-Ups: DÃ©sactiver les pop-up
+popup-includes-participants-help: si activÃ©, les participants sont affichÃ©s dans les pop-ups de l'Ã©vÃ©nement.
 Display Participants in popup: Afficher les participants dans un pop-up
-summary_length-help: Longueur maximale de la description brève dans les vues des calendriers
+summary_length-help: Longueur maximale de la description brÃ¨ve dans les vues des calendriers
 Brief Description Length: Longueur de la description rapide
-user_sort-help: Détermine l'ordre de tri pour les listes d'utilisateurs et de non-utilisateurs
+user_sort-help: DÃ©termine l'ordre de tri pour les listes d'utilisateurs et de non-utilisateurs
 User Sort Order: Ordre de tri utilisateur
-Lastname, Firstname: Nom, prénom
-Firstname, Lastname: Prénom, nom
-public-access-override-help: Permet de cacher les noms et descriptions des événements sur l'agenda public
-Override event name/description for public access: Changer les nom/description d'évenement pour l'accès public
-public-access-override-text-help: Le texte à afficher si l'option ci-dessus est active.
-Text to display to public access: Le texte à afficher pour l'accès public
-public-access-captcha-help: Si activé, les événéments ajoutés par Public requierent une validation par CAPTCHA
-Require CAPTCHA validation for public access new events: Recquiert une validation par CAPTCHA pour les nouveaux événements en accès public
-uac-enabled-help: Autorise le contrôle d'accès au niveau de l'utilisateur
-User Access Control enabled: Contrôle d'accès Utilisateur actif
-resource-enabled-help: Si activé, les administrateurs auront la possibilité d'ajouter des calendriers de ressources
+Lastname, Firstname: Nom, prÃ©nom
+Firstname, Lastname: PrÃ©nom, nom
+public-access-override-help: Permet de cacher les noms et descriptions des Ã©vÃ©nements sur l'agenda public
+Override event name/description for public access: Changer les nom/description d'Ã©venement pour l'accÃ¨s public
+public-access-override-text-help: Le texte Ã  afficher si l'option ci-dessus est active.
+Text to display to public access: Le texte Ã  afficher pour l'accÃ¨s public
+public-access-captcha-help: Si activÃ©, les Ã©vÃ©nÃ©ments ajoutÃ©s par Public requierent une validation par CAPTCHA
+Require CAPTCHA validation for public access new events: Recquiert une validation par CAPTCHA pour les nouveaux Ã©vÃ©nements en accÃ¨s public
+uac-enabled-help: Autorise le contrÃ´le d'accÃ¨s au niveau de l'utilisateur
+User Access Control enabled: ContrÃ´le d'accÃ¨s Utilisateur actif
+resource-enabled-help: Si activÃ©, les administrateurs auront la possibilitÃ© d'ajouter des calendriers de ressources
 Resource Calendars enabled: Calendriers de ressources activÃ©s
-resource-list-help: Où afficher les calendriers de ressources dans la liste des participants
+resource-list-help: OÃ¹ afficher les calendriers de ressources dans la liste des participants
 Display in participants list at: Afficher dans la liste des participants Ã 
-Upcoming Events: Evènements à venir
+Upcoming Events: EvÃ¨nements Ã  venir
 upcoming-events-help: Activer upcoming.php
-Enabled: activés
+Enabled: activÃ©s
 upcoming-events-allow-override: Autoriser l'utilisateur pour upcoming.php
-Allow user override: Autoriser l'utilisateur à remplacer
-upcoming-events-display-caticons: Inclure les catégories d'icônes dans upcoming.php
-Display category icons: Afficher les catégories d'icônes
+Allow user override: Autoriser l'utilisateur Ã  remplacer
+upcoming-events-display-caticons: Inclure les catÃ©gories d'icÃ´nes dans upcoming.php
+Display category icons: Afficher les catÃ©gories d'icÃ´nes
 upcoming-events-display-layers: Afficher les calques dans upcoming.php
 Display layers: Afficher les calques
 upcoming-events-display-links: Afficher les liens dans upcoming.php
-Display links to events: Afficher les liens pour les événements
-upcoming-events-display-popups: Afficher les popups pour les événements dans upcoming.php
-Display event popups: Afficher les popups des évènements
+Display links to events: Afficher les liens pour les Ã©vÃ©nements
+upcoming-events-display-popups: Afficher les popups pour les Ã©vÃ©nements dans upcoming.php
+Display event popups: Afficher les popups des Ã©vÃ¨nements
 remotes-enabled-help: Permet aux utilisateurs de charger des fichiers ics distants via une URL
 Allow remote calendars: Autoriser les agendas distants
-icon_upload-enabled-help: Si activé, les utilisateurs peuvent télécharger des icônes pour les catégories
-Category Icon Upload enabled: Téléchargement d'icône pour les catégorie activé
+icon_upload-enabled-help: Si activÃ©, les utilisateurs peuvent tÃ©lÃ©charger des icÃ´nes pour les catÃ©gories
+Category Icon Upload enabled: TÃ©lÃ©chargement d'icÃ´ne pour les catÃ©gorie activÃ©
 allow-self-registration-help: Permet aux nouveaux utilisateurs de s'auto-enregistrer
 Allow self-registration: Autorise l'auto-enregistrement
-use-blacklist-help: Limite l'accès aux fonctions de WebCalendar d'après l'adresse IP
-Restrict self-registration to blacklist: Interdit l'auto-enregistrement à la liste noire
-allow-self-registration-full-help: Autorise les nouveaux utilisateurs à complèter le processus d'auto-enregistrement en ligne
-Use self-registration email notifications: Générer des mots de passe et envoyer aux nouveaux utilisateurs
-allow-attachment-help: Autoriser les utilisateurs à ajouter des fchiers joints aux événements
-Allow file attachments to events: Autorise les fichiers joints pour les événements
-Admin and owner can always add attachments if enabled.: L'administrateur et le propriétaire peuvent toujours ajouter des fichiers joints si activé.
-allow-comments-help: Autoriser les utilisateurs à ajouter des commentaires aux événements
-Allow comments to events: Autoriser les commentaires sur les événements
-Admin and owner can always add comments if enabled.: L'administrateur et le propriétaire peuvent toujours ajouter des fichiers joints si activé.
-email-mailer: Choisissez la méthode d'envoi des mails
-Email Mailer: Méthode d'envoi des mails
-email-smtp-host: Hôte(s) du(es) serveur(s) SMTP séparés par des virgules
-SMTP Host name(s): Nom(s) d'hôte(s) SMTP
-email-smtp-port: Numéro de prt SMTP (généralement 25)
-SMTP Port Number: Numéro de port SMTP
-email-smtp-tls: Utiliser TLS pour sécuriser la connexion SMTP
+use-blacklist-help: Limite l'accÃ¨s aux fonctions de WebCalendar d'aprÃ¨s l'adresse IP
+Restrict self-registration to blacklist: Interdit l'auto-enregistrement Ã  la liste noire
+allow-self-registration-full-help: Autorise les nouveaux utilisateurs Ã  complÃ¨ter le processus d'auto-enregistrement en ligne
+Use self-registration email notifications: GÃ©nÃ©rer des mots de passe et envoyer aux nouveaux utilisateurs
+allow-attachment-help: Autoriser les utilisateurs Ã  ajouter des fchiers joints aux Ã©vÃ©nements
+Allow file attachments to events: Autorise les fichiers joints pour les Ã©vÃ©nements
+Admin and owner can always add attachments if enabled.: L'administrateur et le propriÃ©taire peuvent toujours ajouter des fichiers joints si activÃ©.
+allow-comments-help: Autoriser les utilisateurs Ã  ajouter des commentaires aux Ã©vÃ©nements
+Allow comments to events: Autoriser les commentaires sur les Ã©vÃ©nements
+Admin and owner can always add comments if enabled.: L'administrateur et le propriÃ©taire peuvent toujours ajouter des fichiers joints si activÃ©.
+email-mailer: Choisissez la mÃ©thode d'envoi des mails
+Email Mailer: MÃ©thode d'envoi des mails
+email-smtp-host: HÃ´te(s) du(es) serveur(s) SMTP sÃ©parÃ©s par des virgules
+SMTP Host name(s): Nom(s) d'hÃ´te(s) SMTP
+email-smtp-port: NumÃ©ro de prt SMTP (gÃ©nÃ©ralement 25)
+SMTP Port Number: NumÃ©ro de port SMTP
+email-smtp-tls: Utiliser TLS pour sÃ©curiser la connexion SMTP
 Use STARTTLS: Utiliser STARTTLS
 email-smtp-auth: Utiliser l'authentification SMTP
 SMTP Authentication: Authentification SMTP
@@ -880,15 +881,15 @@ email-smtp-username: Nom d'utilisateur SMTP si utilisation de l'authentification
 SMTP Username: Nom d'utilisateur SMTP
 email-smtp-password: Mot de passe SMTP si utilisation de l'authentification
 SMTP Password: Mot de passe SMTP
-Default user settings: Réglages par défaut de l'utilisateur
+Default user settings: RÃ©glages par dÃ©faut de l'utilisateur
 Color options: Options de couleurs
-gradient-colors: Si activé, les couleurs en dégradé seront utilisées. Ceci peut avoir un impact sur performances
+gradient-colors: Si activÃ©, les couleurs en dÃ©gradÃ© seront utilisÃ©es. Ceci peut avoir un impact sur performances
 Not available: Non disponible
 Background Image options: Options des images de fond
-bgimage-help: URL de l'image de fond. Peut être un lien relatif.
+bgimage-help: URL de l'image de fond. Peut Ãªtre un lien relatif.
 Background Image: Image de fond
-bgrepeat-help: Contrôle le comportement de répétition de l'image de fond.
-Background Repeat: Répétition du fond
+bgrepeat-help: ContrÃ´le le comportement de rÃ©pÃ©tition de l'image de fond.
+Background Repeat: RÃ©pÃ©tition du fond
 
 ########################################
 # Page: help_index.php
@@ -899,10 +900,10 @@ About WebCalendar: A propos de WebCalendar
 ########################################
 # Page: help_bug.php
 #
-Report Bug: Signaler un problème
+Report Bug: Signaler un problÃ¨me
 Please include all the information below when reporting a bug.: Merci d'inclure toutes les informations ci-dessous quand vous rapportez un bug.
 Also, please use English rather than: De plus, veuillez utiliser l'anglais plutÃ´t que
-Also, please use English rather than XXX.: Merci également d'utiliser <strong>l'anglais</strong> plutôt que XXX
+Also, please use English rather than XXX.: Merci Ã©galement d'utiliser <strong>l'anglais</strong> plutÃ´t que XXX
 
 ########################################
 # Page: docadd.php
@@ -914,18 +915,18 @@ Comment: Commentaire
 # Page: reject_entry.php
 #
 Continue: Continuer
-(Your comments will be emailed to the other participants.): (Vos commentaires vont être envoyés par email aux autres participants.)
-XXX has rejected an appointment.: XXX a rejeté un événement.
-Rejected by XXX.: Rejeté par XXX.
+(Your comments will be emailed to the other participants.): (Vos commentaires vont Ãªtre envoyÃ©s par email aux autres participants.)
+XXX has rejected an appointment.: XXX a rejetÃ© un Ã©vÃ©nement.
+Rejected by XXX.: RejetÃ© par XXX.
 
 ########################################
 # Page: search_handler.php
 #
-You must enter one or more search keywords.: Vous devez indiquer un ou plusieurs mot(s) clé(s) pour la recherche
-Search Results: Résultats de la recherche
-match found: événement correspond à votre recherche
-matches found: événements correspondent à votre recherche
-No matches found: Aucun événement ne correspond à votre recherche
+You must enter one or more search keywords.: Vous devez indiquer un ou plusieurs mot(s) clÃ©(s) pour la recherche
+Search Results: RÃ©sultats de la recherche
+match found: Ã©vÃ©nement correspond Ã  votre recherche
+matches found: Ã©vÃ©nements correspondent Ã  votre recherche
+No matches found: Aucun Ã©vÃ©nement ne correspond Ã  votre recherche
 New Search: Nouvelle recherche
 
 ########################################
@@ -934,50 +935,50 @@ New Search: Nouvelle recherche
 Export: Exporter
 Export format: Format d'exportation
 Include all layers: Inclure tous les calques
-Include deleted entries: Inclure les entrées supprimées
+Include deleted entries: Inclure les entrÃ©es supprimÃ©es
 Export all dates: Exporter toutes les dates
-Start date: Date de début
+Start date: Date de dÃ©but
 End date: Date de fin
-Modified since: Modifié depuis
+Modified since: ModifiÃ© depuis
 
 ########################################
 # Page: availability.php
 #
 user: utilisateur
-year: année
+year: annÃ©e
 month: mois
 day: jour
 
 ########################################
 # Page: security_audit.php
 #
-Security Audit: Audit de sécurité
-list potential security issues: L'information ci-dessous liste les problèmes potentiels avec l'installation de votre Webcalendar à corriger pour votre installation plus sécurisée.
-View your current PHP settings: visualiser vos paramètres PHP
-Security Issue: Problème de sécurité
-Default admin user password: Mot de passe par défaut pour l'utilisateur admin
+Security Audit: Audit de sÃ©curitÃ©
+list potential security issues: L'information ci-dessous liste les problÃ¨mes potentiels avec l'installation de votre Webcalendar Ã  corriger pour votre installation plus sÃ©curisÃ©e.
+View your current PHP settings: visualiser vos paramÃ¨tres PHP
+Security Issue: ProblÃ¨me de sÃ©curitÃ©
+Default admin user password: Mot de passe par dÃ©faut pour l'utilisateur admin
 You should change the password of the default admin user.: Vous devez changer le mot de passe de l'utilisateur admin.
 File permissions XXX: Permissions fichier : XXX
-item XXX should not be writable: Cet item ne doit pas avoir les droits en écriture :<br /><tt>XXX</tt>
+item XXX should not be writable: Cet item ne doit pas avoir les droits en Ã©criture :<br /><tt>XXX</tt>
 File exists XXX: Ce fichier existe : "XXX"
-Because you have email disabled, you should remove this file.: Les emails sont désactivés, vous pouvez détruire ce fichier.
+Because you have email disabled, you should remove this file.: Les emails sont dÃ©sactivÃ©s, vous pouvez dÃ©truire ce fichier.
 File location XXX: Emplacement fichier : "XXX"
-remove XXX if not using: si vous n'utilisez pas ce fichier "XXX", vous pouvez le détruire. ou le déplacer dans un autre répertoire.
-System Settings XXX: Paramètres système : "XXX"
+remove XXX if not using: si vous n'utilisez pas ce fichier "XXX", vous pouvez le dÃ©truire. ou le dÃ©placer dans un autre rÃ©pertoire.
+System Settings XXX: ParamÃ¨tres systÃ¨me : "XXX"
 consider enabling UAC: =
-recommend approving new public events: Nous vous recommendons que tous les événements publics soient approuvés.
-recommend using CAPTCHA: CAPTCHA est recommandé pour prévenir contre l'ajout d'événements automatique.
-Database cache directory location: Emplacement du répertoire cache de la base de données
-db cache should be inaccessible: Le cache de base de données devrait se trouver dans un répertoire qui ne peut pas être accessible avec une URL.
-PHP Settings XXX: Paramètres PHP : "XXX"
-recommend setting XXX Off: Le paramètre pour "XXX" est à Off.
+recommend approving new public events: Nous vous recommendons que tous les Ã©vÃ©nements publics soient approuvÃ©s.
+recommend using CAPTCHA: CAPTCHA est recommandÃ© pour prÃ©venir contre l'ajout d'Ã©vÃ©nements automatique.
+Database cache directory location: Emplacement du rÃ©pertoire cache de la base de donnÃ©es
+db cache should be inaccessible: Le cache de base de donnÃ©es devrait se trouver dans un rÃ©pertoire qui ne peut pas Ãªtre accessible avec une URL.
+PHP Settings XXX: ParamÃ¨tres PHP : "XXX"
+recommend setting XXX Off: Le paramÃ¨tre pour "XXX" est Ã  Off.
 recommend setting XXX On: Recommander le rÃ©glage XXX On
-recommend setting allow_url_fopen Off: Le paramétrage recommandé pour "allow_url_fopen" est Off quand les calendriers distant sont activés.
+recommend setting allow_url_fopen Off: Le paramÃ©trage recommandÃ© pour "allow_url_fopen" est Off quand les calendriers distant sont activÃ©s.
 
 ########################################
 # Page: freebusy.php
 #
-No user specified.: Aucun utilisateur spécifié.
+No user specified.: Aucun utilisateur spÃ©cifiÃ©.
 
 ########################################
 # Page: select_user.php
@@ -987,11 +988,11 @@ View Another Users Calendar: Visualiser l'agenda d'un autre utilisateur
 ########################################
 # Page: edit_remotes_handler.php
 #
-Import Results: Résultat de l'importation
-Events successfully imported: Événements importés avec succès
-Create a new layer to view this calendar.: Créer un nouveau calque pour visualiser cet agenda
+Import Results: RÃ©sultat de l'importation
+Events successfully imported: Ã‰vÃ©nements importÃ©s avec succÃ¨s
+Create a new layer to view this calendar.: CrÃ©er un nouveau calque pour visualiser cet agenda
 Errors: Erreurs
-There was an error parsing the import file or no events were returned.: Erreur lors de l'analyse du fichier d'importation - ou - aucun événement n'a été détecté
+There was an error parsing the import file or no events were returned.: Erreur lors de l'analyse du fichier d'importation - ou - aucun Ã©vÃ©nement n'a Ã©tÃ© dÃ©tectÃ©
 
 ########################################
 # Page: adminhome.php
@@ -1002,9 +1003,9 @@ Account: Compte
 Views: Vues
 Reports: Rapports
 Activity Log: Journal de suivi
-System Log: Log du système
-Public Preferences: Paramètres publiques
-Unapproved Public Events: Événements publiques non approuvés
+System Log: Log du systÃ¨me
+Public Preferences: ParamÃ¨tres publiques
+Unapproved Public Events: Ã‰vÃ©nements publiques non approuvÃ©s
 Administrative Tools: Outils d'administration
 
 ########################################
@@ -1014,13 +1015,13 @@ Are you sure you want to delete this resource calendar?: ÃŠtes-vous sÃ»r de voul
 This will remove all events for this resource calendar.: Cela supprimera tous les Ã©vÃ©nements de ce calendrier de ressources.
 Unique Calendar ID for resource calendar: Identifiant unique du calendrier pour le calendrier de ressources
 Admin of this resource calendar: Administrateur de ce calendrier de ressources
-Enabling allows this resource calendar to be used as a public calendar, and a link directly to it will be displayed on the login page.: L'activation permet Ã  ce calendrier de ressources d'Ãªtre utilisÃ© comme un calendrier public, et un lien direct vers celui-ci sera affichÃ© sur la page de connexion.
+Enabling allows this resource calendar to be used as a public calendar, and a link directly to it will be displayed on the login page.: L'activation permet Ã  ce calendrier de ressources d'ÃŠtre utilisÃ© comme un calendrier public, et un lien direct vers celui-ci sera affichÃ© sur la page de connexion.
 Number of events currently in the resource calendar: Nombre d'Ã©vÃ©nements actuellement prÃ©sents dans le calendrier des ressources
 Add Resource Calendar: Ajouter un Calendrier des Ressources
 Delete Resource Calendar: Supprimer le Calendrier des Ressources
-Resource Calendar successfully added.: Le Calendrier des Ressources a Ã©tÃ© ajoutÃ© avec succÃ¨s.
-Resource Calendar successfully updated.: Calendrier des ressources mis Ã  jour avec succÃ¨s.
-Resource calendar successfully deleted.: Calendrier des ressources supprimÃ© avec succÃ¨s.
+Resource Calendar successfully added.: Le Calendrier des Ressources a Ã©tÃ© ajoutÃ© avec succÃªs.
+Resource Calendar successfully updated.: Calendrier des ressources mis Ã  jour avec succÃªs.
+Resource calendar successfully deleted.: Calendrier des ressources supprimÃ© avec succÃªs.
 
 ########################################
 # Page: upcoming.php
@@ -1040,12 +1041,12 @@ Password: Mot de passe
 Save login via cookies so I dont have to login next time.: Sauvegarder l'identifiant dans un cookie, pour ne plus le saisir la prochaine fois
 Login: Connexion
 public: =
-cookies-note: <b>Note:</b> Cette application nécessite l'activation des cookies
+cookies-note: <b>Note:</b> Cette application nÃ©cessite l'activation des cookies
 
 ########################################
 # Page: docdel.php
 #
-Removed: Supprimée
+Removed: SupprimÃ©e
 
 ########################################
 # Page: views_edit.php
@@ -1056,55 +1057,55 @@ Edit View: Modifier la vue
 View Name: Nom de la vue
 View Type: Type de la vue
 Day by Time: Jour par temps
-Week (Users horizontal): Semaine (utilisateurs à l'horizontale)
+Week (Users horizontal): Semaine (utilisateurs Ã  l'horizontale)
 Week by Time: Semaine par temps
-Week (Users vertical): Semaine (utilisateurs à la verticale)
+Week (Users vertical): Semaine (utilisateurs Ã  la verticale)
 Week (Timebar): Semaine (planning)
 Month (Timebar): Mois (planning)
-Month (side by side): Mois (côte à côte)
-Month (on same calendar): Mois (sur le même agenda)
+Month (side by side): Mois (cÃ´te Ã  cÃ´te)
+Month (on same calendar): Mois (sur le mÃªme agenda)
 
 ########################################
 # Page: del_entry.php
 #
-XXX has canceled an appointment.: XXX a annulé un rendez-vous.
+XXX has canceled an appointment.: XXX a annulÃ© un rendez-vous.
 
 ########################################
 # Page: nulogin.php
 #
-A login must be specified.: Vous devez spécifier un nom d'utilisateur
+A login must be specified.: Vous devez spÃ©cifier un nom d'utilisateur
 No such nonuser calendar: Pas de calendrier Non-utilisateur
 
 ########################################
 # Page: edit_entry_handler.php
 #
-XXX has made a new appointment.: XXX a créé un nouveau rendez-vous.
-XXX has updated an appointment.: XXX a modifié un rendez-vous.
-Security violation!: Violation de sécurité !
-You must enter the anti-spam text on the previous page.: Vous devez saisir le texte anti-spam sur la page précédente
-The following conflicts with the suggested time: Cet événement est en conflit avec l'heure suggérée.
-User removed from participants list.: Utilisateur retiré des participants
+XXX has made a new appointment.: XXX a crÃ©Ã© un nouveau rendez-vous.
+XXX has updated an appointment.: XXX a modifiÃ© un rendez-vous.
+Security violation!: Violation de sÃ©curitÃ© !
+You must enter the anti-spam text on the previous page.: Vous devez saisir le texte anti-spam sur la page prÃ©cÃ©dente
+The following conflicts with the suggested time: Cet Ã©vÃ©nement est en conflit avec l'heure suggÃ©rÃ©e.
+User removed from participants list.: Utilisateur retirÃ© des participants
 Please look on XXX to accept or reject this appointment.: Merci de regarder sur XXX pour accepter ou rejeter ce rendez-vous
 Please look on XXX to view this appointment.: Merci de regarder sur XXX pour visualiser ce rendez-vous
 Scheduling Conflict: Conflit entre agendas
 Your suggested time of: Votre suggestion de
-conflicts with the following existing calendar entries: est en conflit avec les événements suivants
+conflicts with the following existing calendar entries: est en conflit avec les Ã©vÃ©nements suivants
 
 ########################################
 # Page: help_edit_entry.php
 #
-Adding/Editing Calendar Entries: Ajouter/Modifier un événement
+Adding/Editing Calendar Entries: Ajouter/Modifier un Ã©vÃ©nement
 For More Information...: Pour plus d'information...
-Repeat End Date: Date de fin de répétition
-Repeat Day: Répétition du Jour
-repeat-day-help: Spécifie quels jours de la semaine l'événement doit être répété. Vous devez l'utiliser seulement si <i>Type de répétition</i> est sur <i>Hebdomadaire</i>.
+Repeat End Date: Date de fin de rÃ©pÃ©tition
+Repeat Day: RÃ©pÃ©tition du Jour
+repeat-day-help: SpÃ©cifie quels jours de la semaine l'Ã©vÃ©nement doit Ãªtre rÃ©pÃ©tÃ©. Vous devez l'utiliser seulement si <i>Type de rÃ©pÃ©tition</i> est sur <i>Hebdomadaire</i>.
 
 ########################################
 # Page: ajax.php
 #
 Duplicate Name XXX: Nom en double : "XXX".
-Username XXX already exists.: Le nom d'utilisateur "XXX" existe déjà.
-Email address XXX already exists.: L'adresse email "XXX" existe déjà.
+Username XXX already exists.: Le nom d'utilisateur "XXX" existe dÃ©jÃ .
+Email address XXX already exists.: L'adresse email "XXX" existe dÃ©jÃ .
 
 ########################################
 # Page: assistant_edit.php
@@ -1114,76 +1115,76 @@ Your assistants: Vos assistants
 ########################################
 # Page: list_unapproved.php
 #
-No unapproved entries for XXX.: Aucune entrée non approuvée pour : "XXX".
-Approve Selected entries?: Approuver les entrées sélectionnées ?
-Reject Selected entries?: Rejeter les entrées sélectionnées ?
+No unapproved entries for XXX.: Aucune entrÃ©e non approuvÃ©e pour : "XXX".
+Approve Selected entries?: Approuver les entrÃ©es sÃ©lectionnÃ©es ?
+Reject Selected entries?: Rejeter les entrÃ©es sÃ©lectionnÃ©es ?
 
 ########################################
 # Page: add_entry.php
 #
-Event XXX is already on your calendar.: L'événement XXX est déjà dans votre agenda
-a XXX event may not be added to your calendar: Ceci est un événement XXX qui ne peut pas être ajouté à votre agenda.
+Event XXX is already on your calendar.: L'Ã©vÃ©nement XXX est dÃ©jÃ  dans votre agenda
+a XXX event may not be added to your calendar: Ceci est un Ã©vÃ©nement XXX qui ne peut pas Ãªtre ajoutÃ© Ã  votre agenda.
 confidential: confidentiel
-private: privé
-Error adding event XXX.: Erreur lors de l'ajout de l'événement : XXX.
+private: privÃ©
+Error adding event XXX.: Erreur lors de l'ajout de l'Ã©vÃ©nement : XXX.
 
 ########################################
 # Page: help_uac.php
 #
-Allows for fine control of user access and permissions. Users can also grant default and per individual permission if authorized by the administrator.: Permet un contrôle précis des accès et persmissions des utilisateurs. Les utilisateurs peuvent aussi donner des droits par défaut et/ou sur une base individuel si permit par l'administrateur.
-If disabled, this user cannot send you emails.: Si désactivé, cet utilisateur ne pourra pas vous envoyer d'email.
-If disabled, this user cannot see you in the participants list.: Si désactivé, cet utilisateur ne pourra pas vous voir dans la liste des participants
-If enabled, this user cannot view the details of any of your entries.: Si activé, cet utilisateur ne pourra voir le détail d'aucune de vos entrée.
+Allows for fine control of user access and permissions. Users can also grant default and per individual permission if authorized by the administrator.: Permet un contrÃ´le prÃ©cis des accÃ¨s et persmissions des utilisateurs. Les utilisateurs peuvent aussi donner des droits par dÃ©faut et/ou sur une base individuel si permit par l'administrateur.
+If disabled, this user cannot send you emails.: Si dÃ©sactivÃ©, cet utilisateur ne pourra pas vous envoyer d'email.
+If disabled, this user cannot see you in the participants list.: Si dÃ©sactivÃ©, cet utilisateur ne pourra pas vous voir dans la liste des participants
+If enabled, this user cannot view the details of any of your entries.: Si activÃ©, cet utilisateur ne pourra voir le dÃ©tail d'aucune de vos entrÃ©e.
 
 ########################################
 # Page: search.php
 #
-Advanced Search: Recherche avancée
+Advanced Search: Recherche avancÃ©e
 Search: Rechercher
-Keywords: Mots clés
-Enter % for all entries: Entrez %  pour toutes les entrées
+Keywords: Mots clÃ©s
+Enter % for all entries: Entrez %  pour toutes les entrÃ©es
 Include: Inclure
 Filter by Date: Filtrer par date
 All Dates: Toutes les dates
-Past: Précédent
+Past: PrÃ©cÃ©dent
 Upcoming: Suivant
 Range: Etendue
 
 ########################################
 # Page: register.php
 #
-Email address cannot be blank.: L'adresse email ne peut pas être vide.
-Username already exists.: Cet utilisateur existe déjà.
-Email address already exists.: Cette adresse Email existe déjà.
+Email address cannot be blank.: L'adresse email ne peut pas Ãªtre vide.
+Username already exists.: Cet utilisateur existe dÃ©jÃ .
+Email address already exists.: Cette adresse Email existe dÃ©jÃ .
 The passwords were not identical.: Les mots de passe saisis ne sont pas identiques
 New user via self-registration.: Nouvel utilisateur par auto-enregistrement.
-A new WebCalendar account has been set up for you.: Un nouveau compte webcalendar a été créé pour vous.
+A new WebCalendar account has been set up for you.: Un nouveau compte webcalendar a Ã©tÃ© crÃ©Ã© pour vous.
 Your username is XXX.: Votre nom d'utilisateur est "XXX".
 Your password is XXX.: Votre mot de passe est "XXX"
 Please visit XXX to log in and start using your account!: Merci de visiter "XXX"
-You may change your password after logging in the first time.: Vous devriez changer votre mot de passe après votre première connexion.
-If you received this email in error: Si vous avez reçu ce mail par erreur et n'avez pas demander l'ouverture d'un compte WebCalendar, merci de ne pas tenir compte de ce mail, ou répondez-y avec une courte note
+You may change your password after logging in the first time.: Vous devriez changer votre mot de passe aprÃ¨s votre premiÃ¨re connexion.
+If you received this email in error: Si vous avez reÃ§u ce mail par erreur et n'avez pas demander l'ouverture d'un compte WebCalendar, merci de ne pas tenir compte de ce mail, ou rÃ©pondez-y avec une courte note
 Administrator: Administrateur
 Welcome: Bienvenue
 New user via email.: Nouvel utilisateur par email
 You have not entered a password.: Vous n'avez pas saisi de mot de passe
-Email cannot be blank.: L'e-mail ne peut pas Ãªtre vide.
+Email cannot be blank.: L'e-mail ne peut pas ÃŠtre vide.
 Registration: Enregistrement
 Welcome to WebCalendar: Bienvenue sur WebCalendar
-Your email should arrive shortly.: L'email devrait vous parvenir très prochainement.
-Return to Login screen: Retourner à la page d'identification
-First Name: Prénom
+Your email should arrive shortly.: L'email devrait vous parvenir trÃ¨s prochainement.
+Return to Login screen: Retourner Ã  la page d'identification
+First Name: PrÃ©nom
 Last Name: Nom
 E-mail address: Adresse de couriel 
 Password (again): Mot de passe (confirmation)
-Your account information will be emailed to you.: Les informations sur votre compte vont vous être envoyées par email.
+Your account information will be emailed to you.: Les informations sur votre compte vont vous Ãªtre envoyÃ©es par email.
 
 ########################################
 # Page: about.php
 #
 version XXX: =
-WebCalendar is a PHP application used...: WebCalendar est une application PHP utilisée pour maintenir un calendrier   en mode usagé simple ou multiple. WebCalendar peut aussi être configuré comme un calendrier d'événements.
-Credits: Crédits
+WebCalendar is a PHP application used...: WebCalendar est une application PHP utilisÃ©e pour maintenir un calendrier   en mode usagÃ© simple ou multiple. WebCalendar peut aussi Ãªtre configurÃ© comme un calendrier d'Ã©vÃ©nements.
+Credits: CrÃ©dits
 About: A propos
 
 ########################################
@@ -1197,33 +1198,33 @@ Currently in English only.: Uniquement en anglais pour le moment
 #
 AVAILABLE CATEGORIES: CATEGORIES DISPONIBLES
 ENTRY CATEGORIES: CATEGORIES D'ENTREE
-Global Category: Catégorie globale
+Global Category: CatÃ©gorie globale
 
 ########################################
 # Page: import_handler.php
 #
 No file: Aucun fichier
-Error deleting palm events from webcalendar.: Erreur lors de l'effacement d'événements palm de webcalendar
-Events from prior import marked as deleted: Les événements importés précédemment sont marqués supprimés
-Conflicting events: Événements en conflits
-The import file contained no data.: Le fichier à importer ne contient aucune donnée exploitable
+Error deleting palm events from webcalendar.: Erreur lors de l'effacement d'Ã©vÃ©nements palm de webcalendar
+Events from prior import marked as deleted: Les Ã©vÃ©nements importÃ©s prÃ©cÃ©demment sont marquÃ©s supprimÃ©s
+Conflicting events: Ã‰vÃ©nements en conflits
+The import file contained no data.: Le fichier Ã  importer ne contient aucune donnÃ©e exploitable
 
 ########################################
 # Page: category_handler.php
 #
 Category name is required: Le nom de la catÃ©gorie est requis.
-File size exceeds maximum.: La taille du fichier dépasse le maximum autorisé.
+File size exceeds maximum.: La taille du fichier dÃ©passe le maximum autorisÃ©.
 File is not a GIF or PNG image: Le fichier n'est pas une image GIF ou PNG.
 
 ########################################
 # Page: icons.php
 #
-Click to Select: Cliquez pour sélectionner
+Click to Select: Cliquez pour sÃ©lectionner
 
 ########################################
 # Page: export_handler.php
 #
-export format not defined or incorrect.: Le format d'exportation n'est pas défini ou est incorrect
+export format not defined or incorrect.: Le format d'exportation n'est pas dÃ©fini ou est incorrect
 
 ########################################
 # Page: users_ajax.php
@@ -1240,21 +1241,21 @@ Calendar ID already in use: Identifiant du calendrier est dÃ©jÃ  utilisÃ©
 # Page: help_import.php
 #
 Palm Desktop: =
-allow you to import entries from the Palm...: Ce formulaire vous permet d'importer des entrées en provenance de votre Palm Desktop Datebook. c'est supposé être dans le répertoire de votre Palm <tt>datebook/datebook.dat</tt> dans un sous-répertoire à votre nom.
-The following entries will not be imported: Les entrées suivantes ne seront pas importées
-Entries older than the current date: Entrées antérieures à la date courante
-Entries created in the Palm Desktop...: Entrées crées dans le logiciel Palm Desktop qui n'ont pas été synchronisées via HotSync
-Anything imported from Palm...: tout ce qui a été importé de votre Palm sera écrasé lors du prochain import (tant que la date de l'événement n'est pas passée). A présent les mises à jour doivent être faites sur le Palm
+allow you to import entries from the Palm...: Ce formulaire vous permet d'importer des entrÃ©es en provenance de votre Palm Desktop Datebook. c'est supposÃ© Ãªtre dans le rÃ©pertoire de votre Palm <tt>datebook/datebook.dat</tt> dans un sous-rÃ©pertoire Ã  votre nom.
+The following entries will not be imported: Les entrÃ©es suivantes ne seront pas importÃ©es
+Entries older than the current date: EntrÃ©es antÃ©rieures Ã  la date courante
+Entries created in the Palm Desktop...: EntrÃ©es crÃ©es dans le logiciel Palm Desktop qui n'ont pas Ã©tÃ© synchronisÃ©es via HotSync
+Anything imported from Palm...: tout ce qui a Ã©tÃ© importÃ© de votre Palm sera Ã©crasÃ© lors du prochain import (tant que la date de l'Ã©vÃ©nement n'est pas passÃ©e). A prÃ©sent les mises Ã  jour doivent Ãªtre faites sur le Palm
 vCal: =
-This form will import vCalendar (.vcs) 1.0 events.: Ce formulaire importera les événementx vCalendar (.vcs) 1.0.
-The following formats have been tested: Les formats suivants ont été testés
-This form will import iCalendar (.ics) events.: Ce formulaire importera les événements iCalendar (.ics).
+This form will import vCalendar (.vcs) 1.0 events.: Ce formulaire importera les Ã©vÃ©nementx vCalendar (.vcs) 1.0.
+The following formats have been tested: Les formats suivants ont Ã©tÃ© testÃ©s
+This form will import iCalendar (.ics) events.: Ce formulaire importera les Ã©vÃ©nements iCalendar (.ics).
 will cause events imported previously...: =
 
 ########################################
 # Page: user_mgmt.php
 #
-Are you sure you want to delete this user?: Êtes-vous certain de vouloir supprimer cet utilisateur ?
+Are you sure you want to delete this user?: ÃŠtes-vous certain de vouloir supprimer cet utilisateur ?
 This will delete all events for this user.: Cela supprimera tous les Ã©vÃ©nements pour cet utilisateur.
 Invalid email address: Adresse Ã©lectronique non valide
 Add User: Ajouter un utilisateur
@@ -1262,23 +1263,23 @@ New username: Nouveau nom d'utilisateur
 Change Password: Changer de mot de passe
 Delete User: supprimer l'utilisateur
 Edit User: Modifier un utilisateur
-User successfully added.: Utilisateur ajoutÃ© avec succÃ¨s.
-User successfully updated.: Utilisateur mis Ã  jour avec succÃ¨s.
-Password successfully updated.: Le mot de passe a Ã©tÃ© mis Ã  jour avec succÃ¨s.
-User successfully deleted.: Utilisateur supprimÃ© avec succÃ¨s.
+User successfully added.: Utilisateur ajoutÃ© avec succÃªs.
+User successfully updated.: Utilisateur mis Ã  jour avec succÃªs.
+Password successfully updated.: Le mot de passe a Ã©tÃ© mis Ã  jour avec succÃªs.
+User successfully deleted.: Utilisateur supprimÃ© avec succÃªs.
 
 ########################################
 # Page: week_details.php
 #
-New Entry: Nouvel événement
+New Entry: Nouvel Ã©vÃ©nement
 cont.: suite
 
 ########################################
 # Page: edit_template.php
 #
-Edit Custom Header: Éditer les en-têtes personnalisés
-Edit Custom Script/Stylesheet: Éditer les scripts/feuilles de style personnalisé(e)s
-Edit Custom Trailer: Éditer les fins de pages personnalisées
+Edit Custom Header: Ã‰diter les en-tÃªtes personnalisÃ©s
+Edit Custom Script/Stylesheet: Ã‰diter les scripts/feuilles de style personnalisÃ©(e)s
+Edit Custom Trailer: Ã‰diter les fins de pages personnalisÃ©es
 
 ########################################
 # Page: edit_report.php
@@ -1289,20 +1290,20 @@ Yesterday: Hier
 Day before yesterday: Avant-hier
 Next week: Semaine prochaine
 This week: Semaine en cours
-Last week: Semaine dernière
-Week before last: Semaine précédente
-Next week and week after: La semaine précédente et la semaine prochaine
+Last week: Semaine derniÃ¨re
+Week before last: Semaine prÃ©cÃ©dente
+Next week and week after: La semaine prÃ©cÃ©dente et la semaine prochaine
 This week and next week: Cette semaine et la semaine prochaine
-Last week and this week: La semaine dernière et cette semaine
-Last two weeks: Les deux dernières semaines
+Last week and this week: La semaine derniÃ¨re et cette semaine
+Last two weeks: Les deux derniÃ¨res semaines
 Next month: Mois prochain
 This month: Mois en cours
 Last month: Mois dernier
-Month before last: Mois précédent
-Next year: Année prochaine
-This year: Année en cours
-Last year: Année dernière
-Year before last: Année précécente
+Month before last: Mois prÃ©cÃ©dent
+Next year: AnnÃ©e prochaine
+This year: AnnÃ©e en cours
+Last year: AnnÃ©e derniÃ¨re
+Year before last: AnnÃ©e prÃ©cÃ©cente
 Next 14 days: Les 14 prochains jours
 Next 30 days: Les 30 prochains jours
 Next 60 days: Les 60 prochains jours
@@ -1311,28 +1312,28 @@ Next 180 days: Les 180 prochains jours
 Next 365 days: Les 365 prochains jours
 Invalid report id XXX.: ID de rapport invalide : "XXX";
 Add Report: Ajouter un rapport
-Edit Report: Éditer un rapport
+Edit Report: Ã‰diter un rapport
 Report Name: Nom du Rapport
 Current User: Utilisateur actuel
 Include link in menu: Inclure le lien dans le menu
 Include standard header/trailer: Inclure les hauts et bas de pages standards
-Include previous/next links: Inclure les liens avant/après
-Include empty dates: Inclure les dates non renseignées
-Date range: Période
+Include previous/next links: Inclure les liens avant/aprÃ¨s
+Include empty dates: Inclure les dates non renseignÃ©es
+Date range: PÃ©riode
 Are you sure you want to delete this report?: Etes vous certain de vouloir effacer ce rapport ?
 Template variables: Variables disponibles
 
 ########################################
 # Page: help_pref.php
 #
-default-category-help: Spécifie la catégorie par défaut lors de la création d'événement.
-email-boss-notifications-help: Détermine si les "décideurs" reçoivent des courriels de notification 
-boss-approve-event-help: Détermine si le "décideur" doit approuver les événements ajoutés par ses assistants
+default-category-help: SpÃ©cifie la catÃ©gorie par dÃ©faut lors de la crÃ©ation d'Ã©vÃ©nement.
+email-boss-notifications-help: DÃ©termine si les "dÃ©cideurs" reÃ§oivent des courriels de notification 
+boss-approve-event-help: DÃ©termine si le "dÃ©cideur" doit approuver les Ã©vÃ©nements ajoutÃ©s par ses assistants
 
 ########################################
 # Page: tools/reload_remotes.php
 #
-Error connecting to database: Erreur pendant la connexion à la base de donnée
+Error connecting to database: Erreur pendant la connexion Ã  la base de donnÃ©e
 Include Path: =
 No Remote Calendars found: =
 Remote Calendars not enabled: =
@@ -1340,27 +1341,27 @@ Remote Calendars not enabled: =
 ########################################
 # Page: tools/send_reminders.php
 #
-could not find event id: Impossible de trouver l'événement id
-could not find event id XXX in database.: Impossible de trouver l'événement id XXX en base de données.
+could not find event id: Impossible de trouver l'Ã©vÃ©nement id
+could not find event id XXX in database.: Impossible de trouver l'Ã©vÃ©nement id XXX en base de donnÃ©es.
 task: =
 event: &eacute;v&eacute;nement
-This is a reminder for the XXX detailed below.: Ceci est un rappel pour XXX détaillé ci-dessous.
+This is a reminder for the XXX detailed below.: Ceci est un rappel pour XXX dÃ©taillÃ© ci-dessous.
 Reminder: Rappel
 
 ########################################
 # Page: ws/get_events.php
 #
 Checking for events for XXX from date YYY to date ZZZ.: =
-Found XXX events in time range.: trouvé XXX événements dans les heures choisies.
-Event id=XXX YYY at ZZZ on AAA.: Evénement id=XXX "YYY" à ZZZ on AAA.
+Found XXX events in time range.: trouvÃ© XXX Ã©vÃ©nements dans les heures choisies.
+Event id=XXX YYY at ZZZ on AAA.: EvÃ©nement id=XXX "YYY" Ã  ZZZ on AAA.
 
 ########################################
 # Page: ws/user_mod.php
 #
-Not authorized (not admin).: Pas autorisé (pas admin).
-Invalid characters in login: Caractères invalides dans le login.
+Not authorized (not admin).: Pas autorisÃ© (pas admin).
+Invalid characters in login: CaractÃ¨res invalides dans le login.
 Username XXX does not exist.: L'utilisateur "XXX" n'existe pas.
-You cannot remove admin rights from yourself!: Vous ne pouvez pas enlever les droits administrateurs pour vous même !
+You cannot remove admin rights from yourself!: Vous ne pouvez pas enlever les droits administrateurs pour vous mÃªme !
 Unknown error saving user: Erreur inconnue sur la sauvegarde utilisateur.
 
 ########################################
@@ -1372,18 +1373,18 @@ No login required for HTTP authentication.: =
 ########################################
 # Page: ws/event_mod.php
 #
-Unsupported action XXX.: Action non supportée : XXX.
-No event id specified.: Pas d'id spécifié pour l'événement.
+Unsupported action XXX.: Action non supportÃ©e : XXX.
+No event id specified.: Pas d'id spÃ©cifiÃ© pour l'Ã©vÃ©nement.
 
 ########################################
 # Page: ws/get_reminders.php
 #
 Allowing XXX user to view other users calendar.: Autorise l'utilisateur XXX pour visualiser les calendriers des autres utilisateurs.
-Error Email reminders disabled for user XXX.: Erreur: Rappel par email désactivé pour l'utilisateur "XXX".
+Error Email reminders disabled for user XXX.: Erreur: Rappel par email dÃ©sactivÃ© pour l'utilisateur "XXX".
 Number of site_extras XXX.: =
-Reminder set for event.: Rappel activé pour cet événement.
+Reminder set for event.: Rappel activÃ© pour cet Ã©vÃ©nement.
 Mins Before XXX.: Minutes avant : XXX.
-Event time is XXX.: L'heure de l'événement est : XXX.
+Event time is XXX.: L'heure de l'Ã©vÃ©nement est : XXX.
 Remind time is XXX.: L'heure de rappel est : XXX.
 Reminders for user XXX, login YYY.: Rappels pour l'utilisateur "XXX", login "YYY".
 
@@ -1391,14 +1392,14 @@ Reminders for user XXX, login YYY.: Rappels pour l'utilisateur "XXX", login "YYY
 # Page: ws/get_unapproved.php
 #
 Getting unapproved for user XXX.: =
-Event id=XXX YYY already sent.: Evénement id=XXX "YYY" déjà envoyé.
+Event id=XXX YYY already sent.: EvÃ©nement id=XXX "YYY" dÃ©jÃ  envoyÃ©.
 
 ########################################
 # Page: ws/ws.php
 #
-No participants found for event id XXX.: Pas de participant trouvé pour l'événement Id : XXX.
-Db error Could not find event id XXX.: Db erreur: Ne trouve pas l'événement id XXX.
-Error Could not find event id XXX in database.: Erreur: Impossible de trouver l'id XXX en base de données.
+No participants found for event id XXX.: Pas de participant trouvÃ© pour l'Ã©vÃ©nement Id : XXX.
+Db error Could not find event id XXX.: Db erreur: Ne trouve pas l'Ã©vÃ©nement id XXX.
+Error Could not find event id XXX in database.: Erreur: Impossible de trouver l'id XXX en base de donnÃ©es.
 
 ########################################
 # Page: includes/xcal.php
@@ -1416,33 +1417,33 @@ Month Days: Jours du mois
 Days: Jours
 Weeks: Semaines
 Position: =
-Until: Jusqu'à
+Until: Jusqu'Ã 
 Count: Compter
 Inclusion Dates: Dates de l'inclusion
 Exclusion Dates: Dates de l'exclusion
-Unnamed Event: événement sans nom
-Event Imported: Événement importé
+Unnamed Event: Ã©vÃ©nement sans nom
+Event Imported: Ã‰vÃ©nement importÃ©
 Palm Pilot: =
 
 ########################################
 # Page: includes/date_formats.php
 #
-December: décembre 
-Dec: Déc
-LANGUAGE DEFINED: LANGAGE DÉFINI
+December: dÃ©cembre 
+Dec: DÃ©c
+LANGUAGE DEFINED: LANGAGE DÃ‰FINI
 
 ########################################
 # Page: includes/formvars.php
 #
-Invalid data format for: Format de données invalide pour
+Invalid data format for: Format de donnÃ©es invalide pour
 
 ########################################
 # Page: includes/access.php
 #
 Another Users Calendar: Agenda d'un autre utilisateur
-Category Management: Gestion des catégories
-Day View: Vue journalière
-Edit Event: Editer un événement
+Category Management: Gestion des catÃ©gories
+Day View: Vue journaliÃ¨re
+Edit Event: Editer un Ã©vÃ©nement
 Month View: Vue mensuelle
 Common Trailer: Pied de page standard
 User Management: Gestion des utilisateurs
@@ -1454,14 +1455,14 @@ Invalid function id: Id de fonction invalide
 # Page: includes/dbi4php.php
 #
 Error connecting to database XXX: Erreur de connexion Ã  la base de donnÃ©es XXX
-db_type not defined.: db_type pas défini.
+db_type not defined.: db_type pas dÃ©fini.
 invalid db_type XXX: Type de base de donnÃ©es XXX non valide
-Cache cleared from previous SQL!: Cache effacé par la requête SQL précédente!
-Error executing query.: Erreur durant l'exécution de la requête SQL.
-Unfortunately, XXX is not implemented for YYY: Malheureusement, "XXX" n'est pas implanté pour (YYY).
+Cache cleared from previous SQL!: Cache effacÃ© par la requÃªte SQL prÃ©cÃ©dente!
+Error executing query.: Erreur durant l'exÃ©cution de la requÃªte SQL.
+Unfortunately, XXX is not implemented for YYY: Malheureusement, "XXX" n'est pas implantÃ© pour (YYY).
 Unsupported db_type.: Type de base de donnÃ©es non pris en charge.
 Unknown ODBC error.: Erreur ODBC inconnu.
-Error opening cache dir XXX.: Erreur d'ouverture du répertoire cache "XXX".
+Error opening cache dir XXX.: Erreur d'ouverture du rÃ©pertoire cache "XXX".
 delete: effacer
 Cache error Could not XXX file YYY.: Erreur de cache: Impossible de XXX le fichier "YYY".
 
@@ -1469,78 +1470,78 @@ Cache error Could not XXX file YYY.: Erreur de cache: Impossible de XXX le fichi
 # Page: includes/common_admin_pref.php
 #
 NonUser Calendars: Agendas Non-Utilisateurs
-Themes: Thèmes
+Themes: ThÃ¨mes
 
 ########################################
 # Page: includes/functions.php
 #
-Error Type not set for activity log!: Erreur: Le type n'est pas défini pour le journal d'activité !
-This event is XXX.: Cet événement est  XXX.
+Error Type not set for activity log!: Erreur: Le type n'est pas dÃ©fini pour le journal d'activitÃ© !
+This event is XXX.: Cet Ã©vÃ©nement est  XXX.
 Conf.: =
-exceeds limit of XXX events per day: dépasse la limite de XXX événements par jour
+exceeds limit of XXX events per day: dÃ©passe la limite de XXX Ã©vÃ©nements par jour
 on: sur
 All Attendees: Tous les participants
 Busy: Indisponible
 Tentative: Attente d'approbation
 Schedule an appointment for XXX.: Planifier un rendez-vous pour XXX.
-Event approved: événement approuvé
-Journal approved: Journal approuvé
-Task approved: Tâche approuvée
+Event approved: Ã©vÃ©nement approuvÃ©
+Journal approved: Journal approuvÃ©
+Task approved: TÃ¢che approuvÃ©e
 Attachment: Fichier joint
-Event created: événement créé
-Journal created: Journal créé
-Task created: Tâche créée
-Event deleted: événement supprimé 
-Journal deleted: Journal supprimé
-Task deleted: tâche supprimée
+Event created: Ã©vÃ©nement crÃ©Ã©
+Journal created: Journal crÃ©Ã©
+Task created: TÃ¢che crÃ©Ã©e
+Event deleted: Ã©vÃ©nement supprimÃ© 
+Journal deleted: Journal supprimÃ©
+Task deleted: tÃ¢che supprimÃ©e
 New user via email (self registration): Nouvel utilisateur par email (auto-enregistrement)
 New user (self registration): Nouvel utilisateur (auto-enregistrement)
-Notification sent: Notification envoyée
-Event rejected: événement rejeté
-Journal rejected: Journal rejeté
-Task rejected: Tâche rejetée
-Reminder sent: Rappel envoyé
-System Message: Message systÃ¨me
-Event updated: événement mis à jour
-Journal updated: Journal mis à jour
-Task updated: Tâche mise à jour
+Notification sent: Notification envoyÃ©e
+Event rejected: Ã©vÃ©nement rejetÃ©
+Journal rejected: Journal rejetÃ©
+Task rejected: TÃ¢che rejetÃ©e
+Reminder sent: Rappel envoyÃ©
+System Message: Message systÃªme
+Event updated: Ã©vÃ©nement mis Ã  jour
+Journal updated: Journal mis Ã  jour
+Task updated: TÃ¢che mise Ã  jour
 WK: sem.
 TASKS: TACHES
 Task_Title: Titre
 Due: Fin
-Task Name: Nom de la tâche
-Task Due Date: Date de fin de la tâche
-You have XXX unapproved entries: Vous avez XXX entrées non approuvées
-Changes successfully saved: Modifications sauvegardées avec succès
-Event: Événement
+Task Name: Nom de la tÃ¢che
+Task Due Date: Date de fin de la tÃ¢che
+You have XXX unapproved entries: Vous avez XXX entrÃ©es non approuvÃ©es
+Changes successfully saved: Modifications sauvegardÃ©es avec succÃ¨s
+Event: Ã‰vÃ©nement
 Action: =
 Printer Friendly: Version&nbsp;imprimable
-Generate printer-friendly version: Générer une version imprimable
-after: après
+Generate printer-friendly version: GÃ©nÃ©rer une version imprimable
+after: aprÃ¨s
 before: avant
 end: fin
-start: début
-View this event: Voir cet événement
-View this task: Voir cette tâche
+start: dÃ©but
+View this event: Voir cet Ã©vÃ©nement
+View this task: Voir cette tÃ¢che
 January: janvier 
-February: février 
+February: fÃ©vrier 
 March: mars 
 April: avril 
 May_: mai 
 June: juin 
 July: juillet 
-August: août 
+August: aoÃ»t 
 September: septembre 
 October: octobre 
 November: novembre 
 Jan: =
-Feb: Fév
+Feb: FÃ©v
 Mar: =
 Apr: Avr
 May: Mai
 Jun: =
 Jul: =
-Aug: Aoû
+Aug: AoÃ»
 Sep: =
 Oct: =
 Nov: =
@@ -1549,19 +1550,19 @@ First Quarter Moon: Premier quartier de lune
 Full Moon: Pleine lune
 Last Quarter Moon: Dernier quartier de lune
 New Moon: Nouvelle lune
-Error TIME_SLOTS undefined!: Erreur: TIME_SLOTS indéfinie!
+Error TIME_SLOTS undefined!: Erreur: TIME_SLOTS indÃ©finie!
 The following error occurred: L'erreur suivante est survenue
-You are not authorized.: Vous n'êtes pas autorisé(e)
-Add N hours to: Ajouter N heure(s) à
-Subtract N hours from: Déduire N heure(s) de
-same as: Aucun - identique à
+You are not authorized.: Vous n'Ãªtes pas autorisÃ©(e)
+Add N hours to: Ajouter N heure(s) Ã 
+Subtract N hours from: DÃ©duire N heure(s) de
+same as: Aucun - identique Ã 
 server time: l'heure du serveur
 Cannot read timezone file XXX.: Ne peut lire le fichier de zone de temps: XXX.
-Your current GMT offset is XXX hours.: Votre décalage GMT est de XXX heures.
-Unauthorized: Non autorisé
-Error approving event XXX.: Erreur lors de l'approbation de l'événement : XXX
-Error deleting event XXX.: Erreur à la suppression de l'événement : XXX.
-Error rejecting event XXX.: Erreur lors du rejet de l'événement : XXX.
+Your current GMT offset is XXX hours.: Votre dÃ©calage GMT est de XXX heures.
+Unauthorized: Non autorisÃ©
+Error approving event XXX.: Erreur lors de l'approbation de l'Ã©vÃ©nement : XXX
+Error deleting event XXX.: Erreur Ã  la suppression de l'Ã©vÃ©nement : XXX.
+Error rejecting event XXX.: Erreur lors du rejet de l'Ã©vÃ©nement : XXX.
 Sunday: Dimanche
 Monday: Lundi
 Tuesday: Mardi
@@ -1584,13 +1585,13 @@ The permissions for the icons directory are set to read-only: Les autorisations 
 #
 incorrect password: Mot de passe incorrect
 no such user: Utilisateur inexistant
-Account disabled: Compte désactivé
+Account disabled: Compte dÃ©sactivÃ©
 Invalid user login: Identifiant invalide
 
 ########################################
 # Page: includes/translate.php
 #
-Browser Language Not Found: Langage du navigateur non déterminée
+Browser Language Not Found: Langage du navigateur non dÃ©terminÃ©e
 (not supported): (non pris en charge) =.
 English: Anglais
 English-US: =
@@ -1600,42 +1601,42 @@ Arabic: =
 Basque: =
 Bulgarian: Bulgare
 Catalan: =
-Chinese (Simplified/GB2312): Chinois (Simplifié/GB2312)
+Chinese (Simplified/GB2312): Chinois (SimplifiÃ©/GB2312)
 Chinese (Traditional/Big5): Chinois (Traditionnel/Big5)
 Croatian: Croate
-Czech: Tchèque
+Czech: TchÃ¨que
 Danish: Danois
-Dutch: Néerlandais
+Dutch: NÃ©erlandais
 Elven: =
 Estonian: Estonien
 Finnish: Finnois
-French: Français
+French: FranÃ§ais
 Galician: Galicien
 German: Allemand
 Greek: Grec
 Hebrew: =
-Holo (Taiwanese): Taïwanais
+Holo (Taiwanese): TaÃ¯wanais
 Hungarian: Hongrois
 Icelandic: Islandais
-Indonesian: Indonésien
+Indonesian: IndonÃ©sien
 Italian: Italien
 Japanese: Japonais
-Korean: Coréen
+Korean: CorÃ©en
 Lithuanian: Lithuanien
-Norwegian: Norvégien
+Norwegian: NorvÃ©gien
 Polish: Polonais
 Portuguese: Portuguais
-Portuguese/Brazil: Portuguais/Brézilien
+Portuguese/Brazil: Portuguais/BrÃ©zilien
 Romanian: Roumain
 Russian: Russe
 Serbian: Serbe
 Slovak: Slovaquien
 Slovenian: =
 Spanish: Espagnol
-Swedish: Suédois
+Swedish: SuÃ©dois
 Turkish: Turque
 Welsh: Gallois
-Browser-defined: Définit par fureteur
+Browser-defined: DÃ©finit par fureteur
 journal: =
 0: =
 1: =
@@ -1652,41 +1653,41 @@ journal: =
 # Page: includes/trailer.php
 #
 My Calendar: Mon agenda
-Add New Entry: Ajouter un événement
-Add New Task: Ajouter une nouvelle tâche
-Logout: Déconnexion
+Add New Entry: Ajouter un Ã©vÃ©nement
+Add New Task: Ajouter une nouvelle tÃ¢che
+Logout: DÃ©connexion
 Home: Accueil
-Back to My Calendar: Retour à mon Agenda
-Go to: Aller à
-Manage calendar of: Gérer l'agenda de
+Back to My Calendar: Retour Ã  mon Agenda
+Go to: Aller Ã 
+Manage calendar of: GÃ©rer l'agenda de
 
 ########################################
 # Page: includes/menu.php
 #
 This Week: Semaine en cours
 This Month: Mois en cours
-This Year: Année en cours
-Add New Event: Ajouter un événement
-Delete Entries: Supprimer les entrées
+This Year: AnnÃ©e en cours
+Add New Event: Ajouter un Ã©vÃ©nement
+Delete Entries: Supprimer les entrÃ©es
 My Views: Mes vues
 Unnamed: Sans nom =.
-Manage Calendar of: Gérer le agenda de
+Manage Calendar of: GÃ©rer le agenda de
 My Reports: Mes rapports
-Your Settings: Vos paramÃ¨tres =.
+Your Settings: Vos paramÃªtres =.
 My Profile: Mon profil
-Admin Settings: ParamÃ¨tres d'administrateur =.
-Settings for: ParamÃ¨tres pour
+Admin Settings: ParamÃªtres d'administrateur =.
+Settings for: ParamÃªtres pour
 Public Calendar: Agenda public
-Unapproved Events: Événements en attente
+Unapproved Events: Ã‰vÃ©nements en attente
 Help Contents: Contenu de l'aide
 
 ########################################
 # Page: includes/config.php
 #
-Could not find settings.php file...: Impossible de trouver le fichier "settings.php".<br />S.V.P. copier "settings.php.orig" vers "settings.php" et éditer pour votre site.
+Could not find settings.php file...: Impossible de trouver le fichier "settings.php".<br />S.V.P. copier "settings.php.orig" vers "settings.php" et Ã©diter pour votre site.
 Incomplete settings.php file...: Fichier "settings.php" incomplet.
-Could not find XXX defined in...: Ne peut trouver "XXX" définit dans le fichier "settings.php".
-You must define XXX in: Vous devez définir "XXX" dans le fichier "settings.php".
+Could not find XXX defined in...: Ne peut trouver "XXX" dÃ©finit dans le fichier "settings.php".
+You must define XXX in: Vous devez dÃ©finir "XXX" dans le fichier "settings.php".
 
 ########################################
 # Page: includes/help_list.php
@@ -1698,11 +1699,11 @@ Page: =
 ########################################
 # Page: includes/js/edit_entry.php
 #
-You have not entered a Brief Description: Vous n'avez pas saisi de description résumée
-time prior to work hours...: L'heure que vous avez spécifiée commence avant l'heure de début de vos journées. Est-ce correct ?
-Invalid Event Date: Date de l'événement invalide
+You have not entered a Brief Description: Vous n'avez pas saisi de description rÃ©sumÃ©e
+time prior to work hours...: L'heure que vous avez spÃ©cifiÃ©e commence avant l'heure de dÃ©but de vos journÃ©es. Est-ce correct ?
+Invalid Event Date: Date de l'Ã©vÃ©nement invalide
 Please add a participant: Veuillez ajouter un participant
-You have not entered a valid time of day: Vous n'avez pas saisi une heure appropriée
+You have not entered a valid time of day: Vous n'avez pas saisi une heure appropriÃ©e
 
 ########################################
 # Page: includes/js/import.php
@@ -1719,28 +1720,28 @@ Invalid Color: Couleur invalide
 # Page: includes/js/translate.js.php
 #
 Server URL must end with /.: L'URL du serveur doit se terminer par '/'
-Color format should be RRGGBB.: Le format de couleur devrait être du type '#RRGGBB'
+Color format should be RRGGBB.: Le format de couleur devrait Ãªtre du type '#RRGGBB'
 Invalid color for table cell background.: Couleur de fond de cellule incorrecte
 Invalid color for document background.: Couleur de fond incorrecte
 Invalid color for table grid.: Couleur de quadrillage incorrecte
 Invalid work hours.: Plage horaire invalide
-Invalid color for event popup background.: Couleur de fond de fenêtre d'alerte incorrecte
-Invalid color for event popup text.: Couleur de texte de fenêtre d'alerte incorrecte
-Invalid color for table header text.: Couleur invalide pour le texte de l'entête de la table.
-Invalid color for table header background.: Couleur de fond de cellule d'en-tête de tableau incorrecte
+Invalid color for event popup background.: Couleur de fond de fenÃªtre d'alerte incorrecte
+Invalid color for event popup text.: Couleur de texte de fenÃªtre d'alerte incorrecte
+Invalid color for table header text.: Couleur invalide pour le texte de l'entÃªte de la table.
+Invalid color for table header background.: Couleur de fond de cellule d'en-tÃªte de tableau incorrecte
 Invalid color for document title.: Couleur de titre de document incorrecte
 Invalid color for table cell background for today.: Couleur de fond de cellule du jour courant incorrecte
-Server URL is required.: L'URL du serveur n'est pas spécifiée
-Change the date and time of this entry?: Modifier la date et l'heure de cet événement ?
+Server URL is required.: L'URL du serveur n'est pas spÃ©cifiÃ©e
+Change the date and time of this entry?: Modifier la date et l'heure de cet Ã©vÃ©nement ?
 Invalid Date: Date invalide
-Calendar ID cannot be blank.: L'ID de l'agenda ne doit pas être vide.
-First and last names cannot both be blank.: Prénom et nom ne doivent pas être vides.
+Calendar ID cannot be blank.: L'ID de l'agenda ne doit pas Ãªtre vide.
+First and last names cannot both be blank.: PrÃ©nom et nom ne doivent pas Ãªtre vides.
 Invalid color: Couleur incorrecte
-URL cannot be blank.: L'URL ne doit pas être vide.
-Database Name: nom de la base de données
-Full Path (no backslashes): Répertoire complet (sans antislashes)
-The password contains illegal characters.: Le mot de passe comporte des caractères illégaux.
-Error you must specify a Single-User Login: Erreur : Vous devez spécifier\nSingle-User Login.
+URL cannot be blank.: L'URL ne doit pas Ãªtre vide.
+Database Name: nom de la base de donnÃ©es
+Full Path (no backslashes): RÃ©pertoire complet (sans antislashes)
+The password contains illegal characters.: Le mot de passe comporte des caractÃ¨res illÃ©gaux.
+Error you must specify a Single-User Login: Erreur : Vous devez spÃ©cifier\nSingle-User Login.
 Could not find XXX.: Impossible de trouver XXX.
 Could not find XXX in DOM.: Impossible de trouver XXX dans DOM.
 
@@ -1757,14 +1758,14 @@ Mb: Mo
 Notification: =
 authenticate: SMTP Erreur: Echec de l\'authentification.
 connect_host: SMTP Erreur: Impossible de connecter le serveur SMTP.
-data_not_accepted: SMTP Erreur: Data non acceptée.
+data_not_accepted: SMTP Erreur: Data non acceptÃ©e.
 encoding: Encodage inconnu:
-execute: Ne peut pas lancer l\'exécution:
-file_access: N\'arrive pas à accéder au fichier:
+execute: Ne peut pas lancer l\'exÃ©cution:
+file_access: N\'arrive pas Ã  accÃ©der au fichier:
 file_open: Erreur Fichier: ouverture impossible:
-from_failed: L\'adresse From suivante a échoué:
+from_failed: L\'adresse From suivante a Ã©chouÃ©:
 instantiate: Impossible d\'instancier la fonction mail.
-mailer_not_supported: mailer non supporté.
+mailer_not_supported: mailer non supportÃ©.
 provide_address: Vous devez fournir au moins une adresse de destinataire.
 recipients_failed: SMTP Erreur: Les destinataires suivants sont en erreur:
 
@@ -1781,13 +1782,13 @@ PHP Version: Version de PHP
 GD Module: 'Module GD' 
 Installed: 'InstallÃ©' 
 Not found: 'Introuvable' 
-GD module required for gradient background colors: 'Le module GD est requis pour les couleurs d'arriÃ¨re-plan en dÃ©gradÃ©' 
+GD module required for gradient background colors: 'Le module GD est requis pour les couleurs d'arriÃªre-plan en dÃ©gradÃ©' 
 Allow File Uploads: Autoriser les tÃ©lÃ©chargements de fichiers
 File uploads are required to upload category icons: 'Les tÃ©lÃ©chargements de fichiers sont nÃ©cessaires pour tÃ©lÃ©charger des icÃ´nes de catÃ©gorie' 
-Allow URL fopen: activer URL fopen (Nécessaire si vous utilisez des calendriers distant)
+Allow URL fopen: activer URL fopen (NÃ©cessaire si vous utilisez des calendriers distant)
 Remote URL fopen is required to load remote calendars: 'La fonction Remote URL fopen est requise pour charger des calendriers distants' 
 Safe Mode: =
-Safe Mode needs to be disabled to allow setting env variables to specify the timezone: Le mode sans Ã©chec doit Ãªtre dÃ©sactivÃ© pour permettre le paramÃ©trage des variables d'environnement pour spÃ©cifier le fuseau horaire
+Safe Mode needs to be disabled to allow setting env variables to specify the timezone: Le mode sans Ã©chec doit ÃŠtre dÃ©sactivÃ© pour permettre le paramÃ©trage des variables d'environnement pour spÃ©cifier le fuseau horaire
 Connection not yet configured: Connexion pas encore configurÃ©e
 Your form post was either missing a required session token or timed out.: Votre message de formulaire manquait d'un jeton de session requis ou a expirÃ©.
 Environment variables: Variables d'environnement
@@ -1797,8 +1798,8 @@ Info: =
 # Page: install/install_dbtables.php
 #
 Upgrade Database: Mise Ã  niveau de la base de donnÃ©es
-Your XXX database named 'YYY' is up to date.  You may go on to the next step.: Votre base de donnÃ©es XXX nommÃ©e Â« YYY Â» est Ã  jour. Vous pouvez passer Ã  l'Ã©tape suivante.
-Your XXX database named 'YYY' is empty and needs tables created.: Votre base de donnÃ©es XXX nommÃ©e Â« YYY Â» est vide et doit Ãªtre initialisÃ©e.
+Your XXX database named 'YYY' is up to date.  You may go on to the next step.: Votre base de donnÃ©es XXX nommÃ©e Ã‚Â« YYY Ã‚Â» est Ã  jour. Vous pouvez passer Ã  l'Ã©tape suivante.
+Your XXX database named 'YYY' is empty and needs tables created.: Votre base de donnÃ©es XXX nommÃ©e Ã‚Â« YYY Ã‚Â» est vide et doit ÃŠtre initialisÃ©e.
 Create Database Tables: CrÃ©er des tables de base de donnÃ©es
 Your XXX database named 'YYY' needs upgrading from version ZZZ.: Votre base de donnÃ©es XXX nommÃ©e 'YYY' nÃ©cessite une mise Ã  niveau Ã  partir de la version ZZZ.
 Display SQL: Afficher le SQL
@@ -1810,13 +1811,13 @@ SQL content copied to clipboard: Le contenu SQL copiÃ© dans le presse-papiers
 # Page: install/headless.php
 #
 Unable to determine current database version.: Impossible de dÃ©terminer la version actuelle de la base de donnÃ©es.
-Database successfully migrated from XXX to YYY: Base de donnÃ©es migrÃ©e avec succÃ¨s de XXX Ã  YYY
+Database successfully migrated from XXX to YYY: Base de donnÃ©es migrÃ©e avec succÃªs de XXX Ã  YYY
 
 ########################################
 # Page: install/install_appsettings.php
 #
-When choosing XXX, changes will need to be made to the file auth-settings.php before user authentication will work properly.: 'Lors du choix de XXX, des modifications devront Ãªtre apportÃ©es au fichier auth-settings.php avant que l'authentification des utilisateurs fonctionne correctement.' 
-You are using environment variables for your settings and must make changes externally.: Vous utilisez des variables d'environnement pour vos paramÃ¨tres et devez apporter des modifications Ã  l'extÃ©rieur.
+When choosing XXX, changes will need to be made to the file auth-settings.php before user authentication will work properly.: 'Lors du choix de XXX, des modifications devront ÃŠtre apportÃ©es au fichier auth-settings.php avant que l'authentification des utilisateurs fonctionne correctement.' 
+You are using environment variables for your settings and must make changes externally.: Vous utilisez des variables d'environnement pour vos paramÃªtres et devez apporter des modifications Ã  l'extÃ©rieur.
 You cannot continue until you set the proper environment variables.: Vous ne pouvez pas continuer jusqu'Ã  ce que vous dÃ©finissiez les variables d'environnement appropriÃ©es.
 Specify how users will be prompted for username and password.: SpÃ©cifiez comment les utilisateurs seront invitÃ©s Ã  saisir le nom d'utilisateur et le mot de passe.
 User Authentication: =
@@ -1837,8 +1838,8 @@ Run Environment: Environnement d'exÃ©cution
 ########################################
 # Page: install/install_auth.php
 #
-If your installation is accessible to anyone untrusted, you should secure the installation pages by restricting access. The easiest way to do this is by providing a passphrase.: Si votre installation est accessible Ã  quiconque non fiable, vous devez sÃ©curiser les pages d'installation en restreignant l'accÃ¨s. La maniÃ¨re la plus facile de le faire est dâ€™utiliser une phrase secrÃ¨te.
-Once the installation is complete, you will need not this passphrase again until you want to upgrade your installation. Please take note of your password because there is no way to recover it.: Une fois l'installation terminÃ©e, vous nâ€™aurez plus besoin de cette phrase secrÃ¨te jusquâ€™Ã  ce que vous souhaitiez mettre Ã  niveau votre installation. Veuillez prendre note de votre mot de passe car il nâ€™est pas possible de le rÃ©cupÃ©rer.
+If your installation is accessible to anyone untrusted, you should secure the installation pages by restricting access. The easiest way to do this is by providing a passphrase.: Si votre installation est accessible Ã  quiconque non fiable, vous devez sÃ©curiser les pages d'installation en restreignant l'accÃªs. La maniÃªre la plus facile de le faire est dÃ¢Â€Â™utiliser une phrase secrÃªte.
+Once the installation is complete, you will need not this passphrase again until you want to upgrade your installation. Please take note of your password because there is no way to recover it.: Une fois l'installation terminÃ©e, vous nÃ¢Â€Â™aurez plus besoin de cette phrase secrÃªte jusquÃ¢Â€Â™Ã  ce que vous souhaitiez mettre Ã  niveau votre installation. Veuillez prendre note de votre mot de passe car il nÃ¢Â€Â™est pas possible de le rÃ©cupÃ©rer.
 This password hint will be provided when the you login at a later time.: Cette indication de mot de passe sera fournie lorsque vous vous connecterez Ã  une date ultÃ©rieure.
 Enter a hint to remember your password: Entrez une indication pour vous rappeler votre mot de passe.
 This passphrase was provided during the initial installation.: Cette phrase de passe a Ã©tÃ© fournie lors de l'installation initiale.
@@ -1872,7 +1873,7 @@ Invalid passphrase.: Phrase de passe non valide.
 ########################################
 # Page: install/install_dbsettings.php
 #
-Because environment variables are being used to configure WebCalendar, you cannot alter the settings on this page.  You must do this externally.: Comme des variables d'environnement sont utilisÃ©es pour configurer WebCalendar, vous ne pouvez pas modifier les paramÃ¨tres sur cette page. Vous devez le faire en externe.
+Because environment variables are being used to configure WebCalendar, you cannot alter the settings on this page.  You must do this externally.: Comme des variables d'environnement sont utilisÃ©es pour configurer WebCalendar, vous ne pouvez pas modifier les paramÃªtres sur cette page. Vous devez le faire en externe.
 Database Server: Serveur de base de donnÃ©es 
 Database Login: Identifiant de la base de donnÃ©es 
 Database Password: Mot de passe de la base de donnÃ©es 
@@ -1882,19 +1883,19 @@ Disabled (recommended): DÃ©sactivÃ© (recommandÃ©)
 Test Connection: Tester la connexion
 Save Settings: =
 Successful database connection: Connexion rÃ©ussie Ã  la base de donnÃ©es
-Failed to connect to the database. Please check your settings.: Ã‰chec de connexion Ã  la base de donnÃ©es. Veuillez vÃ©rifier vos paramÃ¨tres.
+Failed to connect to the database. Please check your settings.: Ã‰chec de connexion Ã  la base de donnÃ©es. Veuillez vÃ©rifier vos paramÃªtres.
 SQLite3 File Path: Chemin du fichier SQLite3
 
 ########################################
 # Page: install/install_adminuser_handler.php
 #
-Default admin account created with login "admin" and password "admin".: Compte administrateur par dÃ©faut crÃ©Ã© avec le login Â« admin Â» et le mot de passe Â« admin Â».
+Default admin account created with login "admin" and password "admin".: Compte administrateur par dÃ©faut crÃ©Ã© avec le login Ã‚Â« admin Ã‚Â» et le mot de passe Ã‚Â« admin Ã‚Â».
 
 ########################################
 # Page: install/install_appsettings_handler.php
 #
 Unknown error: Erreur inconnue.
-Invalid Application Settings: ParamÃ¨tres d'application non valides.
+Invalid Application Settings: ParamÃªtres d'application non valides.
 
 ########################################
 # Page: install/install_functions.php
@@ -1906,27 +1907,27 @@ Conversion Successful: =
 # Page: install/install_welcome.php
 #
 Your WebCalendar database is configured and current with the installed version of WebCalendar.: Votre base de donnÃ©es WebCalendar est configurÃ©e et Ã  jour avec la version installÃ©e de WebCalendar.
-You can use these pages to change your settings and to re-add the default admin user.: Vous pouvez utiliser ces pages pour modifier vos paramÃ¨tres et rÃ©-ajouter l'utilisateur administrateur par dÃ©faut.
+You can use these pages to change your settings and to re-add the default admin user.: Vous pouvez utiliser ces pages pour modifier vos paramÃªtres et rÃ©-ajouter l'utilisateur administrateur par dÃ©faut.
 You can re-add the default admin user.: Vous pouvez ajouter de nouveau l'utilisateur administrateur par dÃ©faut.
 This wizard will guide you through the XXX process.: Cet assistant vous guidera Ã  travers le processus XXX.
 
 ########################################
 # Page: install/install_phpsettings.php
 #
-Setting Description: Description ParamÃ¨tre
-Required Setting: ParamÃ¨tre Requis
-Current Setting: ParamÃ¨tre Actuel
+Setting Description: Description ParamÃªtre
+Required Setting: ParamÃªtre Requis
+Current Setting: ParamÃªtre Actuel
 Correct: 'Correct' = Juste 
 Incorrect: 'Incorrect' = Incorrect 
 Detailed PHP Info: 'Detailed PHP Info' = Informations dÃ©taillÃ©es PHP 
 Some WebCalendar function may be limited.  Are you sure?: 'Some WebCalendar function may be limited. Are you sure?' = Certaines fonctionnalitÃ©s de WebCalendar pourraient Ãªtre limitÃ©es. ÃŠtes-vous sÃ»r? 
-Acknowledge: 'Acknowledge' = ReconnaÃ®tre
+Acknowledge: 'Acknowledge' = Acquitter
 PHP Info: Info PHP
 
 ########################################
 # Page: install/install_dbtables_handler.php
 #
-Database tables successfully created: Tableaux de bases de donnÃ©es crÃ©Ã©s avec succÃ¨s
+Database tables successfully created: Tableaux de bases de donnÃ©es crÃ©Ã©s avec succÃªs
 
 ########################################
 # Page: install/install_ajax.php


### PR DESCRIPTION
A lot of characters were incorrectly encoded in the French translations file (for example 'Ã¨' instead of 'ê').