### PR TITLE
fix: prevent "Error executing query" on first login after upgrade (#676)

### DIFF
--- a/includes/user.php
+++ b/includes/user.php
@@ -62,17 +62,25 @@ function user_valid_login ( $login, $password, $silent=false ) {
       if ( $okay && $rehash ) {
         $new_hash = password_hash ( $password, PASSWORD_DEFAULT );
         $sql = 'UPDATE webcal_user SET cal_passwd = ? WHERE cal_login = ?';
-        dbi_execute ( $sql, [$new_hash, $login] );
-        // Verify the hash was stored correctly (column may be too narrow).
+        // Non-fatal: if cal_passwd is too narrow for the 60-char bcrypt hash,
+        // strict-mode MySQL/MariaDB rejects this write with an error. Letting
+        // dbi_execute() fatal here would abort the login with a bare "Error
+        // executing query." Instead we swallow the failure and fall through to
+        // the verify/revert path below so the user can still log in (their
+        // password simply stays in the old format until the column is widened).
+        dbi_execute ( $sql, [$new_hash, $login], false, false );
+        // Verify the hash was stored correctly (column may be too narrow, or
+        // the write above may have been rejected/truncated).
         $res2 = dbi_execute (
           'SELECT cal_passwd FROM webcal_user WHERE cal_login = ?', [$login] );
         if ( $res2 ) {
           $row2 = dbi_fetch_row ( $res2 );
           dbi_free_result ( $res2 );
           if ( ! $row2 || $row2[0] !== $new_hash ) {
-            // Hash was truncated; revert to the old hash to avoid lockout.
+            // New hash was not stored (rejected or truncated); restore the old
+            // hash to avoid lockout. Also non-fatal for the same reason.
             dbi_execute ( 'UPDATE webcal_user SET cal_passwd = ? WHERE cal_login = ?',
-              [$expected_hash, $login] );
+              [$expected_hash, $login], false, false );
           }
         }
       }

--- a/tests/UpgradeSqlTest.php
+++ b/tests/UpgradeSqlTest.php
@@ -66,6 +66,51 @@ final class UpgradeSqlTest extends TestCase
     $this->assertLessThan($modifyPos, $updatePos, 'UPDATE must come before MODIFY');
   }
 
+  /**
+   * Issue #676: webcal_user.cal_passwd must be widened to VARCHAR(255) on any
+   * upgrade path, not just from pre-v1.9.0. A database already past v1.9.0 that
+   * still has a narrow (MD5-sized) column would otherwise fail on the first
+   * login after upgrade, when user_valid_login() rehashes the password to a
+   * 60-char bcrypt hash -- strict-mode MySQL/MariaDB rejects the write and the
+   * login dies with "Error executing query."
+   */
+  public function test_cal_passwd_widened_when_upgrading_from_post_v190_mysql(): void
+  {
+    $sql = getSqlUpdates('v1.9.12', 'mysql', false);
+    $joined = implode("\n", $sql);
+    $this->assertStringContainsStringIgnoringCase(
+      'MODIFY cal_passwd VARCHAR(255)',
+      $joined,
+      'A v1.9.12 -> latest upgrade must widen cal_passwd to hold a bcrypt hash'
+    );
+  }
+
+  public function test_cal_passwd_widened_when_upgrading_from_post_v190_postgres(): void
+  {
+    $sql = getSqlUpdates('v1.9.12', 'postgresql', false);
+    $joined = implode("\n", $sql);
+    $this->assertStringContainsStringIgnoringCase(
+      'ALTER COLUMN cal_passwd TYPE VARCHAR(255)',
+      $joined,
+      'Postgres v1.9.12 -> latest upgrade must widen cal_passwd'
+    );
+  }
+
+  /**
+   * SQLite does not enforce VARCHAR length and cannot parse MySQL "MODIFY",
+   * so the widening step must not leak the default-sql (MySQL) statement to it.
+   */
+  public function test_cal_passwd_widening_not_sent_to_sqlite(): void
+  {
+    $sql = getSqlUpdates('v1.9.12', 'sqlite3', false);
+    $joined = implode("\n", $sql);
+    $this->assertStringNotContainsStringIgnoringCase(
+      'MODIFY cal_passwd',
+      $joined,
+      'SQLite must not receive the MySQL MODIFY cal_passwd statement'
+    );
+  }
+
   public function test_multiple_primary_key_error_is_ignored(): void
   {
     $ref = new ReflectionClass(WizardDatabase::class);

--- a/wizard/shared/upgrade-sql.php
+++ b/wizard/shared/upgrade-sql.php
@@ -668,6 +668,24 @@ SQL
   ],
   [
     'version' => 'v1.9.21',
-    'default-sql' => ''
+    // Ensure webcal_user.cal_passwd is wide enough for a bcrypt hash (60
+    // chars). The original widening lived only in the v1.9.0 block, so any
+    // database already past v1.9.0 with a still-narrow column (e.g. a legacy
+    // VARCHAR(32) sized for MD5) never got widened. On the first login after
+    // upgrade, user_valid_login() rehashes the password to bcrypt; writing 60
+    // chars into that column fails on strict-mode MySQL/MariaDB and aborts the
+    // login with "Error executing query." Widen it here so every upgrade path
+    // is covered. Re-running MODIFY on an already-VARCHAR(255) column is a
+    // harmless no-op.
+    'default-sql' => <<<'SQL'
+ALTER TABLE webcal_user MODIFY cal_passwd VARCHAR(255);
+SQL,
+    'postgresql-sql' => <<<'SQL'
+ALTER TABLE webcal_user ALTER COLUMN cal_passwd TYPE VARCHAR(255);
+SQL,
+    // SQLite does not enforce VARCHAR length (column types are dynamic), so no
+    // change is needed. An explicit empty entry prevents the default-sql
+    // (MySQL MODIFY) fallback, which SQLite cannot parse.
+    'sqlite3-sql' => ''
   ],
 ];


### PR DESCRIPTION
Fixes #676.

## Summary

Upgrading from v1.9.12 (or any database already past v1.9.0) could fail with a bare `Error executing query.` page on the **first login after the upgrade wizard finished**, with nothing logged anywhere.

**Root cause:** `webcal_user.cal_passwd` was left at a narrow width (e.g. `VARCHAR(32)`, sized for MD5) because the widening to `VARCHAR(255)` was gated **only in the v1.9.0 upgrade block** — so databases already past v1.9.0 skipped it. On first login, `user_valid_login()` rehashes the old MD5 password to a 60-char bcrypt hash; writing that into the narrow column is **rejected by strict-mode MySQL/MariaDB**, and `dbi_execute()`'s default fatal-on-error aborted the request. The underlying driver exception is swallowed by the MySQL branch, so nothing appeared in the PHP or DB logs (matching the reporter's observations exactly).

## Changes

**Fix A — `wizard/shared/upgrade-sql.php`:** widen `cal_passwd` to `VARCHAR(255)` in the latest upgrade block so every upgrade path is covered.
- MySQL: `ALTER TABLE webcal_user MODIFY cal_passwd VARCHAR(255)`
- PostgreSQL: `ALTER COLUMN cal_passwd TYPE VARCHAR(255)`
- SQLite: explicit empty entry (length-agnostic; avoids the MySQL `MODIFY` fallback it can't parse)
- Re-running `MODIFY` on an already-`VARCHAR(255)` column is a harmless no-op.

**Fix B — `includes/user.php`:** make the rehash `UPDATE` (and its revert) non-fatal, so a strict-mode narrow-column rejection falls through to the existing verify/revert recovery instead of killing the login. The user logs in normally; the password just stays in the old format until the column is widened.

**Tests — `tests/UpgradeSqlTest.php`:** assert the widening is emitted for a post-v1.9.0 upgrade on MySQL/PostgreSQL and is **not** sent to SQLite.

## Test plan

- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — full suite passes (656 tests)
- [x] New `UpgradeSqlTest` cases verify widening presence/absence per backend
- [ ] Manual: on a MariaDB DB whose `cal_passwd` is `varchar(32)`, run the wizard upgrade and confirm the column becomes `varchar(255)` and first login succeeds
- [ ] Manual (Fix B in isolation): with a deliberately narrow column, confirm login still succeeds (no `Error executing query`) and the password is left in MD5 form

## Notes

The diagnosis is confirmed by mechanism; the reporter has been asked on the issue to confirm their column width via `SHOW COLUMNS FROM webcal_user LIKE 'cal_passwd'` and whether a manual `ALTER` resolves it.