### PR TITLE
Fix function determineServerUrl() when invoked from CLI

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3962,7 +3962,7 @@ function getServerUrl($checkDatabase = true): string
   global $SERVER_URL, $HTTP_HOST, $REQUEST_URI;
   $ret = null;
 
-  if (false&&$checkDatabase) {
+  if ($checkDatabase) {
     $rows = dbi_get_cached_rows('SELECT cal_value FROM webcal_config WHERE cal_setting = ?', ['SERVER_URL']);
     if (!empty($rows) && !empty($rows[0]) && !empty($rows[0][0])) {
       $ret = $rows[0][0];


### PR DESCRIPTION
Having function `determineServerUrl()` working from CLI is needed in `tools/send_reminders.php` for example.