### PR TITLE
Add optional time to the add_event MCP tool

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -6892,7 +6892,7 @@ function mcp_list_tools() {
     ],
     [
       'name' => 'add_event',
-      'description' => 'Add a new basic event (no repeating)',
+      'description' => 'Add a new basic event (no repeating), timed or untimed',
       'inputSchema' => [
         'type' => 'object',
         'properties' => [
@@ -6903,6 +6903,11 @@ function mcp_list_tools() {
           'date' => [
             'type' => 'string',
             'description' => 'Event date in YYYYMMDD format'
+          ],
+          'time' => [
+            'type' => 'string',
+            'description' => 'Start time in HHMMSS format (GMT), or -1 for untimed',
+            'default' => '-1'
           ],
           'description' => [
             'type' => 'string',
@@ -7453,6 +7458,7 @@ function mcp_dispatch_request($request, $tools = null) {
             $result = $tools->add_event(
               $tool_args['name'] ?? '',
               $tool_args['date'] ?? '',
+              $tool_args['time'] ?? '-1',
               $tool_args['description'] ?? '',
               $tool_args['location'] ?? '',
               $tool_args['duration'] ?? 0

--- a/mcp.php
+++ b/mcp.php
@@ -471,8 +471,8 @@ class WebCalendarMcpTools
         return ['events' => $events, 'total' => count($events)];
     }
 
-    #[McpTool(description: 'Add a new basic event (no repeating)')]
-    public function add_event(string $name, string $date, string $description = '', string $location = '', int $duration = 0): array
+    #[McpTool(description: 'Add a new basic event (no repeating), timed or untimed')]
+    public function add_event(string $name, string $date, string $time = '-1', string $description = '', string $location = '', int $duration = 0): array
     {
         // Check if write access is enabled
         if (!is_mcp_write_enabled()) {
@@ -488,6 +488,15 @@ class WebCalendarMcpTools
             return ['error' => 'Event name is required'];
         }
 
+        // Time: -1 (untimed/all-day) or HHMMSS in the GMT frame.
+        $cal_time = -1;
+        if ((string)$time !== '' && (string)$time !== '-1') {
+            if (!preg_match('/^\d{1,6}$/', (string)$time)) {
+                return ['error' => 'Time must be in HHMMSS format or -1 for untimed'];
+            }
+            $cal_time = (int)$time;
+        }
+
         // Generate a new event ID and insert it.
         //
         // webcal_entry.cal_id is a plain INT PRIMARY KEY with no
@@ -499,7 +508,7 @@ class WebCalendarMcpTools
         // portable across SQLite, MySQL and PostgreSQL without any
         // dialect-specific locking.
         $now = date('Ymd');
-        $time = date('His');
+        $mod_time = date('His');
         $sql = "INSERT INTO webcal_entry (cal_id, cal_name, cal_date, cal_time, cal_duration, cal_description, cal_location, cal_create_by, cal_mod_date, cal_mod_time)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -518,7 +527,7 @@ class WebCalendarMcpTools
             // can retry instead of aborting the whole request.
             $res = dbi_execute(
                 $sql,
-                [$candidate_id, $name, $date, -1, $duration, $description, $location, $this->userLogin, $now, $time],
+                [$candidate_id, $name, $date, $cal_time, $duration, $description, $location, $this->userLogin, $now, $mod_time],
                 false,
                 false
             );

--- a/tests/McpSchedulingWriteToolsIntegrationTest.php
+++ b/tests/McpSchedulingWriteToolsIntegrationTest.php
@@ -253,4 +253,33 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         $this->assertStringContainsStringIgnoringCase('authorized', $result['error']);
         $this->assertNotNull($this->entryRow($id), 'the event must still exist after a rejected delete');
     }
+
+    public function test_add_event_stores_the_given_time(): void
+    {
+        $resp = $this->callTool('add_event', [
+            'name' => 'Timed Lunch',
+            'date' => '20260717',
+            'time' => '140000',
+            'duration' => 60,
+        ]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayNotHasKey('error', $result, json_encode($resp));
+
+        $row = $this->entryRow((int)$result['event_id']);
+        $this->assertEquals(140000, $row['cal_time'], 'the requested time must be stored');
+        $this->assertEquals(60, $row['cal_duration']);
+    }
+
+    public function test_add_event_defaults_to_untimed(): void
+    {
+        $resp = $this->callTool('add_event', [
+            'name' => 'All Day',
+            'date' => '20260717',
+        ]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayNotHasKey('error', $result, json_encode($resp));
+
+        $row = $this->entryRow((int)$result['event_id']);
+        $this->assertEquals(-1, $row['cal_time'], 'no time given -> untimed (-1)');
+    }
 }

--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -119,6 +119,12 @@ final class McpTest extends TestCase
     $this->assertContains('date', $schema['required']);
   }
 
+  public function test_add_event_schema_has_optional_time() {
+    $schema = get_mcp_tool_schema('add_event');
+    $this->assertArrayHasKey('time', $schema['properties']);
+    $this->assertNotContains('time', $schema['required']);
+  }
+
   public function test_search_events_schema_required_fields() {
     $schema = get_mcp_tool_schema('search_events');
     $this->assertNotNull($schema);


### PR DESCRIPTION
## Summary

`add_event` stored `cal_time = -1` (untimed) unconditionally, so a one-off **timed** event created through MCP silently lost its time — a 10 AM request landed as an untimed row that the web UI renders at a garbage time. This adds an optional `time` parameter (HHMMSS in the GMT storage frame, or `-1` for untimed), mirroring `add_recurring_event`.

## Changes
- `mcp.php`: `add_event(name, date, time = '-1', description, location, duration)` — validates the time and stores it as `cal_time`; renamed the local mod-time variable to avoid a name clash.
- `includes/functions.php`: `add_event` schema gains an optional `time` property; dispatch passes it.
- **Backward compatible** — `time` defaults to `-1`, so existing callers are unchanged.

## Test plan
- `test_add_event_schema_has_optional_time`
- Integration (installer schema, real HTTP): `add_event` with a time stores that `cal_time`; without a time it stays `-1`.
- Full MCP suite green (13 files); PHPStan level 0 clean.