### PR TITLE
fix(wizard): prevent "Unexpected end of JSON input" on PHP 8.1+ installs

### DIFF
--- a/wizard/WizardDatabase.php
+++ b/wizard/WizardDatabase.php
@@ -15,6 +15,20 @@ class WizardDatabase
   public function __construct(WizardState $state)
   {
     $this->state = $state;
+
+    // PHP 8.1+ defaults mysqli error reporting to
+    // MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT, which makes failed
+    // mysqli calls THROW mysqli_sql_exception instead of returning false /
+    // setting ->error. The "@" operator does NOT suppress thrown
+    // exceptions, so an uncaught exception during connect/select_db (e.g.
+    // selecting a database that does not exist yet) becomes a fatal error
+    // with an empty response body, surfacing in the wizard UI as
+    // "Unexpected end of JSON input" (see issue #642). This class is
+    // written against the legacy return-false semantics, so disable the
+    // throwing behavior for all mysqli calls it makes.
+    if (function_exists('mysqli_report')) {
+      mysqli_report(MYSQLI_REPORT_OFF);
+    }
   }
 
   public function getError(): ?string

--- a/wizard/index.php
+++ b/wizard/index.php
@@ -471,6 +471,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
   while (ob_get_level()) {
     ob_end_clean();
   }
+
+  // Defense in depth: if a fatal error escapes handleApiRequest(), the
+  // response body would otherwise be empty, surfacing in the UI as the
+  // confusing "Unexpected end of JSON input" (issue #642). Emit a valid
+  // JSON error instead so the user sees the real problem.
+  register_shutdown_function(function () {
+    $err = error_get_last();
+    if ($err && in_array($err['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+      while (ob_get_level()) {
+        ob_end_clean();
+      }
+      if (!headers_sent()) {
+        header('Content-Type: application/json');
+      }
+      echo json_encode([
+        'success' => false,
+        'message' => 'Server error: ' . $err['message'],
+      ]);
+    }
+  });
+
   ob_start();
   handleApiRequest($_POST['action'], $state, $validator);
   $output = ob_get_clean();


### PR DESCRIPTION
## Summary

Fixes #642 — the install wizard fails at the "Test Connection" step (and other DB steps) with **"Test failed: Unexpected end of JSON input"** on PHP 8.1+.

### Root cause
`WizardDatabase` is written against **legacy mysqli semantics**: `@`-suppressed calls that check `->error` / `->connect_error` and `false` returns. PHP 8.1+ defaults mysqli to `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`, which makes those calls **throw `mysqli_sql_exception`** instead. The `@` operator does **not** suppress thrown exceptions, so an uncaught exception (e.g. `select_db()` on a not-yet-created database) becomes a fatal error. With `display_errors` off and the output buffer cleaned, the AJAX response body is **empty**, which the wizard JS (`response.json()`) surfaces as "Unexpected end of JSON input".

The reporter's exact path: connect to `localhost` as root succeeds → `checkDatabase()` calls `select_db('myCalendar')` on a DB that doesn't exist yet → throws → empty body. The second commenter (Docker + add-admin-user) hits the same class via `create-admin-user`, which also calls `testConnection()`/`checkDatabase()` first.

`includes/dbi4php.php` already wraps its own mysqli connect in try/catch — the wizard class was the gap.

## Changes
- **`wizard/WizardDatabase.php`** — disable mysqli exception throwing in the constructor (`mysqli_report(MYSQLI_REPORT_OFF)`, guarded by `function_exists`). One line restores the return-false contract the class assumes across all connect/select_db/query calls at once.
- **`wizard/index.php`** — add a `register_shutdown_function` in the API POST handler that emits a valid JSON `{success:false, message}` if any future fatal escapes, so the user sees the real error instead of an empty body.

## Test plan
Reproduced and verified in a **PHP 8.1.21 + MySQL 8.0** container, exercising the real `WizardDatabase` class on the reporter's exact path (connect OK → `select_db` on a missing database):

| | Pre-fix (PHP 8.1 default reporting) | With fix |
|---|---|---|
| `testConnection()` | `true` | `true` |
| `checkDatabase()` | uncaught `mysqli_sql_exception: Unknown database` → fatal | completes cleanly, detects `databaseExists=false` |
| Response body | empty → "Unexpected end of JSON input" | `{"success":true,...}` → wizard advances to create-DB step |

- [x] `php -l` clean on both files
- [x] Reproduced original failure (simulated default reporting) and confirmed fix in Docker
- [ ] Manual end-to-end: fresh wizard install against a non-existent MySQL database, click "Test Connection"

## Notes (out of scope, flagged separately)
- `docker/docker-compose-php8.1-dev.yml` has a pre-existing broken volume mount (`docker/mysql-init.sql:...` parses as a named volume, breaking `compose up`). Unrelated to this fix.