### PR TITLE
feat(attachments): mobile camera capture for event attachments

### DIFF
--- a/docadd.php
+++ b/docadd.php
@@ -231,6 +231,26 @@ print_header();
 <tr class="browse"><td>
  <label for="fileupload"><?php etranslate ( 'Upload file' );?>:</label></td><td>
  <input type="file" name="FileName" id="fileupload" size="45" maxlength="50">
+ <button type="button" id="takephoto" class="btn btn-secondary btn-sm">&#128247;
+  <?php etranslate ( 'Take photo' );?></button>
+ <script>
+  // Issue #646: let mobile users snap a photo straight into the existing
+  // file input. Tapping "Take photo" prefers the rear camera; on desktop or
+  // unsupported browsers it gracefully opens the standard file picker. The
+  // upload still submits via the same FileName field, so no server change.
+  ( function () {
+    var btn = document.getElementById ( 'takephoto' );
+    var inp = document.getElementById ( 'fileupload' );
+    if ( btn && inp ) {
+      btn.addEventListener ( 'click', function () {
+        inp.setAttribute ( 'accept', 'image/*' );
+        inp.setAttribute ( 'capture', 'environment' );
+        inp.click();
+      } );
+    }
+  } )();
+ </script>
+ </td></tr>
 <tr><td class="aligntop"><label for="description">
   <?php etranslate ( 'Description' )?>:</label></td>
   <td><input type="text" name="description" size="50" maxlength="127"></td></tr>


### PR DESCRIPTION
## Summary

Implements #646. Adds a **"📷 Take photo"** button beside the event attachment file input (`docadd.php`, `type=A`) so mobile users can snap a photo straight into an event attachment.

Tapping the button sets `accept="image/*"` and `capture="environment"` on the **existing** file input and triggers it:
- **Mobile** (iOS Safari, Android Chrome): opens the rear camera directly
- **Desktop / unsupported browsers**: gracefully opens the standard file picker

### Why this approach (A)
The issue floated a *second* file input, but the handler reads a single `$_FILES['FileName']` (`docadd.php:143`) — two inputs sharing that name would let an empty one clobber the filled one (`UPLOAD_ERR_NO_FILE`). Reconfiguring the single existing input avoids that entirely:
- **No server-side change** — uploads still submit via the same `FileName` field
- **No regression** — the default input still accepts any file type until the button is used
- Minimal, dependency-free vanilla JS

Also fixes a pre-existing unterminated `<td>`/`<tr>` on the file-input row.

## Test plan
- [x] `php -l docadd.php` clean
- [x] Inline JS passes `node --check`
- [x] Attachment form markup is tag-balanced (tr/td/button/script)
- [ ] Manual on iOS Safari: tapping "Take photo" opens the camera
- [ ] Manual on Android Chrome: tapping "Take photo" opens the camera
- [ ] Manual on desktop: button opens the file picker; normal upload still works
- [ ] Captured photo attaches to the event like any file

> Note: the mobile camera behavior can't be exercised in CI/headless; needs a device check against the boxes above.

## Acceptance criteria (from #646)
- [x] Mobile control opens camera (via `capture="environment"`) — needs device confirmation
- [x] Desktop control opens the standard file picker
- [x] Uploaded image attaches via the existing flow (unchanged)
- [x] No regression to the existing file upload control

Closes #646