### PR TITLE
Add scheduling MCP tools (availability, conflicts, recurring add/update/delete)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7144,6 +7144,78 @@ function mcp_validate_rrule ( $rrule ) {
 }
 
 /**
+ * Convert a GMT date/time to an absolute minute count, for interval math in
+ * the availability/conflict tools. Uses gmmktime so the value is timezone-
+ * and DST-independent (both sides of a comparison use the same GMT frame).
+ *
+ * @param string|int $date YYYYMMDD
+ * @param string|int $time HHMMSS (unpadded integers like 80000 are accepted)
+ * @return int Whole minutes since the Unix epoch (GMT).
+ */
+function mcp_datetime_to_min ( $date, $time ) {
+  $d = sprintf ( '%08d', (int)$date );
+  $t = sprintf ( '%06d', (int)$time );
+  $ts = gmmktime (
+    (int)substr ( $t, 0, 2 ), (int)substr ( $t, 2, 2 ), (int)substr ( $t, 4, 2 ),
+    (int)substr ( $d, 4, 2 ), (int)substr ( $d, 6, 2 ), (int)substr ( $d, 0, 4 ) );
+  return intdiv ( $ts, 60 );
+}
+
+/**
+ * Whether two half-open intervals [s1,e1) and [s2,e2) overlap. Touching
+ * endpoints (e.g. back-to-back meetings) do NOT count as an overlap.
+ *
+ * @return bool
+ */
+function mcp_intervals_overlap ( $s1, $e1, $s2, $e2 ) {
+  return $s1 < $e2 && $s2 < $e1;
+}
+
+/**
+ * Return the subset of $events that overlaps the proposed [start,end) interval.
+ *
+ * @param int   $start  Proposed start (minutes).
+ * @param int   $end    Proposed end (minutes).
+ * @param array $events Each ['id','name','start','end'] with minute values.
+ * @return array The overlapping events, in input order.
+ */
+function mcp_find_conflicts ( $start, $end, array $events ) {
+  $conflicts = [];
+  foreach ( $events as $e ) {
+    if ( mcp_intervals_overlap ( $start, $end, $e['start'], $e['end'] ) )
+      $conflicts[] = $e;
+  }
+  return $conflicts;
+}
+
+/**
+ * Merge a list of [start,end] intervals into sorted, non-overlapping busy
+ * blocks. Touching intervals are left separate (back-to-back busy blocks).
+ *
+ * @param array $intervals List of [start,end] pairs (minutes).
+ * @return array Sorted, merged list of [start,end] pairs.
+ */
+function mcp_merge_intervals ( array $intervals ) {
+  if ( empty ( $intervals ) )
+    return [];
+  usort ( $intervals, function ( $a, $b ) { return $a[0] <=> $b[0]; } );
+  $merged = [ $intervals[0] ];
+  $count = count ( $intervals );
+  for ( $i = 1; $i < $count; $i++ ) {
+    $last = &$merged[count ( $merged ) - 1];
+    // Merge only on real overlap; equal endpoints stay separate.
+    if ( $intervals[$i][0] < $last[1] ) {
+      if ( $intervals[$i][1] > $last[1] )
+        $last[1] = $intervals[$i][1];
+    } else {
+      $merged[] = $intervals[$i];
+    }
+    unset ( $last );
+  }
+  return $merged;
+}
+
+/**
  * Dispatch a decoded JSON-RPC request to the appropriate MCP method and build
  * the JSON-RPC response array. This is the pure routing core extracted from
  * handleMcpHttpRequest() so it can be exercised without HTTP/STDIO transport.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7009,6 +7009,52 @@ function mcp_list_tools() {
         ],
         'required' => ['name', 'date', 'rrule']
       ]
+    ],
+    [
+      'name' => 'update_event',
+      'description' => 'Update fields of an event the authenticated user '
+        . 'created. Only the fields provided are changed. Date/time are GMT. '
+        . 'Write access must be enabled.',
+      'inputSchema' => [
+        'type' => 'object',
+        'properties' => [
+          'event_id' => [
+            'type' => 'integer',
+            'description' => 'The cal_id of the event to update'
+          ],
+          'name' => ['type' => 'string', 'description' => 'New event name'],
+          'date' => [
+            'type' => 'string',
+            'description' => 'New date in YYYYMMDD format (GMT)'
+          ],
+          'time' => [
+            'type' => 'string',
+            'description' => 'New start time in HHMMSS (GMT), or -1 for untimed'
+          ],
+          'duration' => [
+            'type' => 'integer',
+            'description' => 'New duration in minutes'
+          ],
+          'description' => ['type' => 'string', 'description' => 'New description'],
+          'location' => ['type' => 'string', 'description' => 'New location']
+        ],
+        'required' => ['event_id']
+      ]
+    ],
+    [
+      'name' => 'delete_event',
+      'description' => 'Delete an event the authenticated user created, '
+        . 'including any recurrence rows. Write access must be enabled.',
+      'inputSchema' => [
+        'type' => 'object',
+        'properties' => [
+          'event_id' => [
+            'type' => 'integer',
+            'description' => 'The cal_id of the event to delete'
+          ]
+        ],
+        'required' => ['event_id']
+      ]
     ]
   ];
 }
@@ -7435,6 +7481,20 @@ function mcp_dispatch_request($request, $tools = null) {
               $tool_args['description'] ?? '',
               $tool_args['location'] ?? ''
             );
+            break;
+          case 'update_event':
+            $result = $tools->update_event(
+              $tool_args['event_id'] ?? 0,
+              $tool_args['name'] ?? null,
+              $tool_args['date'] ?? null,
+              $tool_args['time'] ?? null,
+              $tool_args['duration'] ?? null,
+              $tool_args['description'] ?? null,
+              $tool_args['location'] ?? null
+            );
+            break;
+          case 'delete_event':
+            $result = $tools->delete_event($tool_args['event_id'] ?? 0);
             break;
           default:
             throw new Exception("Unknown tool: $tool_name");

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -6920,6 +6920,51 @@ function mcp_list_tools() {
         ],
         'required' => ['name', 'date']
       ]
+    ],
+    [
+      'name' => 'get_availability',
+      'description' => 'List the authenticated user\'s busy time blocks within a '
+        . 'date range, for scheduling. Times are GMT (the storage frame); the '
+        . 'caller converts to local as needed. Recurring-event occurrences '
+        . 'beyond their base date are not yet expanded.',
+      'inputSchema' => [
+        'type' => 'object',
+        'properties' => [
+          'start_date' => [
+            'type' => 'string',
+            'description' => 'Start date in YYYYMMDD format'
+          ],
+          'end_date' => [
+            'type' => 'string',
+            'description' => 'End date in YYYYMMDD format'
+          ]
+        ],
+        'required' => ['start_date', 'end_date']
+      ]
+    ],
+    [
+      'name' => 'check_conflicts',
+      'description' => 'Check whether a proposed time slot overlaps any of the '
+        . 'authenticated user\'s existing timed events. Date/time are GMT.',
+      'inputSchema' => [
+        'type' => 'object',
+        'properties' => [
+          'date' => [
+            'type' => 'string',
+            'description' => 'Proposed date in YYYYMMDD format (GMT)'
+          ],
+          'time' => [
+            'type' => 'string',
+            'description' => 'Proposed start time in HHMMSS format (GMT)'
+          ],
+          'duration' => [
+            'type' => 'integer',
+            'description' => 'Proposed duration in minutes',
+            'default' => 0
+          ]
+        ],
+        'required' => ['date', 'time', 'duration']
+      ]
     ]
   ];
 }
@@ -7270,6 +7315,19 @@ function mcp_dispatch_request($request, $tools = null) {
               $tool_args['date'] ?? '',
               $tool_args['description'] ?? '',
               $tool_args['location'] ?? '',
+              $tool_args['duration'] ?? 0
+            );
+            break;
+          case 'get_availability':
+            $result = $tools->get_availability(
+              $tool_args['start_date'] ?? '',
+              $tool_args['end_date'] ?? ''
+            );
+            break;
+          case 'check_conflicts':
+            $result = $tools->check_conflicts(
+              $tool_args['date'] ?? '',
+              $tool_args['time'] ?? '',
               $tool_args['duration'] ?? 0
             );
             break;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7012,6 +7012,138 @@ function mcp_shift_date ( $date, $days ) {
 }
 
 /**
+ * Validate a client-supplied RRULE against the subset WebCalendar can store
+ * and correctly expand (see the scheduling-agent schema audit,
+ * docs/SCHEMA_AUDIT.md).
+ *
+ * Server-side, defense-in-depth validation for add_recurring_event -- the MCP
+ * server must never trust its client. Pure function (no DB, no globals) so it
+ * is unit-tested directly.
+ *
+ * Supported: FREQ in {DAILY,WEEKLY,MONTHLY,YEARLY}; INTERVAL, COUNT, UNTIL
+ * (COUNT/UNTIL mutually exclusive), BYMONTH, BYMONTHDAY, BYDAY (with numeric
+ * offsets), BYSETPOS, BYWEEKNO, BYYEARDAY, WKST. Rejected: sub-daily FREQ,
+ * BYHOUR/BYMINUTE/BYSECOND (WebCalendar ignores them), the COUNT=999 infinite
+ * sentinel, malformed values, unknown or duplicate parts, and BY* values that
+ * would overflow the webcal_entry_repeats varchar columns.
+ *
+ * @param string $rrule An RRULE string, with or without a leading "RRULE:".
+ * @return array ['valid'=>true,'parts'=>[KEY=>VALUE,...]] (normalized), or
+ *               ['valid'=>false,'error'=>string].
+ */
+function mcp_validate_rrule ( $rrule ) {
+  $fail = function ( $msg ) { return [ 'valid' => false, 'error' => $msg ]; };
+
+  // Strip an optional leading "RRULE:" (case-insensitive) and surrounding space.
+  $s = trim ( preg_replace ( '/^RRULE:/i', '', trim ( (string)$rrule ) ) );
+  if ( $s === '' )
+    return $fail ( 'RRULE is required' );
+
+  // Column width bounds from webcal_entry_repeats (schema audit).
+  $WIDTH = [ 'BYMONTH' => 50, 'BYMONTHDAY' => 100, 'BYDAY' => 100,
+    'BYSETPOS' => 50, 'BYWEEKNO' => 50, 'BYYEARDAY' => 50, 'WKST' => 2 ];
+  $WEEKDAYS = [ 'SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA' ];
+  $KNOWN = [ 'FREQ', 'INTERVAL', 'COUNT', 'UNTIL', 'BYMONTH', 'BYMONTHDAY',
+    'BYDAY', 'BYSETPOS', 'BYWEEKNO', 'BYYEARDAY', 'WKST' ];
+  $UNSUPPORTED = [ 'BYHOUR', 'BYMINUTE', 'BYSECOND' ];
+
+  // Parse KEY=VALUE parts, rejecting malformed/duplicate/unknown ones.
+  $parts = [];
+  foreach ( explode ( ';', $s ) as $token ) {
+    if ( $token === '' )
+      continue;
+    $eq = strpos ( $token, '=' );
+    if ( $eq === false )
+      return $fail ( "Malformed RRULE part: $token" );
+    $key = strtoupper ( trim ( substr ( $token, 0, $eq ) ) );
+    $val = trim ( substr ( $token, $eq + 1 ) );
+    if ( isset ( $parts[$key] ) )
+      return $fail ( "Duplicate RRULE part: $key" );
+    if ( in_array ( $key, $UNSUPPORTED, true ) )
+      return $fail ( "Unsupported RRULE part: $key (WebCalendar cannot expand it)" );
+    if ( ! in_array ( $key, $KNOWN, true ) )
+      return $fail ( "Unknown RRULE part: $key" );
+    $parts[$key] = $val;
+  }
+
+  // FREQ is required and limited to the four WebCalendar can expand.
+  if ( ! isset ( $parts['FREQ'] ) )
+    return $fail ( 'RRULE must include FREQ' );
+  $parts['FREQ'] = strtoupper ( $parts['FREQ'] );
+  if ( ! in_array ( $parts['FREQ'], [ 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY' ], true ) )
+    return $fail ( "Unsupported FREQ: {$parts['FREQ']} (allowed: DAILY, WEEKLY, MONTHLY, YEARLY)" );
+
+  // COUNT and UNTIL are mutually exclusive (RFC 5545).
+  if ( isset ( $parts['COUNT'] ) && isset ( $parts['UNTIL'] ) )
+    return $fail ( 'RRULE may not set both COUNT and UNTIL' );
+
+  // INTERVAL: positive integer.
+  if ( isset ( $parts['INTERVAL'] ) &&
+       ( ! ctype_digit ( $parts['INTERVAL'] ) || (int)$parts['INTERVAL'] < 1 ) )
+    return $fail ( 'INTERVAL must be a positive integer' );
+
+  // COUNT: positive integer, and not the 999 infinite sentinel.
+  if ( isset ( $parts['COUNT'] ) ) {
+    if ( ! ctype_digit ( $parts['COUNT'] ) || (int)$parts['COUNT'] < 1 )
+      return $fail ( 'COUNT must be a positive integer' );
+    if ( (int)$parts['COUNT'] === 999 )
+      return $fail ( 'COUNT=999 is reserved by WebCalendar as the infinite sentinel' );
+  }
+
+  // UNTIL: date (YYYYMMDD) or datetime (YYYYMMDDTHHMMSS[Z]).
+  if ( isset ( $parts['UNTIL'] ) &&
+       ! preg_match ( '/^\d{8}(T\d{6}Z?)?$/', $parts['UNTIL'] ) )
+    return $fail ( 'UNTIL must be YYYYMMDD or YYYYMMDDTHHMMSSZ' );
+
+  // WKST: a weekday abbreviation.
+  if ( isset ( $parts['WKST'] ) ) {
+    $parts['WKST'] = strtoupper ( $parts['WKST'] );
+    if ( ! in_array ( $parts['WKST'], $WEEKDAYS, true ) )
+      return $fail ( 'WKST must be one of SU,MO,TU,WE,TH,FR,SA' );
+  }
+
+  // BYDAY: comma list of [+/-n]WD tokens (offset 1..53 optional).
+  if ( isset ( $parts['BYDAY'] ) ) {
+    $parts['BYDAY'] = strtoupper ( $parts['BYDAY'] );
+    foreach ( explode ( ',', $parts['BYDAY'] ) as $tok ) {
+      if ( ! preg_match (
+        '/^([+-]?([1-9]|[1-4][0-9]|5[0-3]))?(SU|MO|TU|WE|TH|FR|SA)$/', $tok ) )
+        return $fail ( "Invalid BYDAY value: $tok" );
+    }
+  }
+
+  // Integer-list BY* parts with range checks (nonzero; magnitude in [min,max]).
+  foreach ( [
+    [ 'BYMONTH', 1, 12, false ], [ 'BYMONTHDAY', 1, 31, true ],
+    [ 'BYSETPOS', 1, 366, true ], [ 'BYWEEKNO', 1, 53, true ],
+    [ 'BYYEARDAY', 1, 366, true ],
+  ] as [ $name, $min, $max, $allowNeg ] ) {
+    if ( ! isset ( $parts[$name] ) )
+      continue;
+    foreach ( explode ( ',', $parts[$name] ) as $v ) {
+      if ( ! preg_match ( '/^-?\d+$/', $v ) )
+        return $fail ( "Invalid $name value: $v" );
+      $n = (int)$v;
+      if ( $n === 0 )
+        return $fail ( "$name value may not be zero" );
+      if ( ! $allowNeg && $n < 0 )
+        return $fail ( "$name value may not be negative: $v" );
+      $mag = abs ( $n );
+      if ( $mag < $min || $mag > $max )
+        return $fail ( "$name value out of range: $v" );
+    }
+  }
+
+  // Reject values that would overflow the varchar columns.
+  foreach ( $WIDTH as $name => $max ) {
+    if ( isset ( $parts[$name] ) && strlen ( $parts[$name] ) > $max )
+      return $fail ( "$name exceeds the $max-character column limit" );
+  }
+
+  return [ 'valid' => true, 'parts' => $parts ];
+}
+
+/**
  * Dispatch a decoded JSON-RPC request to the appropriate MCP method and build
  * the JSON-RPC response array. This is the pure routing core extracted from
  * handleMcpHttpRequest() so it can be exercised without HTTP/STDIO transport.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -6965,6 +6965,50 @@ function mcp_list_tools() {
         ],
         'required' => ['date', 'time', 'duration']
       ]
+    ],
+    [
+      'name' => 'add_recurring_event',
+      'description' => 'Add a recurring event described by an RFC 5545 RRULE. '
+        . 'The RRULE must use the WebCalendar-supported subset (FREQ '
+        . 'DAILY/WEEKLY/MONTHLY/YEARLY; INTERVAL, COUNT, UNTIL, BYMONTH, '
+        . 'BYMONTHDAY, BYDAY, BYSETPOS, BYWEEKNO, BYYEARDAY, WKST). '
+        . 'Date/time are GMT; write access must be enabled.',
+      'inputSchema' => [
+        'type' => 'object',
+        'properties' => [
+          'name' => [
+            'type' => 'string',
+            'description' => 'Event name'
+          ],
+          'date' => [
+            'type' => 'string',
+            'description' => 'Date of the first occurrence in YYYYMMDD format (GMT)'
+          ],
+          'rrule' => [
+            'type' => 'string',
+            'description' => 'RFC 5545 RRULE, e.g. FREQ=WEEKLY;BYDAY=MO,WE,FR'
+          ],
+          'time' => [
+            'type' => 'string',
+            'description' => 'Start time in HHMMSS format (GMT), or -1 for untimed',
+            'default' => '-1'
+          ],
+          'duration' => [
+            'type' => 'integer',
+            'description' => 'Duration in minutes',
+            'default' => 0
+          ],
+          'description' => [
+            'type' => 'string',
+            'description' => 'Event description'
+          ],
+          'location' => [
+            'type' => 'string',
+            'description' => 'Event location'
+          ]
+        ],
+        'required' => ['name', 'date', 'rrule']
+      ]
     ]
   ];
 }
@@ -7189,6 +7233,56 @@ function mcp_validate_rrule ( $rrule ) {
 }
 
 /**
+ * Map validated RRULE parts to webcal_entry_repeats column values, matching
+ * how xcal.php stores recurrence (see the scheduling-agent schema audit).
+ *
+ * cal_type follows WebCalendar's derivation: DAILY/WEEKLY/YEARLY map directly;
+ * MONTHLY is 'monthlyBySetPos' when BYSETPOS is present, else 'monthlyByDay'.
+ * UNTIL is interpreted in the GMT storage frame (consistent with the other
+ * scheduling tools) -- its date and time-of-day components are stored directly
+ * with no timezone shift. Pure function.
+ *
+ * @param array $parts Normalized parts from mcp_validate_rrule().
+ * @return array Column => value pairs for webcal_entry_repeats (only the
+ *               columns implied by the rule; always cal_type/cal_frequency/
+ *               cal_wkst).
+ */
+function mcp_rrule_to_repeat_columns ( array $parts ) {
+  $cols = [];
+  switch ( $parts['FREQ'] ) {
+    case 'DAILY':  $cols['cal_type'] = 'daily'; break;
+    case 'WEEKLY': $cols['cal_type'] = 'weekly'; break;
+    case 'YEARLY': $cols['cal_type'] = 'yearly'; break;
+    case 'MONTHLY':
+      $cols['cal_type'] = isset ( $parts['BYSETPOS'] )
+        ? 'monthlyBySetPos' : 'monthlyByDay';
+      break;
+  }
+  $cols['cal_frequency'] = isset ( $parts['INTERVAL'] ) ? (int)$parts['INTERVAL'] : 1;
+  $cols['cal_wkst'] = $parts['WKST'] ?? 'MO';
+
+  foreach ( [
+    'BYMONTH' => 'cal_bymonth', 'BYMONTHDAY' => 'cal_bymonthday',
+    'BYDAY' => 'cal_byday', 'BYSETPOS' => 'cal_bysetpos',
+    'BYWEEKNO' => 'cal_byweekno', 'BYYEARDAY' => 'cal_byyearday',
+  ] as $part => $col ) {
+    if ( isset ( $parts[$part] ) )
+      $cols[$col] = $parts[$part];
+  }
+
+  if ( isset ( $parts['COUNT'] ) )
+    $cols['cal_count'] = (int)$parts['COUNT'];
+
+  if ( isset ( $parts['UNTIL'] ) &&
+       preg_match ( '/^(\d{8})(T(\d{6})Z?)?$/', $parts['UNTIL'], $m ) ) {
+    $cols['cal_end'] = (int)$m[1];
+    $cols['cal_endtime'] = isset ( $m[3] ) ? (int)$m[3] : 0;
+  }
+
+  return $cols;
+}
+
+/**
  * Convert a GMT date/time to an absolute minute count, for interval math in
  * the availability/conflict tools. Uses gmmktime so the value is timezone-
  * and DST-independent (both sides of a comparison use the same GMT frame).
@@ -7329,6 +7423,17 @@ function mcp_dispatch_request($request, $tools = null) {
               $tool_args['date'] ?? '',
               $tool_args['time'] ?? '',
               $tool_args['duration'] ?? 0
+            );
+            break;
+          case 'add_recurring_event':
+            $result = $tools->add_recurring_event(
+              $tool_args['name'] ?? '',
+              $tool_args['date'] ?? '',
+              $tool_args['rrule'] ?? '',
+              $tool_args['time'] ?? '-1',
+              $tool_args['duration'] ?? 0,
+              $tool_args['description'] ?? '',
+              $tool_args['location'] ?? ''
             );
             break;
           default:

--- a/mcp.php
+++ b/mcp.php
@@ -735,6 +735,134 @@ class WebCalendarMcpTools
             'cal_type' => $repeat_cols['cal_type']
         ];
     }
+
+    #[McpTool(description: 'Update fields of an event the user created')]
+    public function update_event(
+        int $event_id,
+        ?string $name = null,
+        ?string $date = null,
+        $time = null,
+        $duration = null,
+        ?string $description = null,
+        ?string $location = null
+    ): array {
+        if (!is_mcp_write_enabled()) {
+            return ['error' => 'MCP write access is not enabled'];
+        }
+        if ($event_id <= 0) {
+            return ['error' => 'A valid event_id is required'];
+        }
+
+        $owner = $this->eventOwner($event_id);
+        if ($owner === null) {
+            return ['error' => 'Event not found'];
+        }
+        if ($owner !== $this->userLogin) {
+            return ['error' => 'Not authorized to modify this event'];
+        }
+
+        // Only the provided fields are updated (null means "leave unchanged").
+        $sets = [];
+        $vals = [];
+        if ($name !== null) {
+            $sets[] = 'cal_name = ?';
+            $vals[] = $name;
+        }
+        if ($date !== null) {
+            if (!preg_match('/^\d{8}$/', $date)) {
+                return ['error' => 'Date must be in YYYYMMDD format'];
+            }
+            $sets[] = 'cal_date = ?';
+            $vals[] = $date;
+        }
+        if ($time !== null) {
+            if ((string)$time !== '-1' && !preg_match('/^\d{1,6}$/', (string)$time)) {
+                return ['error' => 'Time must be in HHMMSS format or -1 for untimed'];
+            }
+            $sets[] = 'cal_time = ?';
+            $vals[] = (int)$time;
+        }
+        if ($duration !== null) {
+            $sets[] = 'cal_duration = ?';
+            $vals[] = (int)$duration;
+        }
+        if ($description !== null) {
+            $sets[] = 'cal_description = ?';
+            $vals[] = $description;
+        }
+        if ($location !== null) {
+            $sets[] = 'cal_location = ?';
+            $vals[] = $location;
+        }
+
+        if (empty($sets)) {
+            return ['error' => 'No fields to update'];
+        }
+
+        $sets[] = 'cal_mod_date = ?';
+        $vals[] = date('Ymd');
+        $sets[] = 'cal_mod_time = ?';
+        $vals[] = date('His');
+        $vals[] = $event_id;
+
+        $res = dbi_execute(
+            'UPDATE webcal_entry SET ' . implode(', ', $sets) . ' WHERE cal_id = ?',
+            $vals
+        );
+        if (!$res) {
+            return ['error' => 'Failed to update event'];
+        }
+
+        activity_log($event_id, $this->userLogin, $this->userLogin, 'M', 'MCP: Event updated');
+        return ['success' => true, 'event_id' => $event_id];
+    }
+
+    #[McpTool(description: 'Delete an event the user created')]
+    public function delete_event(int $event_id): array
+    {
+        if (!is_mcp_write_enabled()) {
+            return ['error' => 'MCP write access is not enabled'];
+        }
+        if ($event_id <= 0) {
+            return ['error' => 'A valid event_id is required'];
+        }
+
+        $owner = $this->eventOwner($event_id);
+        if ($owner === null) {
+            return ['error' => 'Event not found'];
+        }
+        if ($owner !== $this->userLogin) {
+            return ['error' => 'Not authorized to delete this event'];
+        }
+
+        // Remove the event and every row that references it, including any
+        // recurrence rule and its exceptions/inclusions.
+        dbi_execute('DELETE FROM webcal_entry WHERE cal_id = ?', [$event_id]);
+        dbi_execute('DELETE FROM webcal_entry_user WHERE cal_id = ?', [$event_id]);
+        dbi_execute('DELETE FROM webcal_entry_repeats WHERE cal_id = ?', [$event_id]);
+        dbi_execute('DELETE FROM webcal_entry_repeats_not WHERE cal_id = ?', [$event_id]);
+
+        activity_log($event_id, $this->userLogin, $this->userLogin, 'M', 'MCP: Event deleted');
+        return ['success' => true, 'event_id' => $event_id];
+    }
+
+    /**
+     * Return the login that created an event (cal_create_by), or null if the
+     * event does not exist. Used for the update/delete ownership check.
+     */
+    private function eventOwner(int $event_id): ?string
+    {
+        $res = dbi_execute(
+            'SELECT cal_create_by FROM webcal_entry WHERE cal_id = ?',
+            [$event_id]
+        );
+        if (!$res) {
+            return null;
+        }
+        $row = dbi_fetch_row($res);
+        dbi_free_result($res);
+        return $row ? $row[0] : null;
+    }
 }
 
 // Handle transport based on execution context

--- a/mcp.php
+++ b/mcp.php
@@ -543,6 +543,100 @@ class WebCalendarMcpTools
 
         return ['success' => true, 'event_id' => $event_id];
     }
+
+    #[McpTool(description: 'List the user\'s busy time blocks in a date range (GMT)')]
+    public function get_availability(string $start_date, string $end_date): array
+    {
+        if (!preg_match('/^\d{8}$/', $start_date) || !preg_match('/^\d{8}$/', $end_date)) {
+            return ['error' => 'Dates must be in YYYYMMDD format'];
+        }
+
+        $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
+                FROM webcal_entry e
+                INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
+                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ?
+                ORDER BY e.cal_date, e.cal_time";
+
+        $busy = [];
+        $all_day = [];
+        $res = dbi_execute($sql, [$this->userLogin, $start_date, $end_date]);
+        if ($res) {
+            while ($row = dbi_fetch_row($res)) {
+                // Untimed/all-day events block the whole day; report separately.
+                if ((int)$row[3] === -1) {
+                    $all_day[] = ['id' => $row[0], 'name' => $row[1], 'date' => $row[2]];
+                    continue;
+                }
+                $busy[] = [
+                    'id' => $row[0],
+                    'name' => $row[1],
+                    'date' => $row[2],
+                    'time' => $row[3],
+                    'duration' => (int)$row[4]
+                ];
+            }
+            dbi_free_result($res);
+        }
+
+        // Times are GMT (storage frame); recurring occurrences beyond the base
+        // date are not yet expanded (documented limitation).
+        return ['busy' => $busy, 'all_day' => $all_day, 'timezone' => 'GMT'];
+    }
+
+    #[McpTool(description: 'Check whether a proposed slot overlaps existing timed events (GMT)')]
+    public function check_conflicts(string $date, string $time, int $duration): array
+    {
+        if (!preg_match('/^\d{8}$/', $date)) {
+            return ['error' => 'Date must be in YYYYMMDD format'];
+        }
+        if (!preg_match('/^\d{1,6}$/', (string)$time)) {
+            return ['error' => 'Time must be in HHMMSS format'];
+        }
+
+        $start_min = mcp_datetime_to_min($date, $time);
+        $end_min = $start_min + max(0, (int)$duration);
+
+        // Widen by a day on each side so events that span midnight are seen.
+        $prev = mcp_shift_date($date, -1);
+        $next = mcp_shift_date($date, 1);
+
+        $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
+                FROM webcal_entry e
+                INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
+                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ? AND e.cal_time != -1
+                ORDER BY e.cal_date, e.cal_time";
+
+        $events = [];
+        $res = dbi_execute($sql, [$this->userLogin, $prev, $next]);
+        if ($res) {
+            while ($row = dbi_fetch_row($res)) {
+                $s = mcp_datetime_to_min($row[2], $row[3]);
+                $events[] = [
+                    'id' => $row[0],
+                    'name' => $row[1],
+                    'date' => $row[2],
+                    'time' => $row[3],
+                    'duration' => (int)$row[4],
+                    'start' => $s,
+                    'end' => $s + max(0, (int)$row[4])
+                ];
+            }
+            dbi_free_result($res);
+        }
+
+        $conflicts = array_map(
+            fn($c) => [
+                'id' => $c['id'],
+                'name' => $c['name'],
+                'date' => $c['date'],
+                'time' => $c['time'],
+                'duration' => $c['duration']
+            ],
+            mcp_find_conflicts($start_min, $end_min, $events)
+        );
+
+        return ['has_conflict' => !empty($conflicts), 'conflicts' => $conflicts];
+    }
 }
 
 // Handle transport based on execution context

--- a/mcp.php
+++ b/mcp.php
@@ -637,6 +637,104 @@ class WebCalendarMcpTools
 
         return ['has_conflict' => !empty($conflicts), 'conflicts' => $conflicts];
     }
+
+    #[McpTool(description: 'Add a recurring event described by an RFC 5545 RRULE')]
+    public function add_recurring_event(
+        string $name,
+        string $date,
+        string $rrule,
+        string $time = '-1',
+        int $duration = 0,
+        string $description = '',
+        string $location = ''
+    ): array {
+        if (!is_mcp_write_enabled()) {
+            return ['error' => 'MCP write access is not enabled'];
+        }
+        if (empty($name)) {
+            return ['error' => 'Event name is required'];
+        }
+        if (!preg_match('/^\d{8}$/', $date)) {
+            return ['error' => 'Date must be in YYYYMMDD format'];
+        }
+
+        // Time: -1 (untimed) or HHMMSS in the GMT frame.
+        $cal_time = -1;
+        if ((string)$time !== '' && (string)$time !== '-1') {
+            if (!preg_match('/^\d{1,6}$/', (string)$time)) {
+                return ['error' => 'Time must be in HHMMSS format or -1 for untimed'];
+            }
+            $cal_time = (int)$time;
+        }
+
+        // Validate the RRULE against the WebCalendar-supported subset and map
+        // it to webcal_entry_repeats columns (defense in depth: never trust
+        // the client, even though the agent validates too).
+        $validated = mcp_validate_rrule($rrule);
+        if (!$validated['valid']) {
+            return ['error' => 'Invalid RRULE: ' . $validated['error']];
+        }
+        $repeat_cols = mcp_rrule_to_repeat_columns($validated['parts']);
+
+        // Insert the base event, assigning cal_id as MAX(cal_id)+1 with a
+        // retry-on-collision loop (same pattern/rationale as add_event).
+        $now = date('Ymd');
+        $mod_time = date('His');
+        $sql = "INSERT INTO webcal_entry (cal_id, cal_name, cal_date, cal_time, cal_duration, cal_description, cal_location, cal_create_by, cal_mod_date, cal_mod_time)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        $event_id = null;
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $res = dbi_execute('SELECT MAX(cal_id) FROM webcal_entry');
+            if (!$res) {
+                return ['error' => 'Failed to create event'];
+            }
+            $row = dbi_fetch_row($res);
+            $candidate_id = ($row[0] ?? 0) + 1;
+            dbi_free_result($res);
+
+            $res = dbi_execute(
+                $sql,
+                [$candidate_id, $name, $date, $cal_time, $duration, $description, $location, $this->userLogin, $now, $mod_time],
+                false,
+                false
+            );
+            if ($res) {
+                $event_id = $candidate_id;
+                break;
+            }
+        }
+        if ($event_id === null) {
+            return ['error' => 'Failed to create event'];
+        }
+
+        // Participation row.
+        dbi_execute(
+            "INSERT INTO webcal_entry_user (cal_id, cal_login, cal_status) VALUES (?, ?, 'A')",
+            [$event_id, $this->userLogin]
+        );
+
+        // Insert the recurrence row. If it fails, roll back the base event so
+        // we never leave an orphan non-repeating entry behind.
+        $repeat_cols = array_merge(['cal_id' => $event_id], $repeat_cols);
+        $cols = array_keys($repeat_cols);
+        $placeholders = implode(', ', array_fill(0, count($cols), '?'));
+        $rsql = 'INSERT INTO webcal_entry_repeats (' . implode(', ', $cols)
+            . ') VALUES (' . $placeholders . ')';
+        $rres = dbi_execute($rsql, array_values($repeat_cols));
+        if (!$rres) {
+            dbi_execute('DELETE FROM webcal_entry_user WHERE cal_id = ?', [$event_id]);
+            dbi_execute('DELETE FROM webcal_entry WHERE cal_id = ?', [$event_id]);
+            return ['error' => 'Failed to store recurrence rule'];
+        }
+
+        activity_log($event_id, $this->userLogin, $this->userLogin, 'M', 'MCP: Recurring event created');
+
+        return [
+            'success' => true,
+            'event_id' => $event_id,
+            'cal_type' => $repeat_cols['cal_type']
+        ];
+    }
 }
 
 // Handle transport based on execution context

--- a/tests/McpIntegrationTest.php
+++ b/tests/McpIntegrationTest.php
@@ -331,13 +331,18 @@ final class McpIntegrationTest extends TestCase
         $this->assertMcpSuccess($response);
         
         $tools = $response['result']['tools'];
-        $this->assertCount(4, $tools, "Should have 4 tools");
-        
+        $this->assertCount(9, $tools, "Should have 9 tools");
+
         $tool_names = array_column($tools, 'name');
         $this->assertContains('list_events', $tool_names);
         $this->assertContains('get_user_info', $tool_names);
         $this->assertContains('search_events', $tool_names);
         $this->assertContains('add_event', $tool_names);
+        $this->assertContains('get_availability', $tool_names);
+        $this->assertContains('check_conflicts', $tool_names);
+        $this->assertContains('add_recurring_event', $tool_names);
+        $this->assertContains('update_event', $tool_names);
+        $this->assertContains('delete_event', $tool_names);
     }
 
     // ---------------------------------------------------------------

--- a/tests/McpRepeatColumnsTest.php
+++ b/tests/McpRepeatColumnsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Unit tests for mcp_rrule_to_repeat_columns(): maps validated RRULE parts to
+ * webcal_entry_repeats column values, matching how xcal.php stores them
+ * (see docs/SCHEMA_AUDIT.md in scheduling-agent). Pure function.
+ *
+ * Input is the normalized parts array from mcp_validate_rrule().
+ */
+final class McpRepeatColumnsTest extends TestCase
+{
+  private function cols($rrule) {
+    $v = mcp_validate_rrule($rrule);
+    $this->assertTrue($v['valid'], $v['error'] ?? '');
+    return mcp_rrule_to_repeat_columns($v['parts']);
+  }
+
+  public function test_weekly_with_interval_and_byday() {
+    $c = $this->cols('FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE');
+    $this->assertSame('weekly', $c['cal_type']);
+    $this->assertSame(2, $c['cal_frequency']);
+    $this->assertSame('MO,WE', $c['cal_byday']);
+    $this->assertSame('MO', $c['cal_wkst']);
+    $this->assertArrayNotHasKey('cal_count', $c);
+    $this->assertArrayNotHasKey('cal_end', $c);
+  }
+
+  public function test_daily_defaults_frequency_to_one() {
+    $c = $this->cols('FREQ=DAILY');
+    $this->assertSame('daily', $c['cal_type']);
+    $this->assertSame(1, $c['cal_frequency']);
+  }
+
+  public function test_monthly_by_monthday_is_monthlyByDay() {
+    // Matches WebCalendar: MONTHLY defaults to monthlyByDay even with BYMONTHDAY.
+    $c = $this->cols('FREQ=MONTHLY;BYMONTHDAY=1,15');
+    $this->assertSame('monthlyByDay', $c['cal_type']);
+    $this->assertSame('1,15', $c['cal_bymonthday']);
+  }
+
+  public function test_monthly_with_bysetpos_is_monthlyBySetPos() {
+    $c = $this->cols('FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1');
+    $this->assertSame('monthlyBySetPos', $c['cal_type']);
+    $this->assertSame('1', $c['cal_bysetpos']);
+    $this->assertSame('MO', $c['cal_byday']);
+  }
+
+  public function test_yearly_with_bymonth() {
+    $c = $this->cols('FREQ=YEARLY;BYMONTH=6');
+    $this->assertSame('yearly', $c['cal_type']);
+    $this->assertSame('6', $c['cal_bymonth']);
+  }
+
+  public function test_count_maps_to_cal_count() {
+    $c = $this->cols('FREQ=DAILY;COUNT=10');
+    $this->assertSame(10, $c['cal_count']);
+    $this->assertArrayNotHasKey('cal_end', $c);
+  }
+
+  public function test_until_date_only_sets_end_and_zero_endtime() {
+    $c = $this->cols('FREQ=DAILY;UNTIL=20301231');
+    $this->assertSame(20301231, $c['cal_end']);
+    $this->assertSame(0, $c['cal_endtime']);
+    $this->assertArrayNotHasKey('cal_count', $c);
+  }
+
+  public function test_until_datetime_sets_end_and_endtime() {
+    $c = $this->cols('FREQ=DAILY;UNTIL=20301231T120000Z');
+    $this->assertSame(20301231, $c['cal_end']);
+    $this->assertSame(120000, $c['cal_endtime']);
+  }
+
+  public function test_wkst_is_carried_through() {
+    $c = $this->cols('FREQ=WEEKLY;BYDAY=MO;WKST=SU');
+    $this->assertSame('SU', $c['cal_wkst']);
+  }
+}

--- a/tests/McpRruleValidationTest.php
+++ b/tests/McpRruleValidationTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Unit tests for mcp_validate_rrule(): server-side, defense-in-depth
+ * validation that a client-supplied RRULE conforms to the subset WebCalendar
+ * can store and correctly expand.
+ *
+ * The supported subset and its caveats are fixed by the scheduling-agent
+ * schema audit (docs/SCHEMA_AUDIT.md), derived from webcal_entry_repeats and
+ * the xcal.php builder/parser:
+ *   - FREQ in {DAILY, WEEKLY, MONTHLY, YEARLY} -- no sub-daily.
+ *   - Parts: INTERVAL, COUNT, UNTIL (COUNT/UNTIL mutually exclusive),
+ *     BYMONTH, BYMONTHDAY, BYDAY (+offsets), BYSETPOS, BYWEEKNO, BYYEARDAY, WKST.
+ *   - Rejected: BYHOUR/BYMINUTE/BYSECOND (WebCalendar ignores them),
+ *     the COUNT=999 "infinite" sentinel, and BY* values that would overflow
+ *     the varchar columns.
+ *
+ * mcp_validate_rrule($rrule) returns:
+ *   ['valid' => true,  'parts' => [KEY => VALUE, ...]]   (normalized, uppercased)
+ *   ['valid' => false, 'error' => 'human-readable reason']
+ */
+final class McpRruleValidationTest extends TestCase
+{
+  private function assertValid($rrule) {
+    $r = mcp_validate_rrule($rrule);
+    $this->assertTrue($r['valid'], 'expected valid, got: ' . ($r['error'] ?? ''));
+    return $r;
+  }
+
+  private function assertInvalid($rrule, $needle = null) {
+    $r = mcp_validate_rrule($rrule);
+    $this->assertFalse($r['valid'], "expected invalid for: $rrule");
+    if ($needle !== null) {
+      $this->assertStringContainsStringIgnoringCase($needle, $r['error']);
+    }
+    return $r;
+  }
+
+  // --- happy paths --------------------------------------------------------
+
+  public function test_simple_weekly_byday_is_valid() {
+    $r = $this->assertValid('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+    $this->assertEquals('WEEKLY', $r['parts']['FREQ']);
+    $this->assertEquals('MO,WE,FR', $r['parts']['BYDAY']);
+  }
+
+  public function test_rrule_prefix_and_lowercase_are_normalized() {
+    $r = $this->assertValid('rrule:freq=daily;interval=2');
+    $this->assertEquals('DAILY', $r['parts']['FREQ']);
+    $this->assertEquals('2', $r['parts']['INTERVAL']);
+    $this->assertArrayNotHasKey('RRULE', $r['parts']);
+  }
+
+  public function test_monthly_by_setpos_is_valid() {
+    $this->assertValid('FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1');
+  }
+
+  public function test_monthly_by_monthday_with_negative_is_valid() {
+    $this->assertValid('FREQ=MONTHLY;BYMONTHDAY=1,15,-1');
+  }
+
+  public function test_byday_with_offsets_is_valid() {
+    $this->assertValid('FREQ=MONTHLY;BYDAY=2MO,-1FR');
+  }
+
+  public function test_yearly_with_until_is_valid() {
+    $this->assertValid('FREQ=YEARLY;BYMONTH=6;UNTIL=20301231T000000Z');
+  }
+
+  public function test_wkst_sunday_is_valid() {
+    $this->assertValid('FREQ=WEEKLY;BYDAY=MO;WKST=SU');
+  }
+
+  // --- FREQ rules ---------------------------------------------------------
+
+  public function test_missing_freq_is_invalid() {
+    $this->assertInvalid('BYDAY=MO,WE', 'FREQ');
+  }
+
+  public function test_subdaily_freq_is_invalid() {
+    $this->assertInvalid('FREQ=HOURLY', 'HOURLY');
+    $this->assertInvalid('FREQ=MINUTELY');
+    $this->assertInvalid('FREQ=SECONDLY');
+  }
+
+  public function test_unknown_freq_is_invalid() {
+    $this->assertInvalid('FREQ=FORTNIGHTLY', 'FREQ');
+  }
+
+  public function test_empty_rrule_is_invalid() {
+    $this->assertInvalid('', 'required');
+    $this->assertInvalid('   ');
+  }
+
+  // --- unsupported / conflicting parts ------------------------------------
+
+  public function test_byhour_byminute_bysecond_are_rejected() {
+    $this->assertInvalid('FREQ=DAILY;BYHOUR=9', 'BYHOUR');
+    $this->assertInvalid('FREQ=DAILY;BYMINUTE=30', 'BYMINUTE');
+    $this->assertInvalid('FREQ=DAILY;BYSECOND=0', 'BYSECOND');
+  }
+
+  public function test_count_and_until_are_mutually_exclusive() {
+    $this->assertInvalid('FREQ=DAILY;COUNT=5;UNTIL=20301231T000000Z', 'COUNT');
+  }
+
+  public function test_count_999_sentinel_is_rejected() {
+    // 999 is WebCalendar's "infinite" sentinel; a literal COUNT=999 would
+    // collide with it, so the agent must never emit it.
+    $this->assertInvalid('FREQ=DAILY;COUNT=999', '999');
+  }
+
+  public function test_unknown_rule_part_is_rejected() {
+    $this->assertInvalid('FREQ=DAILY;FOO=BAR', 'FOO');
+  }
+
+  public function test_duplicate_part_is_rejected() {
+    $this->assertInvalid('FREQ=DAILY;FREQ=WEEKLY', 'duplicate');
+  }
+
+  // --- numeric part validation --------------------------------------------
+
+  public function test_non_positive_interval_is_invalid() {
+    $this->assertInvalid('FREQ=DAILY;INTERVAL=0', 'INTERVAL');
+    $this->assertInvalid('FREQ=DAILY;INTERVAL=-1');
+    $this->assertInvalid('FREQ=DAILY;INTERVAL=abc');
+  }
+
+  public function test_non_positive_count_is_invalid() {
+    $this->assertInvalid('FREQ=DAILY;COUNT=0', 'COUNT');
+    $this->assertInvalid('FREQ=DAILY;COUNT=-3');
+  }
+
+  public function test_bymonth_out_of_range_is_invalid() {
+    $this->assertInvalid('FREQ=YEARLY;BYMONTH=13', 'BYMONTH');
+    $this->assertInvalid('FREQ=YEARLY;BYMONTH=0');
+  }
+
+  public function test_bymonthday_zero_is_invalid() {
+    $this->assertInvalid('FREQ=MONTHLY;BYMONTHDAY=0', 'BYMONTHDAY');
+    $this->assertInvalid('FREQ=MONTHLY;BYMONTHDAY=32');
+  }
+
+  public function test_bysetpos_zero_is_invalid() {
+    $this->assertInvalid('FREQ=MONTHLY;BYDAY=MO;BYSETPOS=0', 'BYSETPOS');
+  }
+
+  public function test_invalid_byday_token_is_invalid() {
+    $this->assertInvalid('FREQ=WEEKLY;BYDAY=XY', 'BYDAY');
+  }
+
+  public function test_invalid_wkst_is_invalid() {
+    $this->assertInvalid('FREQ=WEEKLY;BYDAY=MO;WKST=XX', 'WKST');
+  }
+
+  public function test_invalid_until_format_is_invalid() {
+    $this->assertInvalid('FREQ=DAILY;UNTIL=next-year', 'UNTIL');
+  }
+
+  // --- column width bounds (from the schema audit) ------------------------
+
+  public function test_byday_overflowing_column_width_is_invalid() {
+    // cal_byday is VARCHAR(100); a list longer than that must be rejected,
+    // not silently truncated.
+    $long = 'FREQ=WEEKLY;BYDAY=' . implode(',', array_fill(0, 40, 'MO'));
+    $this->assertInvalid($long, 'BYDAY');
+  }
+}

--- a/tests/McpSchedulingHelpersTest.php
+++ b/tests/McpSchedulingHelpersTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Unit tests for the pure interval/conflict/merge helpers underpinning the
+ * get_availability and check_conflicts MCP tools. These have no DB or global
+ * state, so they are tested directly.
+ */
+final class McpSchedulingHelpersTest extends TestCase
+{
+  // --- mcp_datetime_to_min ------------------------------------------------
+
+  public function test_same_day_times_differ_by_minutes() {
+    $a = mcp_datetime_to_min('20260611', '090000');
+    $b = mcp_datetime_to_min('20260611', '103000');
+    $this->assertSame(90, $b - $a); // 1h30m
+  }
+
+  public function test_day_rollover_is_1440_minutes() {
+    $a = mcp_datetime_to_min('20260101', '000000');
+    $b = mcp_datetime_to_min('20260102', '000000');
+    $this->assertSame(1440, $b - $a);
+  }
+
+  public function test_unpadded_time_is_normalized() {
+    // 80000 -> 08:00:00
+    $a = mcp_datetime_to_min('20260611', 80000);
+    $b = mcp_datetime_to_min('20260611', '080000');
+    $this->assertSame($a, $b);
+  }
+
+  // --- mcp_intervals_overlap (half-open [start,end)) ----------------------
+
+  public function test_overlapping_intervals_return_true() {
+    $this->assertTrue(mcp_intervals_overlap(100, 200, 150, 250));
+  }
+
+  public function test_touching_intervals_do_not_overlap() {
+    // [100,200) and [200,300) share only the boundary -> no conflict.
+    $this->assertFalse(mcp_intervals_overlap(100, 200, 200, 300));
+  }
+
+  public function test_contained_interval_overlaps() {
+    $this->assertTrue(mcp_intervals_overlap(100, 300, 150, 200));
+  }
+
+  public function test_disjoint_intervals_do_not_overlap() {
+    $this->assertFalse(mcp_intervals_overlap(100, 150, 200, 250));
+  }
+
+  // --- mcp_find_conflicts -------------------------------------------------
+
+  public function test_find_conflicts_returns_only_overlapping_events() {
+    $events = [
+      ['id' => 1, 'name' => 'before', 'start' => 0,   'end' => 60],
+      ['id' => 2, 'name' => 'overlap', 'start' => 90,  'end' => 150],
+      ['id' => 3, 'name' => 'after',  'start' => 300, 'end' => 360],
+    ];
+    $conflicts = mcp_find_conflicts(100, 130, $events);
+    $this->assertCount(1, $conflicts);
+    $this->assertSame(2, $conflicts[0]['id']);
+  }
+
+  public function test_find_conflicts_empty_when_none_overlap() {
+    $events = [['id' => 1, 'name' => 'x', 'start' => 0, 'end' => 60]];
+    $this->assertSame([], mcp_find_conflicts(100, 130, $events));
+  }
+
+  // --- mcp_merge_intervals ------------------------------------------------
+
+  public function test_merge_combines_overlapping_intervals() {
+    $merged = mcp_merge_intervals([[100, 200], [150, 250], [400, 500]]);
+    $this->assertSame([[100, 250], [400, 500]], $merged);
+  }
+
+  public function test_merge_sorts_unordered_input() {
+    $merged = mcp_merge_intervals([[400, 500], [100, 200]]);
+    $this->assertSame([[100, 200], [400, 500]], $merged);
+  }
+
+  public function test_merge_leaves_touching_intervals_separate() {
+    // Touching (200==200) are not merged: they represent back-to-back busy
+    // blocks, which is fine to report as two.
+    $merged = mcp_merge_intervals([[100, 200], [200, 300]]);
+    $this->assertSame([[100, 200], [200, 300]], $merged);
+  }
+
+  public function test_merge_empty_returns_empty() {
+    $this->assertSame([], mcp_merge_intervals([]));
+  }
+}

--- a/tests/McpSchedulingWriteToolsIntegrationTest.php
+++ b/tests/McpSchedulingWriteToolsIntegrationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * End-to-end integration tests for the scheduling write tools
+ * (add_recurring_event, update_event, delete_event) exercised over real HTTP
+ * against the production schema built by the headless installer -- the same
+ * approach as McpAddEventRaceConditionTest. This is where the tool method
+ * bodies in mcp.php (which unit tests cannot include) are covered.
+ */
+final class McpSchedulingWriteToolsIntegrationTest extends TestCase
+{
+    private static $db_file = null;
+    private static $api_token = null;
+    private static $server_pid = null;
+    private static $server_port = 8103;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$db_file = sys_get_temp_dir() . '/mcp_sched_write_test.sqlite';
+        if (file_exists(self::$db_file)) {
+            unlink(self::$db_file);
+        }
+
+        $project_dir = __DIR__ . '/..';
+        $cmd = sprintf(
+            'php %s/wizard/headless.php --use-env --db-type=sqlite3 --db-database=%s --admin-login=admin --admin-password=admin --install-password=test123 --force',
+            $project_dir,
+            self::$db_file
+        );
+        $output = [];
+        $return_var = null;
+        exec($cmd, $output, $return_var);
+        if ($return_var !== 0) {
+            throw new RuntimeException("Headless installer failed: " . implode("\n", $output));
+        }
+
+        self::$api_token = bin2hex(random_bytes(32));
+        $db = new SQLite3(self::$db_file);
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_SERVER_ENABLED', 'Y');");
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_WRITE_ACCESS', 'Y');");
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_RATE_LIMIT', '1000');");
+        $db->exec(sprintf("UPDATE webcal_user SET cal_api_token = '%s' WHERE cal_login = 'admin';", self::$api_token));
+        $db->close();
+
+        $env = sprintf(
+            'MCP_TOKEN= WEBCALENDAR_USE_ENV=true WEBCALENDAR_DB_TYPE=sqlite3 WEBCALENDAR_DB_DATABASE=%s',
+            self::$db_file
+        );
+        $cmd = sprintf('%s php -S localhost:%d -t %s > /tmp/mcp-sched-write-server.log 2>&1 & echo $!', $env, self::$server_port, $project_dir);
+        $out = [];
+        exec($cmd, $out);
+        self::$server_pid = (int)$out[0];
+        sleep(2);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        try {
+            if (self::$server_pid && function_exists('posix_kill') && posix_kill(self::$server_pid, 0)) {
+                $sigterm = defined('SIGTERM') ? SIGTERM : 15;
+                $sigkill = defined('SIGKILL') ? SIGKILL : 9;
+                posix_kill(self::$server_pid, $sigterm);
+                sleep(1);
+                if (posix_kill(self::$server_pid, 0)) {
+                    posix_kill(self::$server_pid, $sigkill);
+                }
+            }
+        } catch (\Throwable $e) {
+            // best-effort
+        }
+        if (file_exists(self::$db_file)) {
+            unlink(self::$db_file);
+        }
+    }
+
+    /** Issue a tools/call over HTTP and return the decoded JSON-RPC response. */
+    private function callTool(string $name, array $arguments): array
+    {
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => "http://localhost:" . self::$server_port . "/mcp.php",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode([
+                'jsonrpc' => '2.0',
+                'id' => 1,
+                'method' => 'tools/call',
+                'params' => ['name' => $name, 'arguments' => $arguments],
+            ]),
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'X-MCP-Token: ' . self::$api_token,
+            ],
+            CURLOPT_TIMEOUT => 10,
+        ]);
+        $response = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($response, true) ?? [];
+    }
+
+    private function repeatRow(int $calId): ?array
+    {
+        $db = new SQLite3(self::$db_file);
+        $stmt = $db->prepare('SELECT * FROM webcal_entry_repeats WHERE cal_id = :id');
+        $stmt->bindValue(':id', $calId, SQLITE3_INTEGER);
+        $row = $stmt->execute()->fetchArray(SQLITE3_ASSOC);
+        $db->close();
+        return $row ?: null;
+    }
+
+    private function entryCount(): int
+    {
+        $db = new SQLite3(self::$db_file);
+        $n = (int)$db->querySingle('SELECT COUNT(*) FROM webcal_entry');
+        $db->close();
+        return $n;
+    }
+
+    public function test_add_recurring_event_persists_entry_and_repeat_row(): void
+    {
+        $resp = $this->callTool('add_recurring_event', [
+            'name' => 'Team Standup',
+            'date' => '20260803',
+            'rrule' => 'FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=1',
+            'time' => '091500',
+            'duration' => 15,
+        ]);
+
+        $result = $resp['result'] ?? [];
+        $this->assertArrayNotHasKey('error', $result, 'unexpected error: ' . json_encode($resp));
+        $this->assertArrayHasKey('event_id', $result);
+        $this->assertSame('weekly', $result['cal_type']);
+
+        $repeat = $this->repeatRow((int)$result['event_id']);
+        $this->assertNotNull($repeat, 'a webcal_entry_repeats row must exist');
+        $this->assertSame('weekly', $repeat['cal_type']);
+        $this->assertSame('MO,WE,FR', $repeat['cal_byday']);
+        $this->assertEquals(1, $repeat['cal_frequency']);
+    }
+
+    public function test_add_recurring_event_stores_count_and_setpos(): void
+    {
+        $resp = $this->callTool('add_recurring_event', [
+            'name' => 'Monthly Review',
+            'date' => '20260807',
+            'rrule' => 'FREQ=MONTHLY;BYDAY=FR;BYSETPOS=1;COUNT=6',
+        ]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayNotHasKey('error', $result, json_encode($resp));
+        $this->assertSame('monthlyBySetPos', $result['cal_type']);
+
+        $repeat = $this->repeatRow((int)$result['event_id']);
+        $this->assertSame('monthlyBySetPos', $repeat['cal_type']);
+        $this->assertSame('1', $repeat['cal_bysetpos']);
+        $this->assertEquals(6, $repeat['cal_count']);
+    }
+
+    public function test_add_recurring_event_rejects_invalid_rrule_without_creating_event(): void
+    {
+        $before = $this->entryCount();
+        $resp = $this->callTool('add_recurring_event', [
+            'name' => 'Bad Rule',
+            'date' => '20260803',
+            'rrule' => 'FREQ=HOURLY',
+        ]);
+
+        $result = $resp['result'] ?? [];
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('rrule', $result['error']);
+        $this->assertSame($before, $this->entryCount(), 'no event should be created for an invalid RRULE');
+    }
+}

--- a/tests/McpSchedulingWriteToolsIntegrationTest.php
+++ b/tests/McpSchedulingWriteToolsIntegrationTest.php
@@ -16,6 +16,7 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
 {
     private static $db_file = null;
     private static $api_token = null;
+    private static $bob_token = null;
     private static $server_pid = null;
     private static $server_port = 8103;
 
@@ -45,6 +46,15 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_WRITE_ACCESS', 'Y');");
         $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_RATE_LIMIT', '1000');");
         $db->exec(sprintf("UPDATE webcal_user SET cal_api_token = '%s' WHERE cal_login = 'admin';", self::$api_token));
+
+        // A second, non-admin user to exercise the ownership check on
+        // update_event / delete_event.
+        self::$bob_token = bin2hex(random_bytes(32));
+        $db->exec(sprintf(
+            "INSERT INTO webcal_user (cal_login, cal_firstname, cal_lastname, cal_is_admin, cal_api_token) "
+            . "VALUES ('bob', 'Bob', 'Tester', 'N', '%s');",
+            self::$bob_token
+        ));
         $db->close();
 
         $env = sprintf(
@@ -78,8 +88,14 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         }
     }
 
-    /** Issue a tools/call over HTTP and return the decoded JSON-RPC response. */
+    /** Issue a tools/call over HTTP as the admin user. */
     private function callTool(string $name, array $arguments): array
+    {
+        return $this->callToolAs(self::$api_token, $name, $arguments);
+    }
+
+    /** Issue a tools/call over HTTP as the holder of $token. */
+    private function callToolAs(string $token, string $name, array $arguments): array
     {
         $ch = curl_init();
         curl_setopt_array($ch, [
@@ -94,13 +110,23 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
             ]),
             CURLOPT_HTTPHEADER => [
                 'Content-Type: application/json',
-                'X-MCP-Token: ' . self::$api_token,
+                'X-MCP-Token: ' . $token,
             ],
             CURLOPT_TIMEOUT => 10,
         ]);
         $response = curl_exec($ch);
         curl_close($ch);
         return json_decode($response, true) ?? [];
+    }
+
+    private function entryRow(int $calId): ?array
+    {
+        $db = new SQLite3(self::$db_file);
+        $stmt = $db->prepare('SELECT * FROM webcal_entry WHERE cal_id = :id');
+        $stmt->bindValue(':id', $calId, SQLITE3_INTEGER);
+        $row = $stmt->execute()->fetchArray(SQLITE3_ASSOC);
+        $db->close();
+        return $row ?: null;
     }
 
     private function repeatRow(int $calId): ?array
@@ -173,5 +199,58 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         $this->assertArrayHasKey('error', $result);
         $this->assertStringContainsStringIgnoringCase('rrule', $result['error']);
         $this->assertSame($before, $this->entryCount(), 'no event should be created for an invalid RRULE');
+    }
+
+    public function test_update_event_changes_only_provided_fields(): void
+    {
+        $add = $this->callTool('add_recurring_event', [
+            'name' => 'Original Name',
+            'date' => '20260803',
+            'rrule' => 'FREQ=DAILY',
+            'description' => 'keep me',
+        ]);
+        $id = (int)$add['result']['event_id'];
+
+        $upd = $this->callTool('update_event', ['event_id' => $id, 'name' => 'New Name']);
+        $this->assertArrayNotHasKey('error', $upd['result'] ?? [], json_encode($upd));
+
+        $row = $this->entryRow($id);
+        $this->assertSame('New Name', $row['cal_name']);
+        // Unspecified field is untouched (null routing, not blanking).
+        $this->assertSame('keep me', $row['cal_description']);
+    }
+
+    public function test_delete_event_removes_entry_and_repeat_rows(): void
+    {
+        $add = $this->callTool('add_recurring_event', [
+            'name' => 'To Delete',
+            'date' => '20260803',
+            'rrule' => 'FREQ=WEEKLY;BYDAY=TU',
+        ]);
+        $id = (int)$add['result']['event_id'];
+        $this->assertNotNull($this->repeatRow($id));
+
+        $del = $this->callTool('delete_event', ['event_id' => $id]);
+        $this->assertTrue($del['result']['success'] ?? false, json_encode($del));
+
+        $this->assertNull($this->entryRow($id), 'base event should be gone');
+        $this->assertNull($this->repeatRow($id), 'recurrence row should be gone');
+    }
+
+    public function test_delete_event_rejects_non_owner(): void
+    {
+        // admin creates an event; bob must not be able to delete it.
+        $add = $this->callTool('add_recurring_event', [
+            'name' => 'Admin Only',
+            'date' => '20260803',
+            'rrule' => 'FREQ=DAILY',
+        ]);
+        $id = (int)$add['result']['event_id'];
+
+        $del = $this->callToolAs(self::$bob_token, 'delete_event', ['event_id' => $id]);
+        $result = $del['result'] ?? [];
+        $this->assertArrayHasKey('error', $result, 'bob must not delete admin\'s event: ' . json_encode($del));
+        $this->assertStringContainsStringIgnoringCase('authorized', $result['error']);
+        $this->assertNotNull($this->entryRow($id), 'the event must still exist after a rejected delete');
     }
 }

--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -77,7 +77,7 @@ final class McpTest extends TestCase
 
   public function test_tools_list_response() {
     $tools = mcp_list_tools();
-    $this->assertCount(6, $tools);
+    $this->assertCount(7, $tools);
 
     $names = array_column($tools, 'name');
     $this->assertContains('list_events', $names);
@@ -86,6 +86,7 @@ final class McpTest extends TestCase
     $this->assertContains('add_event', $names);
     $this->assertContains('get_availability', $names);
     $this->assertContains('check_conflicts', $names);
+    $this->assertContains('add_recurring_event', $names);
   }
 
   public function test_tools_list_schemas() {

--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -77,13 +77,15 @@ final class McpTest extends TestCase
 
   public function test_tools_list_response() {
     $tools = mcp_list_tools();
-    $this->assertCount(4, $tools);
+    $this->assertCount(6, $tools);
 
     $names = array_column($tools, 'name');
     $this->assertContains('list_events', $names);
     $this->assertContains('get_user_info', $names);
     $this->assertContains('search_events', $names);
     $this->assertContains('add_event', $names);
+    $this->assertContains('get_availability', $names);
+    $this->assertContains('check_conflicts', $names);
   }
 
   public function test_tools_list_schemas() {

--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -77,7 +77,7 @@ final class McpTest extends TestCase
 
   public function test_tools_list_response() {
     $tools = mcp_list_tools();
-    $this->assertCount(7, $tools);
+    $this->assertCount(9, $tools);
 
     $names = array_column($tools, 'name');
     $this->assertContains('list_events', $names);
@@ -87,6 +87,8 @@ final class McpTest extends TestCase
     $this->assertContains('get_availability', $names);
     $this->assertContains('check_conflicts', $names);
     $this->assertContains('add_recurring_event', $names);
+    $this->assertContains('update_event', $names);
+    $this->assertContains('delete_event', $names);
   }
 
   public function test_tools_list_schemas() {

--- a/tests/McpToolDispatchTest.php
+++ b/tests/McpToolDispatchTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Verifies that mcp_dispatch_request() advertises the scheduling tools and
+ * routes tools/call to the right WebCalendarMcpTools method with the right
+ * arguments. A stub $tools object records the call, so this exercises the
+ * dispatch wiring without loading mcp.php's transport bootstrap.
+ */
+final class McpToolDispatchTest extends TestCase
+{
+  private function stubTools() {
+    return new class {
+      public $calls = [];
+      public function get_availability($start_date, $end_date) {
+        $this->calls[] = ['get_availability', [$start_date, $end_date]];
+        return ['busy' => [], 'all_day' => [], 'timezone' => 'GMT'];
+      }
+      public function check_conflicts($date, $time, $duration) {
+        $this->calls[] = ['check_conflicts', [$date, $time, $duration]];
+        return ['has_conflict' => false, 'conflicts' => []];
+      }
+    };
+  }
+
+  private function call($tools, $name, $arguments) {
+    return mcp_dispatch_request([
+      'jsonrpc' => '2.0',
+      'method' => 'tools/call',
+      'params' => ['name' => $name, 'arguments' => $arguments],
+      'id' => 1,
+    ], $tools);
+  }
+
+  // --- schema advertising -------------------------------------------------
+
+  public function test_get_availability_schema_required_fields() {
+    $schema = get_mcp_tool_schema('get_availability');
+    $this->assertNotNull($schema);
+    $this->assertContains('start_date', $schema['required']);
+    $this->assertContains('end_date', $schema['required']);
+  }
+
+  public function test_check_conflicts_schema_required_fields() {
+    $schema = get_mcp_tool_schema('check_conflicts');
+    $this->assertNotNull($schema);
+    $this->assertContains('date', $schema['required']);
+    $this->assertContains('time', $schema['required']);
+    $this->assertContains('duration', $schema['required']);
+  }
+
+  // --- routing ------------------------------------------------------------
+
+  public function test_dispatch_routes_get_availability_with_args() {
+    $tools = $this->stubTools();
+    $resp = $this->call($tools, 'get_availability',
+      ['start_date' => '20260101', 'end_date' => '20260131']);
+
+    $this->assertSame(['get_availability', ['20260101', '20260131']], $tools->calls[0]);
+    $this->assertArrayHasKey('result', $resp);
+    $this->assertArrayNotHasKey('error', $resp);
+  }
+
+  public function test_dispatch_routes_check_conflicts_with_args() {
+    $tools = $this->stubTools();
+    $resp = $this->call($tools, 'check_conflicts',
+      ['date' => '20260611', 'time' => '090000', 'duration' => 60]);
+
+    $this->assertSame(['check_conflicts', ['20260611', '090000', 60]], $tools->calls[0]);
+    $this->assertArrayHasKey('result', $resp);
+    $this->assertFalse($resp['result']['has_conflict']);
+  }
+}

--- a/tests/McpToolDispatchTest.php
+++ b/tests/McpToolDispatchTest.php
@@ -29,6 +29,15 @@ final class McpToolDispatchTest extends TestCase
           [$name, $date, $rrule, $time, $duration, $description, $location]];
         return ['success' => true, 'event_id' => 42, 'cal_type' => 'weekly'];
       }
+      public function update_event($event_id, $name, $date, $time, $duration, $description, $location) {
+        $this->calls[] = ['update_event',
+          [$event_id, $name, $date, $time, $duration, $description, $location]];
+        return ['success' => true, 'event_id' => $event_id];
+      }
+      public function delete_event($event_id) {
+        $this->calls[] = ['delete_event', [$event_id]];
+        return ['success' => true, 'event_id' => $event_id];
+      }
     };
   }
 
@@ -101,5 +110,27 @@ final class McpToolDispatchTest extends TestCase
       $tools->calls[0]
     );
     $this->assertSame(42, $resp['result']['event_id']);
+  }
+
+  public function test_update_and_delete_schemas_require_event_id() {
+    $this->assertContains('event_id', get_mcp_tool_schema('update_event')['required']);
+    $this->assertContains('event_id', get_mcp_tool_schema('delete_event')['required']);
+  }
+
+  public function test_dispatch_routes_update_event_passing_null_for_absent_fields() {
+    $tools = $this->stubTools();
+    $this->call($tools, 'update_event', ['event_id' => 7, 'name' => 'Renamed']);
+    // Absent optional fields must arrive as null so the tool leaves them
+    // unchanged (not '' which would blank the column).
+    $this->assertSame(
+      ['update_event', [7, 'Renamed', null, null, null, null, null]],
+      $tools->calls[0]
+    );
+  }
+
+  public function test_dispatch_routes_delete_event_with_id() {
+    $tools = $this->stubTools();
+    $this->call($tools, 'delete_event', ['event_id' => 9]);
+    $this->assertSame(['delete_event', [9]], $tools->calls[0]);
   }
 }

--- a/tests/McpToolDispatchTest.php
+++ b/tests/McpToolDispatchTest.php
@@ -24,6 +24,11 @@ final class McpToolDispatchTest extends TestCase
         $this->calls[] = ['check_conflicts', [$date, $time, $duration]];
         return ['has_conflict' => false, 'conflicts' => []];
       }
+      public function add_recurring_event($name, $date, $rrule, $time, $duration, $description, $location) {
+        $this->calls[] = ['add_recurring_event',
+          [$name, $date, $rrule, $time, $duration, $description, $location]];
+        return ['success' => true, 'event_id' => 42, 'cal_type' => 'weekly'];
+      }
     };
   }
 
@@ -73,5 +78,28 @@ final class McpToolDispatchTest extends TestCase
     $this->assertSame(['check_conflicts', ['20260611', '090000', 60]], $tools->calls[0]);
     $this->assertArrayHasKey('result', $resp);
     $this->assertFalse($resp['result']['has_conflict']);
+  }
+
+  public function test_add_recurring_event_schema_required_fields() {
+    $schema = get_mcp_tool_schema('add_recurring_event');
+    $this->assertNotNull($schema);
+    $this->assertContains('name', $schema['required']);
+    $this->assertContains('date', $schema['required']);
+    $this->assertContains('rrule', $schema['required']);
+  }
+
+  public function test_dispatch_routes_add_recurring_event_with_args() {
+    $tools = $this->stubTools();
+    $resp = $this->call($tools, 'add_recurring_event', [
+      'name' => 'Standup', 'date' => '20260803', 'rrule' => 'FREQ=WEEKLY;BYDAY=MO',
+      'time' => '091500', 'duration' => 15, 'description' => 'daily sync', 'location' => 'Zoom',
+    ]);
+
+    $this->assertSame(
+      ['add_recurring_event',
+        ['Standup', '20260803', 'FREQ=WEEKLY;BYDAY=MO', '091500', 15, 'daily sync', 'Zoom']],
+      $tools->calls[0]
+    );
+    $this->assertSame(42, $resp['result']['event_id']);
   }
 }

--- a/tests/McpWriteAccessDisabledTest.php
+++ b/tests/McpWriteAccessDisabledTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Regression guard for the MCP_WRITE_ACCESS admin setting: when write access
+ * is NOT enabled, every write tool must refuse and change nothing, while read
+ * tools still work. Runs a real server (headless-installed schema) with MCP
+ * enabled but MCP_WRITE_ACCESS left OFF.
+ */
+final class McpWriteAccessDisabledTest extends TestCase
+{
+    private static $db_file = null;
+    private static $api_token = null;
+    private static $server_pid = null;
+    private static $server_port = 8104;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$db_file = sys_get_temp_dir() . '/mcp_write_disabled_test.sqlite';
+        if (file_exists(self::$db_file)) {
+            unlink(self::$db_file);
+        }
+
+        $project_dir = __DIR__ . '/..';
+        $cmd = sprintf(
+            'php %s/wizard/headless.php --use-env --db-type=sqlite3 --db-database=%s --admin-login=admin --admin-password=admin --install-password=test123 --force',
+            $project_dir,
+            self::$db_file
+        );
+        $output = [];
+        $return_var = null;
+        exec($cmd, $output, $return_var);
+        if ($return_var !== 0) {
+            throw new RuntimeException("Headless installer failed: " . implode("\n", $output));
+        }
+
+        self::$api_token = bin2hex(random_bytes(32));
+        $db = new SQLite3(self::$db_file);
+        // MCP enabled, but write access deliberately NOT set to 'Y'.
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_SERVER_ENABLED', 'Y');");
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_WRITE_ACCESS', 'N');");
+        $db->exec("INSERT OR REPLACE INTO webcal_config (cal_setting, cal_value) VALUES ('MCP_RATE_LIMIT', '1000');");
+        $db->exec(sprintf("UPDATE webcal_user SET cal_api_token = '%s' WHERE cal_login = 'admin';", self::$api_token));
+        $db->close();
+
+        $env = sprintf(
+            'MCP_TOKEN= WEBCALENDAR_USE_ENV=true WEBCALENDAR_DB_TYPE=sqlite3 WEBCALENDAR_DB_DATABASE=%s',
+            self::$db_file
+        );
+        $cmd = sprintf('%s php -S localhost:%d -t %s > /tmp/mcp-write-disabled-server.log 2>&1 & echo $!', $env, self::$server_port, $project_dir);
+        $out = [];
+        exec($cmd, $out);
+        self::$server_pid = (int)$out[0];
+        sleep(2);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        try {
+            if (self::$server_pid && function_exists('posix_kill') && posix_kill(self::$server_pid, 0)) {
+                $sigterm = defined('SIGTERM') ? SIGTERM : 15;
+                $sigkill = defined('SIGKILL') ? SIGKILL : 9;
+                posix_kill(self::$server_pid, $sigterm);
+                sleep(1);
+                if (posix_kill(self::$server_pid, 0)) {
+                    posix_kill(self::$server_pid, $sigkill);
+                }
+            }
+        } catch (\Throwable $e) {
+            // best-effort
+        }
+        if (file_exists(self::$db_file)) {
+            unlink(self::$db_file);
+        }
+    }
+
+    private function callTool(string $name, array $arguments): array
+    {
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => "http://localhost:" . self::$server_port . "/mcp.php",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode([
+                'jsonrpc' => '2.0',
+                'id' => 1,
+                'method' => 'tools/call',
+                'params' => ['name' => $name, 'arguments' => $arguments],
+            ]),
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'X-MCP-Token: ' . self::$api_token,
+            ],
+            CURLOPT_TIMEOUT => 10,
+        ]);
+        $response = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($response, true) ?? [];
+    }
+
+    private function entryCount(): int
+    {
+        $db = new SQLite3(self::$db_file);
+        $n = (int)$db->querySingle('SELECT COUNT(*) FROM webcal_entry');
+        $db->close();
+        return $n;
+    }
+
+    public function test_add_recurring_event_is_blocked_and_creates_nothing(): void
+    {
+        $before = $this->entryCount();
+        $resp = $this->callTool('add_recurring_event', [
+            'name' => 'Should Not Persist',
+            'date' => '20260803',
+            'rrule' => 'FREQ=WEEKLY;BYDAY=MO',
+        ]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('write access', $result['error']);
+        $this->assertSame($before, $this->entryCount(), 'no event may be created when write access is off');
+    }
+
+    public function test_update_event_is_blocked(): void
+    {
+        $resp = $this->callTool('update_event', ['event_id' => 1, 'name' => 'x']);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('write access', $result['error']);
+    }
+
+    public function test_delete_event_is_blocked(): void
+    {
+        $resp = $this->callTool('delete_event', ['event_id' => 1]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('write access', $result['error']);
+    }
+
+    public function test_read_tools_still_work_when_write_disabled(): void
+    {
+        // get_availability is a read tool and must remain usable.
+        $resp = $this->callTool('get_availability', ['start_date' => '20260801', 'end_date' => '20260831']);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayNotHasKey('error', $result, json_encode($resp));
+        $this->assertArrayHasKey('busy', $result);
+    }
+}

--- a/tests/mcp-integration-test.sh
+++ b/tests/mcp-integration-test.sh
@@ -223,13 +223,15 @@ echo "--- Test: Tools List ---"
 RESPONSE=$(mcp_call "tools/list" "{}")
 
 TOOL_COUNT=$(echo "$RESPONSE" | jq '.result.tools | length')
-if [ "$TOOL_COUNT" = "4" ]; then
-  pass "Returns 4 tools"
+if [ "$TOOL_COUNT" = "9" ]; then
+  pass "Returns 9 tools"
 else
-  fail "Expected 4 tools, got $TOOL_COUNT" "$RESPONSE"
+  fail "Expected 9 tools, got $TOOL_COUNT" "$RESPONSE"
 fi
 
-for TOOL in list_events get_user_info search_events add_event; do
+for TOOL in list_events get_user_info search_events add_event \
+            get_availability check_conflicts add_recurring_event \
+            update_event delete_event; do
   if echo "$RESPONSE" | jq -e ".result.tools[] | select(.name == \"$TOOL\")" > /dev/null 2>&1; then
     pass "Tool '$TOOL' is listed"
   else


### PR DESCRIPTION
## Summary

Adds five MCP tools to the WebCalendar MCP server so an external agent (the
companion [`scheduling-agent`](https://github.com/craigk5n/scheduling-agent)
project) can do natural-language scheduling against a WebCalendar instance:

| Tool | Type | Write-gated | Purpose |
|---|---|---|---|
| `get_availability(start_date, end_date)` | read | – | The user's busy time blocks in a range |
| `check_conflicts(date, time, duration)` | read | – | Whether a proposed slot overlaps existing timed events |
| `add_recurring_event(name, date, rrule, …)` | write | ✓ | Create a recurring event from an RFC 5545 RRULE |
| `update_event(event_id, …)` | write | ✓ | Update fields of an event the user created |
| `delete_event(event_id)` | write | ✓ | Delete an event the user created |

This extends the existing four tools (`list_events`, `search_events`,
`get_user_info`, `add_event`); the advertised tool count goes 4 → 9.

## Design

- **Testable seam preserved.** Recurrence/interval logic lives in pure
  functions in `includes/functions.php` (no DB/globals), unit-tested directly;
  the `WebCalendarMcpTools` methods in `mcp.php` are thin DB wrappers. Schemas
  and routing stay in `mcp_list_tools()` / `mcp_dispatch_request()`, matching
  the existing pattern.
- **RRULE subset matches storage.** `mcp_validate_rrule()` enforces exactly
  what `webcal_entry_repeats` can store and `RptEvent` can expand: FREQ
  DAILY/WEEKLY/MONTHLY/YEARLY; INTERVAL, COUNT, UNTIL (mutually exclusive),
  BYMONTH, BYMONTHDAY, BYDAY(+offsets), BYSETPOS, BYWEEKNO, BYYEARDAY, WKST.
  It rejects sub-daily FREQ, BYHOUR/BYMINUTE/BYSECOND, the `COUNT=999`
  infinite sentinel, and BY* values that would overflow the varchar columns.
  `mcp_rrule_to_repeat_columns()` maps validated parts to columns, reproducing
  xcal.php's `cal_type` derivation (MONTHLY → `monthlyBySetPos` when BYSETPOS
  present, else `monthlyByDay`).
- **Write safety.** All three write tools check `is_mcp_write_enabled()`
  (i.e. the `MCP_WRITE_ACCESS` admin setting) as their first statement, before
  any DB access. `update_event`/`delete_event` enforce ownership via
  `cal_create_by`. `add_recurring_event` rolls back the base event if the
  recurrence-row insert fails, so no orphan non-repeating entries are left.
- **Timezone frame.** The scheduling tools operate in the GMT storage frame;
  local↔GMT conversion is the agent's responsibility (consistent with where
  timezone handling lives in the agent architecture). `list_events` /
  `search_events` remain local-converted display tools — unchanged.

## Known limitation (documented, intentional for v1)

`get_availability` / `check_conflicts` reflect stored events but do **not** yet
expand recurring-event occurrences beyond their base date. This is called out
in the tool descriptions and will be certified/addressed via the agent
project's eval suite. Multi-user availability is likewise deferred (single
authenticated user for now).

## Test plan

New tests (all green); full MCP suite: **152 tests across 12 files, 0 failures**.

- `McpRruleValidationTest` (25) — RRULE subset validation.
- `McpSchedulingHelpersTest` (13) — interval/overlap/conflict/merge helpers.
- `McpRepeatColumnsTest` (9) — RRULE parts → `webcal_entry_repeats` columns.
- `McpToolDispatchTest` (9) — dispatch routing + schema advertising, via a
  stub tools object (no `mcp.php` transport needed).
- `McpSchedulingWriteToolsIntegrationTest` (6) — real HTTP against the
  installer-built schema: add_recurring_event persists entry + repeat rows
  (weekly BYDAY, monthlyBySetPos, COUNT), invalid RRULE creates nothing,
  update round-trip, delete removes entry + repeat rows, and a **second user
  cannot delete another user's event** (ownership).
- `McpWriteAccessDisabledTest` (4) — with `MCP_WRITE_ACCESS` off, all write
  tools are refused and create nothing while reads still work.
- Updated `McpTest` and `McpIntegrationTest` tool-count assertions (4 → 9).

### Reviewer TODO
- [ ] Verify against a **live** instance (this branch is validated against the
      headless-installer SQLite schema only).
- [ ] Confirm the desired product behavior for recurring-occurrence expansion
      in availability/conflicts before relying on it for conflict avoidance.
