### PR TITLE
fix(mcp): exclude deleted/rejected events from read tools

### DIFF
--- a/mcp.php
+++ b/mcp.php
@@ -368,11 +368,14 @@ class WebCalendarMcpTools
 
         // Query events
         $events = [];
+        // cal_status IN ('A','W') excludes deleted ('D') and rejected ('R')
+        // events, matching the core UI's event queries (see includes/functions.php).
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration,
                        e.cal_description, e.cal_location, e.cal_priority
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ?
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ?
                 ORDER BY e.cal_date, e.cal_time";
 
         $res = dbi_execute($sql, [$this->userLogin, $query_start, $query_end]);
@@ -436,10 +439,12 @@ class WebCalendarMcpTools
         $limit = max(1, min(100, $limit));
 
         $events = [];
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_description
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND (e.cal_name LIKE ? OR e.cal_description LIKE ?)
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND (e.cal_name LIKE ? OR e.cal_description LIKE ?)
                 ORDER BY e.cal_date DESC, e.cal_time DESC
                 LIMIT " . (int)$limit;
 
@@ -558,10 +563,12 @@ class WebCalendarMcpTools
             return ['error' => 'Dates must be in YYYYMMDD format'];
         }
 
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ?
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ?
                 ORDER BY e.cal_date, e.cal_time";
 
         $busy = [];
@@ -607,10 +614,12 @@ class WebCalendarMcpTools
         $prev = mcp_shift_date($date, -1);
         $next = mcp_shift_date($date, 1);
 
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ? AND e.cal_time != -1
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ? AND e.cal_time != -1
                 ORDER BY e.cal_date, e.cal_time";
 
         $events = [];

--- a/tests/McpSchedulingWriteToolsIntegrationTest.php
+++ b/tests/McpSchedulingWriteToolsIntegrationTest.php
@@ -282,4 +282,68 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         $row = $this->entryRow((int)$result['event_id']);
         $this->assertEquals(-1, $row['cal_time'], 'no time given -> untimed (-1)');
     }
+
+    /**
+     * Soft-delete an event the way the web UI does: set its per-user status to
+     * 'D' rather than removing the row (see includes/xcal.php delete flow).
+     */
+    private function softDelete(int $calId): void
+    {
+        $db = new SQLite3(self::$db_file);
+        $stmt = $db->prepare('UPDATE webcal_entry_user SET cal_status = :s WHERE cal_id = :id');
+        $stmt->bindValue(':s', 'D', SQLITE3_TEXT);
+        $stmt->bindValue(':id', $calId, SQLITE3_INTEGER);
+        $stmt->execute();
+        $db->close();
+    }
+
+    public function test_read_tools_exclude_ui_deleted_events(): void
+    {
+        // A uniquely named, timed event that lands in every read tool's window.
+        $unique = 'SoftDeleteMe_' . bin2hex(random_bytes(4));
+        $add = $this->callTool('add_event', [
+            'name' => $unique,
+            'date' => '20260720',
+            'time' => '150000',
+            'duration' => 60,
+        ]);
+        $id = (int)($add['result']['event_id'] ?? 0);
+        $this->assertGreaterThan(0, $id, 'setup add_event failed: ' . json_encode($add));
+
+        // Before deletion: search_events finds it (sanity check the fixture).
+        $before = $this->callTool('search_events', ['keyword' => $unique]);
+        $names = array_column($before['result']['events'] ?? [], 'name');
+        $this->assertContains($unique, $names, 'event should be visible before deletion');
+
+        // Soft-delete as the UI does, then every read tool must exclude it.
+        $this->softDelete($id);
+
+        $search = $this->callTool('search_events', ['keyword' => $unique]);
+        $this->assertNotContains(
+            $unique,
+            array_column($search['result']['events'] ?? [], 'name'),
+            'search_events must not return a deleted event'
+        );
+
+        $list = $this->callTool('list_events', ['start_date' => '20260720', 'end_date' => '20260720']);
+        $this->assertNotContains(
+            $id,
+            array_column($list['result']['events'] ?? [], 'id'),
+            'list_events must not return a deleted event'
+        );
+
+        $avail = $this->callTool('get_availability', ['start_date' => '20260720', 'end_date' => '20260720']);
+        $this->assertNotContains(
+            $id,
+            array_column($avail['result']['busy'] ?? [], 'id'),
+            'get_availability must not report a deleted event as busy'
+        );
+
+        $conf = $this->callTool('check_conflicts', ['date' => '20260720', 'time' => '150000', 'duration' => 60]);
+        $this->assertNotContains(
+            $id,
+            array_column($conf['result']['conflicts'] ?? [], 'id'),
+            'check_conflicts must not flag a deleted event'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The MCP read tools were returning events that had been deleted through the WebCalendar web UI.

WebCalendar's UI **soft-deletes** events: it sets `webcal_entry_user.cal_status = 'D'` and leaves the row in place (see the delete flow in `includes/xcal.php`). But all four MCP read tools joined `webcal_entry_user` **without filtering `cal_status`**, so soft-deleted (`'D'`) and rejected (`'R'`) events still appeared in MCP results. The core UI's own event queries always filter `cal_status IN ('A','W')` (e.g. `includes/functions.php`); the MCP tools never adopted that convention.

## Fix

Add `AND eu.cal_status IN ('A','W')` to the read queries in `mcp.php`:

- `list_events`
- `search_events`
- `get_availability`
- `check_conflicts`

This matches the exact status filter the web UI uses, so MCP clients now see the same set of live events a user sees in the calendar.

**Scope:** read-only. `delete_event` (MCP) already hard-deletes rows and is unaffected. Events deleted *through MCP* were already gone; this only fixes visibility of events deleted *through the UI*.

## Test plan

- [x] New regression test `test_read_tools_exclude_ui_deleted_events` in `tests/McpSchedulingWriteToolsIntegrationTest.php`:
  - adds a timed event, confirms `search_events` returns it,
  - soft-deletes it the way the UI does (`cal_status = 'D'`),
  - asserts `search_events`, `list_events`, `get_availability`, and `check_conflicts` all then exclude it.
- [x] Full MCP suite green: **165 tests, 588 assertions** (MySQL cases skipped locally — no DB creds; SQLite + PostgreSQL run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
