### PR TITLE
fix(mcp): exclude deleted/rejected events from read tools; correct SDK install hint

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -765,7 +765,7 @@ if ( ! $error ) {
     <fieldset class="border p-2"><legend>' . translate('MCP Server Configuration') . '</legend>'
     . ( ! is_mcp_available()
       ? '<p class="bold"><span style="color: #cc0000;">' . translate( 'MCP Server is not available.' ) . '</span></p><p>'
-        . translate( 'The MCP SDK PHP package must be installed. Run: composer require mcp/sdk' ) . '</p>'
+        . translate( 'The MCP SDK PHP package must be installed. Run: composer install' ) . '</p>'
       : '<div class="form-inline mt-1 mb-2"><label title="' . tooltip ( 'mcp-server-enabled-help' ) . '">'
         . translate ( 'MCP Server enabled' ) . ':</label>'
         . print_radio ( 'MCP_SERVER_ENABLED', '', '', 'N' ) . '</div>

--- a/mcp.php
+++ b/mcp.php
@@ -368,11 +368,14 @@ class WebCalendarMcpTools
 
         // Query events
         $events = [];
+        // cal_status IN ('A','W') excludes deleted ('D') and rejected ('R')
+        // events, matching the core UI's event queries (see includes/functions.php).
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration,
                        e.cal_description, e.cal_location, e.cal_priority
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ?
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ?
                 ORDER BY e.cal_date, e.cal_time";
 
         $res = dbi_execute($sql, [$this->userLogin, $query_start, $query_end]);
@@ -436,10 +439,12 @@ class WebCalendarMcpTools
         $limit = max(1, min(100, $limit));
 
         $events = [];
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_description
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND (e.cal_name LIKE ? OR e.cal_description LIKE ?)
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND (e.cal_name LIKE ? OR e.cal_description LIKE ?)
                 ORDER BY e.cal_date DESC, e.cal_time DESC
                 LIMIT " . (int)$limit;
 
@@ -558,10 +563,12 @@ class WebCalendarMcpTools
             return ['error' => 'Dates must be in YYYYMMDD format'];
         }
 
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ?
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ?
                 ORDER BY e.cal_date, e.cal_time";
 
         $busy = [];
@@ -607,10 +614,12 @@ class WebCalendarMcpTools
         $prev = mcp_shift_date($date, -1);
         $next = mcp_shift_date($date, 1);
 
+        // Exclude deleted/rejected events (cal_status IN ('A','W')), as the UI does.
         $sql = "SELECT e.cal_id, e.cal_name, e.cal_date, e.cal_time, e.cal_duration
                 FROM webcal_entry e
                 INNER JOIN webcal_entry_user eu ON e.cal_id = eu.cal_id
-                WHERE eu.cal_login = ? AND e.cal_date BETWEEN ? AND ? AND e.cal_time != -1
+                WHERE eu.cal_login = ? AND eu.cal_status IN ('A','W')
+                      AND e.cal_date BETWEEN ? AND ? AND e.cal_time != -1
                 ORDER BY e.cal_date, e.cal_time";
 
         $events = [];

--- a/mcp.php
+++ b/mcp.php
@@ -328,12 +328,12 @@ load_global_settings();
 // Import MCP SDK
 if ( ! file_exists( 'includes/mcp-loader.php' ) || ! class_exists( 'Mcp\Server' ) ) {
   if ( php_sapi_name() === 'cli' ) {
-    fwrite( STDERR, "Error: MCP SDK not found. Run 'composer require mcp/sdk' to install.\n" );
+    fwrite( STDERR, "Error: MCP SDK not found. Run 'composer install' to install.\n" );
   } else {
     header( 'Content-Type: application/json' );
     echo json_encode( [
       'error' => 'MCP server is not available',
-      'message' => 'The MCP SDK PHP package must be installed. Run: composer require mcp/sdk'
+      'message' => 'The MCP SDK PHP package must be installed. Run: composer install'
     ] );
   }
   exit( 1 );

--- a/tests/McpSchedulingWriteToolsIntegrationTest.php
+++ b/tests/McpSchedulingWriteToolsIntegrationTest.php
@@ -282,4 +282,68 @@ final class McpSchedulingWriteToolsIntegrationTest extends TestCase
         $row = $this->entryRow((int)$result['event_id']);
         $this->assertEquals(-1, $row['cal_time'], 'no time given -> untimed (-1)');
     }
+
+    /**
+     * Soft-delete an event the way the web UI does: set its per-user status to
+     * 'D' rather than removing the row (see includes/xcal.php delete flow).
+     */
+    private function softDelete(int $calId): void
+    {
+        $db = new SQLite3(self::$db_file);
+        $stmt = $db->prepare('UPDATE webcal_entry_user SET cal_status = :s WHERE cal_id = :id');
+        $stmt->bindValue(':s', 'D', SQLITE3_TEXT);
+        $stmt->bindValue(':id', $calId, SQLITE3_INTEGER);
+        $stmt->execute();
+        $db->close();
+    }
+
+    public function test_read_tools_exclude_ui_deleted_events(): void
+    {
+        // A uniquely named, timed event that lands in every read tool's window.
+        $unique = 'SoftDeleteMe_' . bin2hex(random_bytes(4));
+        $add = $this->callTool('add_event', [
+            'name' => $unique,
+            'date' => '20260720',
+            'time' => '150000',
+            'duration' => 60,
+        ]);
+        $id = (int)($add['result']['event_id'] ?? 0);
+        $this->assertGreaterThan(0, $id, 'setup add_event failed: ' . json_encode($add));
+
+        // Before deletion: search_events finds it (sanity check the fixture).
+        $before = $this->callTool('search_events', ['keyword' => $unique]);
+        $names = array_column($before['result']['events'] ?? [], 'name');
+        $this->assertContains($unique, $names, 'event should be visible before deletion');
+
+        // Soft-delete as the UI does, then every read tool must exclude it.
+        $this->softDelete($id);
+
+        $search = $this->callTool('search_events', ['keyword' => $unique]);
+        $this->assertNotContains(
+            $unique,
+            array_column($search['result']['events'] ?? [], 'name'),
+            'search_events must not return a deleted event'
+        );
+
+        $list = $this->callTool('list_events', ['start_date' => '20260720', 'end_date' => '20260720']);
+        $this->assertNotContains(
+            $id,
+            array_column($list['result']['events'] ?? [], 'id'),
+            'list_events must not return a deleted event'
+        );
+
+        $avail = $this->callTool('get_availability', ['start_date' => '20260720', 'end_date' => '20260720']);
+        $this->assertNotContains(
+            $id,
+            array_column($avail['result']['busy'] ?? [], 'id'),
+            'get_availability must not report a deleted event as busy'
+        );
+
+        $conf = $this->callTool('check_conflicts', ['date' => '20260720', 'time' => '150000', 'duration' => 60]);
+        $this->assertNotContains(
+            $id,
+            array_column($conf['result']['conflicts'] ?? [], 'id'),
+            'check_conflicts must not flag a deleted event'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two MCP server fixes:

1. **Exclude soft-deleted/rejected events from MCP read tools** (`004234fc`). `list_events`, `search_events`, `get_availability`, and `check_conflicts` all joined `webcal_entry_user` but never filtered `cal_status`, so events soft-deleted through the web UI (`cal_status='D'`, rows left in place) — and rejected events (`'R'`) — still surfaced in MCP results. Each of the four read queries now adds `AND eu.cal_status IN ('A','W')`, matching the core UI's event queries in `includes/functions.php`.

2. **Recommend `composer install` instead of `composer require mcp/sdk`** (`99771f7b`). `mcp/sdk` is already a locked dependency in `composer.json`, so `composer install` is sufficient. `composer require` would rewrite `composer.json`/`composer.lock`, which are tracked by the signed security-audit manifest and would then be flagged as MODIFIED. Updated the CLI/JSON error messages in `mcp.php` and the admin settings hint in `admin.php`.

## Changes

- `mcp.php` — add `cal_status IN ('A','W')` to the four read-tool queries; fix SDK-not-found messages.
- `admin.php` — fix the "MCP SDK must be installed" hint.
- `tests/McpSchedulingWriteToolsIntegrationTest.php` — integration test that soft-deletes an event the way the UI does and asserts every read tool then excludes it.

## Test plan

- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — full suite passes
- [x] New integration test verifies soft-deleted events are excluded from all four read tools
- [x] Manual: soft-delete an event in the web UI, confirm it no longer appears via `list_events` / `search_events` / `get_availability` / `check_conflicts`
- [ ] Manual: with the SDK absent, confirm the CLI and admin messages now say `composer install`