### PR TITLE
fix(mcp): make CLI/STDIO transport work via shared dispatcher

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7523,4 +7523,59 @@ function mcp_dispatch_request($request, $tools = null) {
 
   return $response;
 }
+
+/**
+ * Runs the MCP STDIO transport loop. Reads newline-delimited JSON-RPC messages
+ * from $in, dispatches each via mcp_dispatch_request() -- the same handler the
+ * HTTP transport uses -- and writes newline-delimited JSON-RPC responses to
+ * $out. JSON-RPC notifications (messages with no 'id', e.g.
+ * notifications/initialized) receive no response. Returns when $in reaches EOF.
+ *
+ * Separated from mcp.php so the framing logic can be unit-tested with in-memory
+ * streams instead of a real STDIO process.
+ *
+ * @param resource $in    Readable stream (e.g. php://stdin).
+ * @param resource $out   Writable stream (e.g. php://stdout).
+ * @param object   $tools WebCalendarMcpTools instance for tools/call routing.
+ * @return void
+ */
+function mcp_run_stdio_loop($in, $out, $tools) {
+  while (($line = fgets($in)) !== false) {
+    $line = trim($line);
+    if ($line === '') {
+      continue;
+    }
+
+    $request = json_decode($line, true);
+    if (!is_array($request)) {
+      // Malformed JSON: reply with a JSON-RPC parse error.
+      fwrite($out, json_encode([
+        'jsonrpc' => '2.0',
+        'id' => null,
+        'error' => ['code' => -32700, 'message' => 'Parse error']
+      ]) . "\n");
+      continue;
+    }
+
+    // Notifications (no 'id') must not receive a response.
+    $is_notification = !array_key_exists('id', $request);
+
+    try {
+      $response = mcp_dispatch_request($request, $tools);
+    } catch (Exception $e) {
+      // mcp_dispatch_request handles its own errors, but guard the loop so a
+      // single bad message cannot terminate a long-running server.
+      error_log('MCP STDIO error: ' . $e->getMessage());
+      $response = [
+        'jsonrpc' => '2.0',
+        'id' => $request['id'] ?? null,
+        'error' => ['code' => -32603, 'message' => 'Internal error']
+      ];
+    }
+
+    if (!$is_notification) {
+      fwrite($out, json_encode($response) . "\n");
+    }
+  }
+}
 ?>

--- a/mcp.php
+++ b/mcp.php
@@ -341,8 +341,6 @@ if ( ! file_exists( 'includes/mcp-loader.php' ) || ! class_exists( 'Mcp\Server' 
 
 require_once 'includes/mcp-loader.php';
 
-use Mcp\Server;
-use Mcp\Server\Transport\StdioTransport;
 use Mcp\Capability\Attribute\McpTool;
 
 // Define MCP Tools
@@ -867,33 +865,26 @@ class WebCalendarMcpTools
 
 // Handle transport based on execution context
 if (php_sapi_name() === 'cli') {
-    // STDIO transport for CLI execution
-    $server = Server::builder()
-        ->setServerInfo('WebCalendar MCP Server', '1.0.0')
-        ->setDiscovery(__DIR__, ['.'])
-        ->addToolInstance(new WebCalendarMcpTools($user_login))
-        ->build();
-
-    $transport = new StdioTransport();
-} else {
-    // HTTP transport for web requests - implement custom JSON-RPC handler
-    handleMcpHttpRequest($user_login);
-    exit; // handleMcpHttpRequest handles the response and exits
-}
-
-try {
-    $server->run($transport);
-} catch (Exception $e) {
-    $error_msg = 'MCP Server error: ' . $e->getMessage();
-    error_log($error_msg);
-    if (php_sapi_name() === 'cli') {
-        fwrite(STDERR, "Error: $error_msg\n");
+    // STDIO transport: read newline-delimited JSON-RPC messages from stdin and
+    // dispatch each through mcp_dispatch_request() -- the same handler the HTTP
+    // transport uses -- so STDIO and HTTP advertise and route tools identically
+    // (single source of truth: mcp_list_tools). The loop lives in
+    // mcp_run_stdio_loop() (includes/functions.php) so it can be unit-tested
+    // with in-memory streams.
+    $tools = new WebCalendarMcpTools($user_login);
+    $stdin = fopen('php://stdin', 'r');
+    if ($stdin === false) {
+        fwrite(STDERR, "Error: unable to open stdin\n");
         exit(1);
-    } else {
-        header('Content-Type: application/json');
-        echo json_encode(['error' => 'Internal server error']);
-        exit;
     }
+
+    mcp_run_stdio_loop($stdin, STDOUT, $tools);
+
+    fclose($stdin);
+    exit(0);
 }
-?></content>
-<parameter name="filePath">mcp.php
+
+// HTTP transport for web requests -- custom JSON-RPC handler.
+handleMcpHttpRequest($user_login);
+exit; // handleMcpHttpRequest handles the response and exits
+?>

--- a/tests/McpStdioLoopTest.php
+++ b/tests/McpStdioLoopTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/../includes/dbi4php.php";
+require_once __DIR__ . "/../includes/functions.php";
+
+/**
+ * Verifies mcp_run_stdio_loop() frames newline-delimited JSON-RPC correctly:
+ * one response line per request, no response for notifications, parse errors
+ * for malformed input, and routing through mcp_dispatch_request(). Uses
+ * in-memory streams so the STDIO transport is exercised without a real process.
+ */
+final class McpStdioLoopTest extends TestCase
+{
+  private function stubTools() {
+    return new class {
+      public $calls = [];
+      public function list_events($start_date, $end_date) {
+        $this->calls[] = ['list_events', [$start_date, $end_date]];
+        return ['events' => []];
+      }
+    };
+  }
+
+  /**
+   * Runs the loop over $input and returns the decoded response lines (in order).
+   *
+   * @return array<int, array> One decoded JSON object per output line.
+   */
+  private function runLoop($input, $tools = null) {
+    $in = fopen('php://memory', 'r+');
+    fwrite($in, $input);
+    rewind($in);
+
+    $out = fopen('php://memory', 'r+');
+
+    mcp_run_stdio_loop($in, $out, $tools ?? $this->stubTools());
+
+    rewind($out);
+    $raw = stream_get_contents($out);
+    fclose($in);
+    fclose($out);
+
+    $lines = array_values(array_filter(explode("\n", $raw), function ($l) {
+      return $l !== '';
+    }));
+    return array_map(function ($l) {
+      return json_decode($l, true);
+    }, $lines);
+  }
+
+  public function test_initialize_returns_single_response() {
+    $responses = $this->runLoop(
+      json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize']) . "\n"
+    );
+    $this->assertCount(1, $responses);
+    $this->assertSame('2.0', $responses[0]['jsonrpc']);
+    $this->assertSame(1, $responses[0]['id']);
+    $this->assertArrayHasKey('result', $responses[0]);
+  }
+
+  public function test_tools_list_is_advertised() {
+    $responses = $this->runLoop(
+      json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']) . "\n"
+    );
+    $this->assertCount(1, $responses);
+    $names = array_column($responses[0]['result']['tools'], 'name');
+    $this->assertContains('list_events', $names);
+  }
+
+  public function test_notification_gets_no_response() {
+    // A message with no "id" is a notification and must not be answered.
+    $responses = $this->runLoop(
+      json_encode(['jsonrpc' => '2.0', 'method' => 'notifications/initialized']) . "\n"
+    );
+    $this->assertCount(0, $responses);
+  }
+
+  public function test_malformed_json_returns_parse_error() {
+    $responses = $this->runLoop("this is not json\n");
+    $this->assertCount(1, $responses);
+    $this->assertSame(-32700, $responses[0]['error']['code']);
+    $this->assertNull($responses[0]['id']);
+  }
+
+  public function test_blank_lines_are_skipped() {
+    $input = "\n" .
+      json_encode(['jsonrpc' => '2.0', 'id' => 3, 'method' => 'initialize']) . "\n" .
+      "\n";
+    $responses = $this->runLoop($input);
+    $this->assertCount(1, $responses);
+    $this->assertSame(3, $responses[0]['id']);
+  }
+
+  public function test_multiple_messages_each_get_a_response() {
+    $input =
+      json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize']) . "\n" .
+      json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']) . "\n";
+    $responses = $this->runLoop($input);
+    $this->assertCount(2, $responses);
+    $this->assertSame(1, $responses[0]['id']);
+    $this->assertSame(2, $responses[1]['id']);
+  }
+
+  public function test_tools_call_routes_to_instance() {
+    $tools = $this->stubTools();
+    $responses = $this->runLoop(
+      json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'tools/call',
+        'params' => ['name' => 'list_events',
+          'arguments' => ['start_date' => '20260101', 'end_date' => '20260131']],
+      ]) . "\n",
+      $tools
+    );
+    $this->assertCount(1, $responses);
+    $this->assertSame(['list_events', ['20260101', '20260131']], $tools->calls[0]);
+  }
+}


### PR DESCRIPTION
## Problem

The CLI/STDIO path in `mcp.php` called `Server::builder()->…->addToolInstance(new WebCalendarMcpTools($user_login))->build()`. **`addToolInstance` exists in no version of `mcp/sdk` (0.3.0–0.6.0)** — the Builder only ever had `addTool`, is `final`, and has no `__call`. So `php mcp.php` fataled with *"Call to undefined method"* on every invocation. The documented STDIO entrypoint (Claude Desktop, `command: php … mcp.php`) has never worked; it's untested, so CI never caught it.

It was also **divergent by design**: the SDK Builder derives tool metadata from `#[McpTool]` attributes + docblock/param reflection, which would **not** match the curated definitions in `mcp_list_tools()` that the HTTP transport advertises.

## Fix

Replace the broken SDK Builder block with a small newline-delimited JSON-RPC loop, `mcp_run_stdio_loop()`, that dispatches each message through the **same** `mcp_dispatch_request()` / `mcp_list_tools()` path the HTTP transport already uses. STDIO and HTTP now advertise and route tools identically from a single source of truth.

- JSON-RPC notifications (no `id`, e.g. `notifications/initialized`) receive no response.
- Malformed input yields a JSON-RPC `-32700` parse error.
- One bad message can't kill the loop.
- Removed the now-unused `Mcp\Server` and `Mcp\Server\Transport\StdioTransport` imports. (`#[McpTool]` attribute + the `class_exists('Mcp\Server')` guard remain.)

The loop lives in `includes/functions.php` (next to `mcp_dispatch_request`) so it's unit-testable with in-memory streams — following the existing precedent that extracted `mcp_dispatch_request` for the same reason.

### Drive-by: removed committed tool-call artifact
`mcp.php` ended with literal garbage after the closing `?>`:
```
?></content>
<parameter name="filePath">mcp.php
```
An AI tool-call wrapper accidentally committed in `d0abe343`. Latent (both transport branches `exit()` before EOF) but clearly wrong. Since this PR rewrites the end of the file, it's cleaned up here.

## Tests

New `tests/McpStdioLoopTest.php` (7 cases, in-memory streams): initialize round-trip, `tools/list` advertising, notification suppression, parse-error framing, blank-line skipping, multi-message framing, and `tools/call` routing to the instance.

## Test plan
- [x] `php -l mcp.php` / `includes/functions.php` clean
- [x] New `McpStdioLoopTest` passes (7 tests)
- [x] Full PHPUnit suite green locally on PHP 8.2 (**649 tests, 2098 assertions, 1 skipped** — MySQL-only)
- [ ] CI green (PHPUnit 8.2/8.3/8.4, MCP unit/integration)

## Notes
- Registration is HTTP-only in practice (`claude_add_webcalendar_mcp.sh` uses `--transport http`), so this restores a documented-but-broken alternative transport with zero change to the HTTP path.
- No runtime dependence on the `mcp/sdk` Server/Transport classes remains; the dependency is retained for the `#[McpTool]` attribute.