### PR TITLE
fix(security): sanitize rich-text HTML server-side (XSS-3)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,6 +7,12 @@
  * @package WebCalendar
  */
 
+// Server-side rich-text sanitizer (used by the event-popup and day/week views
+// when ALLOW_HTML_DESCRIPTION is enabled). Loaded here so sanitize_html() is
+// available to every page that loads functions.php, including those that do
+// not go through init.php (e.g. upcoming.php).
+require_once __DIR__ . '/htmlsanitize.php';
+
 /* Functions start here. All non-function code should be above this.
  *
  * Note to developers:
@@ -3775,7 +3781,7 @@ function html_for_event_day_at_a_glance ( $event, $date ) {
       <dt>' . translate ( 'Description' ) . ':</dt>
       <dd>'
      . ( ! empty ( $ALLOW_HTML_DESCRIPTION ) && $ALLOW_HTML_DESCRIPTION == 'Y'
-      ? $getDesc : strip_tags ( $getDesc ) ) . '</dd>
+      ? sanitize_html ( $getDesc ) : strip_tags ( $getDesc ) ) . '</dd>
     </dl>' : '' ) . "<br>\n";
 }
 
@@ -6330,7 +6336,7 @@ function build_entry_popup ( $popupid, $user, $description, $time,
       // If there is no HTML found, then go ahead and replace
       // the line breaks ("\n") with the HTML break ("<br>").
       $ret .= ( strstr ( $str, '<' ) && strstr ( $str, '>' )
-        ? $str : nl2br ( $str ) );
+        ? sanitize_html ( $str ) : nl2br ( $str ) );
     } else
       // HTML not allowed in description, escape everything.
       $ret .= nl2br ( htmlspecialchars ( $description ) );

--- a/includes/htmlsanitize.php
+++ b/includes/htmlsanitize.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Dependency-free server-side HTML sanitizer for WebCalendar rich-text fields.
+ *
+ * When ALLOW_HTML_DESCRIPTION is enabled, WebCalendar stores the raw HTML the
+ * TinyMCE editor produces and used to render it verbatim. The client editor
+ * cannot be trusted — a crafted POST bypasses it entirely — so the stored HTML
+ * MUST be sanitized server-side before it is rendered. Without this, a value
+ * such as <img src=x onerror=alert(1)>, <svg onload=...>, or
+ * <a href="javascript:..."> is stored XSS (finding XSS-3).
+ *
+ * Approach: parse the fragment with PHP's built-in DOM extension, walk the
+ * tree keeping only an allow-list of tags and attributes, validate URL schemes
+ * on href/src, and drop everything else. Disallowed *dangerous* elements
+ * (script/iframe/style/svg/...) are removed together with their contents;
+ * other unknown elements are unwrapped so their text survives. This is an
+ * allow-list (default-deny) control, not a block-list.
+ *
+ * @package WebCalendar
+ */
+
+/**
+ * tag => allowed attributes. Any tag not listed is either dangerous (removed
+ * with content, see webcal_sanitize_dangerous_tags) or unwrapped.
+ */
+function webcal_sanitize_allowed_tags() {
+  return [
+    'a'          => ['href', 'title', 'name', 'target'],
+    'abbr'       => ['title'],
+    'b'          => [], 'strong' => [], 'i' => [], 'em' => [], 'u' => [],
+    's'          => [], 'strike' => [], 'del' => [], 'ins' => [], 'mark' => [],
+    'sub'        => [], 'sup' => [], 'small' => [], 'big' => [], 'tt' => [],
+    'p'          => [], 'br' => [], 'hr' => [],
+    'span'       => [], 'div' => [],
+    'blockquote' => ['cite'], 'pre' => [], 'code' => [], 'kbd' => [], 'samp' => [],
+    'ul'         => [], 'ol' => ['start'], 'li' => [], 'dl' => [], 'dt' => [], 'dd' => [],
+    'h1'         => [], 'h2' => [], 'h3' => [], 'h4' => [], 'h5' => [], 'h6' => [],
+    'table'      => [], 'thead' => [], 'tbody' => [], 'tfoot' => [], 'caption' => [],
+    'tr'         => [], 'td' => ['colspan', 'rowspan'],
+    'th'         => ['colspan', 'rowspan', 'scope'],
+    'img'        => ['src', 'alt', 'title', 'width', 'height'],
+    'figure'     => [], 'figcaption' => [],
+  ];
+}
+
+/**
+ * Elements removed together with all their contents. These can execute script
+ * or load active/external content, so their text must NOT be preserved.
+ */
+function webcal_sanitize_dangerous_tags() {
+  return array_flip([
+    'script', 'style', 'iframe', 'object', 'embed', 'applet', 'form', 'input',
+    'button', 'textarea', 'select', 'option', 'optgroup', 'label', 'fieldset',
+    'legend', 'link', 'meta', 'base', 'title', 'head', 'body', 'html', 'frame',
+    'frameset', 'noscript', 'noembed', 'svg', 'math', 'template', 'xml',
+    'marquee', 'audio', 'video', 'source', 'track', 'canvas', 'map', 'area',
+  ]);
+}
+
+/**
+ * Returns true if a URL is safe to keep in an href/src attribute.
+ * Allows relative URLs/anchors and the http(s)/mailto/ftp(s) schemes; blocks
+ * javascript:, data:, vbscript:, etc. Obfuscation via embedded control
+ * characters/whitespace is stripped before the scheme is examined.
+ */
+function webcal_sanitize_url_ok($url) {
+  $url = trim((string) $url);
+  if ($url === '') {
+    return false;
+  }
+  // Relative path, query, or in-page anchor.
+  if ($url[0] === '/' || $url[0] === '#' || $url[0] === '?') {
+    return true;
+  }
+  // Remove control chars / whitespace that can hide a scheme
+  // (e.g. "java\tscript:" or "java\nscript:").
+  $stripped = preg_replace('/[\x00-\x20]+/', '', $url);
+  if (preg_match('/^([a-z][a-z0-9+.\-]*):/i', $stripped, $m)) {
+    return in_array(strtolower($m[1]),
+      ['http', 'https', 'mailto', 'ftp', 'ftps'], true);
+  }
+  // No scheme and not starting with a special char => relative reference.
+  return true;
+}
+
+/**
+ * Sanitize a rich-text HTML fragment, returning safe HTML.
+ *
+ * @param string $html Untrusted HTML (e.g. a stored event description).
+ * @return string Sanitized HTML safe to emit into a page.
+ */
+function sanitize_html($html) {
+  if ($html === null || $html === '') {
+    return '';
+  }
+  // Fail closed if the DOM extension is somehow unavailable.
+  if (!class_exists('DOMDocument')) {
+    return htmlspecialchars((string) $html, ENT_QUOTES);
+  }
+
+  $allowed   = webcal_sanitize_allowed_tags();
+  $dangerous = webcal_sanitize_dangerous_tags();
+
+  $dom  = new DOMDocument('1.0', 'UTF-8');
+  $prev = libxml_use_internal_errors(true);
+  // The XML encoding prolog forces loadHTML to treat the input as UTF-8.
+  // A known wrapper element lets us extract just the sanitized fragment.
+  $wrapped = '<?xml encoding="UTF-8"?><div>' . $html . '</div>';
+  $loaded = $dom->loadHTML($wrapped, LIBXML_NONET);
+  libxml_clear_errors();
+  libxml_use_internal_errors($prev);
+  if (!$loaded) {
+    return htmlspecialchars((string) $html, ENT_QUOTES);
+  }
+
+  // The wrapper is the first <div> in document order (loadHTML nests it under
+  // html > body). Operate on its children.
+  $divs = $dom->getElementsByTagName('div');
+  $root = $divs->length ? $divs->item(0) : null;
+  if (!$root) {
+    return '';
+  }
+
+  webcal_sanitize_walk($root, $allowed, $dangerous);
+
+  $out = '';
+  foreach (iterator_to_array($root->childNodes) as $child) {
+    $out .= $dom->saveHTML($child);
+  }
+  return $out;
+}
+
+/**
+ * Recursively sanitize the children of $node in place.
+ */
+function webcal_sanitize_walk($node, $allowed, $dangerous) {
+  // Snapshot children because we mutate the tree while iterating.
+  foreach (iterator_to_array($node->childNodes) as $child) {
+    if ($child->nodeType === XML_COMMENT_NODE || $child->nodeType === XML_PI_NODE) {
+      // Comments can carry conditional-comment / mXSS tricks.
+      $child->parentNode->removeChild($child);
+      continue;
+    }
+    if ($child->nodeType !== XML_ELEMENT_NODE) {
+      // Text/CDATA nodes are kept; the DOM re-encodes them safely on output.
+      continue;
+    }
+
+    $tag = strtolower($child->nodeName);
+
+    if (isset($dangerous[$tag])) {
+      $child->parentNode->removeChild($child);
+      continue;
+    }
+
+    if (!isset($allowed[$tag])) {
+      // Unknown, non-dangerous tag: sanitize its children, then unwrap it.
+      webcal_sanitize_walk($child, $allowed, $dangerous);
+      webcal_sanitize_unwrap($child);
+      continue;
+    }
+
+    // Allowed tag: drop every attribute not explicitly allowed (this removes
+    // all on* event handlers, style, etc.), and validate URL attributes.
+    $allowedAttrs = $allowed[$tag];
+    if ($child->hasAttributes()) {
+      foreach (iterator_to_array($child->attributes) as $attr) {
+        $aname = strtolower($attr->nodeName);
+        if (!in_array($aname, $allowedAttrs, true)) {
+          $child->removeAttribute($attr->nodeName);
+          continue;
+        }
+        if (($aname === 'href' || $aname === 'src')
+            && !webcal_sanitize_url_ok($attr->nodeValue)) {
+          $child->removeAttribute($attr->nodeName);
+        }
+      }
+    }
+
+    webcal_sanitize_walk($child, $allowed, $dangerous);
+  }
+}
+
+/**
+ * Replace an element with its children (preserving their order), removing the
+ * element itself.
+ */
+function webcal_sanitize_unwrap($element) {
+  $parent = $element->parentNode;
+  if (!$parent) {
+    return;
+  }
+  while ($element->firstChild) {
+    $parent->insertBefore($element->firstChild, $element);
+  }
+  $parent->removeChild($element);
+}

--- a/tests/HtmlSanitizeTest.php
+++ b/tests/HtmlSanitizeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/htmlsanitize.php';
+
+/**
+ * Tests for the dependency-free rich-text HTML sanitizer (XSS-3).
+ *
+ * The sanitizer is an allow-list control: safe formatting must survive, and
+ * every script/handler/dangerous-scheme vector must be neutralized.
+ */
+final class HtmlSanitizeTest extends TestCase
+{
+  /** @dataProvider safeContentPreserved */
+  public function testSafeContentIsPreserved(string $html, string $mustContain): void
+  {
+    self::assertStringContainsString($mustContain, sanitize_html($html));
+  }
+
+  public static function safeContentPreserved(): array
+  {
+    return [
+      'bold'        => ['<b>hi</b>', '<b>hi</b>'],
+      'italic/em'   => ['<i>a</i><em>b</em>', '<em>b</em>'],
+      'paragraph'   => ['<p>text</p>', '<p>text</p>'],
+      'http link'   => ['<a href="http://example.com">x</a>', 'href="http://example.com"'],
+      'https link'  => ['<a href="https://example.com/a?b=c">x</a>', 'href="https://example.com/a?b=c"'],
+      'mailto link' => ['<a href="mailto:a@b.com">m</a>', 'href="mailto:a@b.com"'],
+      'relative'    => ['<a href="/page.php?id=1">r</a>', 'href="/page.php?id=1"'],
+      'anchor'      => ['<a href="#top">t</a>', 'href="#top"'],
+      'list'        => ['<ul><li>one</li></ul>', '<li>one</li>'],
+      'heading'     => ['<h2>Title</h2>', '<h2>Title</h2>'],
+      'table'       => ['<table><tr><td colspan="2">c</td></tr></table>', 'colspan="2"'],
+      'image http'  => ['<img src="https://x/y.png" alt="pic">', 'src="https://x/y.png"'],
+      'utf8'        => ['<p>café — naïve 日本語</p>', '日本語'],
+      'plain text'  => ['just text', 'just text'],
+      'line break'  => ['a<br>b', '<br'],
+    ];
+  }
+
+  /** @dataProvider xssVectors */
+  public function testDangerousContentIsNeutralized(string $html, array $mustNotContain): void
+  {
+    $out = sanitize_html($html);
+    foreach ($mustNotContain as $needle) {
+      self::assertStringNotContainsString($needle, $out, "leaked: $needle  (output: $out)");
+    }
+  }
+
+  public static function xssVectors(): array
+  {
+    return [
+      'script tag'        => ['<script>alert(1)</script>', ['<script', 'alert(1)']],
+      'img onerror'       => ['<img src=x onerror="alert(1)">', ['onerror', 'alert(1)']],
+      'svg onload'        => ['<svg onload="alert(1)"></svg>', ['<svg', 'onload', 'alert(1)']],
+      'body onload'       => ['<body onload=alert(1)>x', ['onload', '<body']],
+      'a javascript'      => ['<a href="javascript:alert(1)">x</a>', ['javascript:', 'alert(1)']],
+      'a JaVaScRiPt'      => ['<a href="JaVaScRiPt:alert(1)">x</a>', ['alert(1)']],
+      'obfuscated scheme' => ["<a href=\"java\tscript:alert(1)\">x</a>", ['alert(1)']],
+      'img data uri'      => ['<img src="data:text/html,<script>alert(1)</script>">', ['data:', '<script']],
+      'iframe'            => ['<iframe src="https://evil"></iframe>', ['<iframe']],
+      'object'            => ['<object data="x"></object>', ['<object']],
+      'embed'             => ['<embed src="x">', ['<embed']],
+      'style attr'        => ['<div style="x:expression(alert(1))">y</div>', ['style', 'expression']],
+      'style tag'         => ['<style>body{}</style>', ['<style', 'body{']],
+      'onclick span'      => ['<span onclick="alert(1)">z</span>', ['onclick', 'alert(1)']],
+      'onmouseover'       => ['<p onmouseover="alert(1)">z</p>', ['onmouseover']],
+      'attr breakout'     => ['<a href="http://x" onmouseover="alert(1)">y</a>', ['onmouseover', 'alert(1)']],
+      'nested script'     => ['<p>ok<script>alert(1)</script></p>', ['<script', 'alert(1)']],
+      'form'              => ['<form action="x"><input></form>', ['<form', '<input']],
+      'html comment'      => ['<!-- <script>alert(1)</script> -->ok', ['<script', 'alert(1)']],
+      'meta refresh'      => ['<meta http-equiv="refresh" content="0;url=javascript:alert(1)">', ['<meta', 'javascript']],
+      'base tag'          => ['<base href="javascript:alert(1)//">', ['<base', 'javascript']],
+    ];
+  }
+
+  public function testUnknownTagIsUnwrappedButTextKept(): void
+  {
+    // marquee is dangerous (removed with content)...
+    self::assertStringNotContainsString('gone', sanitize_html('<marquee>gone</marquee>'));
+    // ...but an unknown, non-dangerous tag keeps its text.
+    $out = sanitize_html('<bogus>keepme</bogus>');
+    self::assertStringContainsString('keepme', $out);
+    self::assertStringNotContainsString('<bogus', $out);
+  }
+
+  public function testScriptContentIsRemovedNotEscaped(): void
+  {
+    // The script body must be GONE, not merely escaped (escaped script text in
+    // a description is harmless but the body should not survive at all).
+    $out = sanitize_html('<script>steal(document.cookie)</script>');
+    self::assertStringNotContainsString('steal(document.cookie)', $out);
+  }
+
+  public function testEmptyAndNull(): void
+  {
+    self::assertSame('', sanitize_html(''));
+    self::assertSame('', sanitize_html(null));
+  }
+
+  public function testNoExecutableAttributesSurviveAnywhere(): void
+  {
+    $out = sanitize_html(
+      '<div><p onclick=x()><a href="javascript:y()" onmouseover=z()>'
+      . '<img src=q onerror=w()></a></p></div>'
+    );
+    foreach (['onclick', 'onmouseover', 'onerror', 'javascript:'] as $bad) {
+      self::assertStringNotContainsString($bad, $out);
+    }
+    // The benign structure should remain.
+    self::assertStringContainsString('<div>', $out);
+    self::assertStringContainsString('<img', $out);
+  }
+}

--- a/view_entry.php
+++ b/view_entry.php
@@ -417,7 +417,7 @@ $str = str_replace ( '&amp;amp;', '&amp;', $str );
 // If there is no HTML found, then go ahead and replace
 // the line breaks ("\n") with the HTML break.
 echo ( strstr ( $str, '<' ) && strstr ( $str, '>' )
-? $str // found some html...
+? sanitize_html ( $str ) // found some html — sanitize it server-side (XSS-3)
 : nl2br ( activate_urls ( $str ) ) );
 } else {
 echo nl2br ( activate_urls ( htmlspecialchars ( $description ) ) );
@@ -894,7 +894,7 @@ $str = str_replace ( '&amp;amp;', '&amp;', $str );
 // If there is no HTML found, then go ahead and replace
 // the line breaks ("\n") with the HTML break.
 $comment_text .= ( strstr ( $str, '<' ) && strstr ( $str, '>' )
-? $str // found some html...
+? sanitize_html ( $str ) // found some html — sanitize it server-side (XSS-3)
 : nl2br ( activate_urls ( $str ) ) );
 } else {
 $comment_text .= nl2br ( activate_urls (


### PR DESCRIPTION
## Summary

Fixes **XSS-3** from the security assessment (the follow-up left open after #654): when `ALLOW_HTML_DESCRIPTION` is enabled, WebCalendar stored the raw HTML produced by the TinyMCE editor and rendered it **verbatim**, trusting the client. A crafted POST bypasses TinyMCE entirely, so an event description or comment containing `<img src=x onerror=...>`, `<svg onload=...>`, `<a href="javascript:...">`, etc. was stored XSS.

This adds a **dependency-free, allow-list HTML sanitizer** and applies it on output at every rich-text render site.

### Why a custom DOM sanitizer (not HTML Purifier)

The project deliberately avoids `vendor/autoload.php` and hand-copies individual dependency files into the tree (e.g. phpmailer → `includes/classes/phpmailer/`); the one library loaded from `vendor/` (MCP SDK) is opt-in. A security control that must *always* be active and ship in every release doesn't fit a heavy bundled library. So `includes/htmlsanitize.php` uses PHP's built-in DOM extension — zero dependencies, always active, ~one reviewable file, no cache directory.

### What the sanitizer does (`sanitize_html()`)

Allow-list / default-deny. It:
- keeps only an allow-list of formatting tags and their attributes;
- **strips every `on*` event handler and the `style` attribute**;
- validates `href`/`src` schemes — only `http`/`https`/`mailto`/`ftp(s)` and relative URLs/anchors are kept; `javascript:`, `data:`, `vbscript:` and control-character-obfuscated schemes (`java\tscript:`) are dropped;
- removes dangerous elements (`script`, `style`, `iframe`, `object`, `embed`, `svg`, `math`, `form`, `meta`, `base`, …) **together with their contents**;
- unwraps unknown non-dangerous tags so their text survives;
- drops comments (mXSS / conditional-comment tricks);
- fails closed (escapes everything) if the DOM extension is unavailable or parsing fails.

### Where it's applied (output-time)

Sanitization is applied at **output**, which protects existing stored data and every render path with the current ruleset, at the four `ALLOW_HTML_DESCRIPTION` sites:
- event **description** body — `view_entry.php`
- **comment** body — `view_entry.php`
- **day-at-a-glance** renderer — `includes/functions.php`
- event **popup** renderer — `includes/functions.php`

Loaded from `functions.php` so `sanitize_html()` is available even to pages that bypass `init.php` (e.g. `upcoming.php`).

## Behavior change

When HTML descriptions are enabled, stored rich text is now sanitized before display. Disallowed markup (scripts, event handlers, dangerous schemes/elements) is removed. The `style` attribute is dropped, so inline colors/alignment in existing rich content are no longer rendered — a deliberate safety trade-off. Re-allowing colors safely would require a CSS-property allow-list on `style` (left as a follow-up).

## Not included (follow-ups)

- **On-save** sanitization (data hygiene for stored rows) — output sanitization already closes the XSS boundary; on-save can be added to also clean the DB.
- A `style` CSS-property allow-list, if colored rich text is desired back.

## Related Issues

Fixes # <!-- link the XSS-3 / security tracking issue if one exists -->

## Checklist

- [x] Tests pass (`vendor/bin/phpunit -c tests/phpunit.xml`) — 558 tests; only the 15 pre-existing, environment-dependent MCP integration failures remain (unchanged by this branch)
- [x] PHP files compile (all changed files `php -l` clean)
- [x] Behavior change documented (see above)
- [ ] Documentation updated (if applicable)

## Test plan

- New `tests/HtmlSanitizeTest.php` (40 cases): safe formatting (bold/links/lists/tables/images/UTF-8) preserved; `script`, `svg`/`onload`, `javascript:`/`data:`/obfuscated schemes, `on*` handlers, `style`, `iframe`/`object`/`embed`/`form`/`meta`/`base`, attribute breakout, comments, and unknown-tag unwrapping all neutralized.
- Manual: with `ALLOW_HTML_DESCRIPTION=Y`, save an event description of `<b>hi</b><img src=x onerror=alert(1)>` and confirm `view_entry.php` (and its popup / day view) renders `<b>hi</b>` with the `onerror` stripped; save a comment with `<a href="javascript:alert(1)">x</a>` and confirm the link is rendered without the dangerous `href`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
