### PR TITLE
Bugfix: sometimes session cookie is invalid

### DIFF
--- a/login.php
+++ b/login.php
@@ -121,8 +121,8 @@ if ($single_user == 'Y' || $use_http_auth) {
     } else if (user_valid_login($login, $password)) {
       user_load_variables($login, '');
 
-      $salt = chr(rand(ord('A'), ord('z')))
-        . chr(rand(ord('A'), ord('z')));
+      $salt = chr(rand(ord('A'), ord('Z')))
+        . chr(rand(ord('A'), ord('Z')));
       $encoded_login = encode_string($login . '|' . crypt($password, $salt));
       // If $remember, set login to expire in 365 days.
       $timeStr = (!empty($remember) && $remember == 'yes'


### PR DESCRIPTION
Sometimes, user has to login twice, because the first time, the generated session cookie was invalid.
That's because the salt used to encode the password sometimes contains chars outside the expected range [0-9A-Za-z].
I chose to restrict to range [A-Z] for simplicity. I hope it's good enough.