### PR TITLE
fix(wizard): restore missing createAdminUser() and getUpgradeSqlCommands()

### DIFF
--- a/wizard/WizardDatabase.php
+++ b/wizard/WizardDatabase.php
@@ -405,6 +405,84 @@ class WizardDatabase
   }
 
   /**
+   * Create an administrator account in webcal_user.
+   *
+   * The "create-admin-user" action only calls testConnection() before this,
+   * which (for mysqli) connects without selecting a database, so select the
+   * target database here first. The password is stored with password_hash()
+   * to match the main app (includes/user.php).
+   */
+  public function createAdminUser(string $login, string $password, string $email = ''): bool
+  {
+    if (!$this->connection) {
+      $this->error = 'No database connection';
+      return false;
+    }
+
+    $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+
+    $sql = "INSERT INTO webcal_user "
+      . "(cal_login, cal_passwd, cal_email, cal_firstname, cal_lastname, cal_is_admin) "
+      . "VALUES (?, ?, ?, 'Administrator', 'Default', 'Y')";
+
+    try {
+      if ($this->state->dbType === 'mysqli') {
+        if (!$this->connection->select_db($this->state->dbDatabase)) {
+          $this->error = $this->connection->error;
+          return false;
+        }
+        $stmt = $this->connection->prepare($sql);
+        if (!$stmt) {
+          $this->error = $this->connection->error;
+          return false;
+        }
+        $stmt->bind_param('sss', $login, $hashedPassword, $email);
+        if (!$stmt->execute()) {
+          $this->error = $stmt->error;
+          return false;
+        }
+        return true;
+      } elseif ($this->state->dbType === 'postgresql') {
+        // pg uses $1, $2, $3 placeholders rather than ?
+        $pgSql = "INSERT INTO webcal_user "
+          . "(cal_login, cal_passwd, cal_email, cal_firstname, cal_lastname, cal_is_admin) "
+          . "VALUES ($1, $2, $3, 'Administrator', 'Default', 'Y')";
+        $result = @pg_query_params($this->connection, $pgSql, [$login, $hashedPassword, $email]);
+        if ($result === false) {
+          $this->error = pg_last_error($this->connection);
+          return false;
+        }
+        return true;
+      } elseif ($this->state->dbType === 'sqlite3') {
+        $stmt = $this->connection->prepare($sql);
+        if (!$stmt) {
+          $this->error = 'Failed to prepare admin user insert';
+          return false;
+        }
+        $stmt->bindValue(1, $login);
+        $stmt->bindValue(2, $hashedPassword);
+        $stmt->bindValue(3, $email);
+        return $stmt->execute() !== false;
+      }
+    } catch (\Exception $e) {
+      $this->error = $e->getMessage();
+      return false;
+    }
+
+    $this->error = "Unsupported database type: " . $this->state->dbType;
+    return false;
+  }
+
+  /**
+   * Return the upgrade SQL commands collected for the detected version,
+   * for display in the wizard (the "get-upgrade-sql" action).
+   */
+  public function getUpgradeSqlCommands(): array
+  {
+    return $this->state->upgradeSqlCommands;
+  }
+
+  /**
    * Execute upgrade SQL commands (or base schema for new installs)
    */
   public function executeUpgrade(): bool


### PR DESCRIPTION
## Summary

Follow-up to #651 for issue #642. @sonntam reported that the wizard still 500s on the **admin-user step** after #651, and dug up the real error:

```
PHP Fatal error: Call to undefined method WizardDatabase::createAdminUser() in /var/www/html/wizard/index.php:389
```

### Root cause
Commit 95c4e08 ("clean up wizard installer and fix PHP 8.x compatibility") **removed two methods from `WizardDatabase` but left their callers in place**:

- `createAdminUser()` — called by `index.php` (`create-admin-user` action) and `headless.php`. Reaching the admin-user step (e.g. a fresh env-var/Docker install that needs an admin created) fatals → HTTP 500 with an empty body → the wizard JS again shows "Unexpected end of JSON input".
- `getUpgradeSqlCommands()` — called by `index.php` (`get-upgrade-sql` action) during the upgrade flow; same undefined-method fatal.

Both existed in the original wizard (commit 7e2968d) and were collateral damage in the cleanup.

### Changes
Restore both methods in `wizard/WizardDatabase.php`. `createAdminUser()` is improved over the deleted version:
- **Password**: stores `password_hash($password, PASSWORD_DEFAULT)` to match the main app (`includes/user.php`) instead of the old `md5()`.
- **mysqli database selection**: the `create-admin-user` action only calls `testConnection()` first (which, for mysqli, connects *without* selecting a database), so the method now `select_db()`s the target — otherwise the INSERT fails with "No database selected".
- **Error reporting**: sets a specific `$this->error` per backend instead of silently returning false.

## Test plan
Verified in a **PHP 8.1 + MySQL 8.0** container on @sonntam's exact path (connect, then create admin without an intervening `checkDatabase()`):

- [x] `method_exists(WizardDatabase, 'createAdminUser')` → true (was the fatal)
- [x] `testConnection()` → true, `createAdminUser('admin2', ...)` → true, no fatal
- [x] Row created with `cal_is_admin='Y'`, `cal_enabled='Y'`, email set
- [x] Stored password is a bcrypt `$2y$` hash that `password_verify()` confirms (admin can log in)
- [x] Audit of every `$db->...()` call in `index.php`/`headless.php` — all now resolve to a defined method
- [x] `php -l` clean on `WizardDatabase.php`, `index.php`, `headless.php`

Fixes #642