### PR TITLE
feat(mcp): show endpoint URL + sample agent config; add per-user MCP tab

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -789,7 +789,26 @@ if ( ! $error ) {
         <div class="form-inline mt-1 mb-2"><label for="admin_MCP_CORS_CUSTOM" title="' . tooltip ( 'mcp-cors-custom-help' ) . '">'
         . translate ( 'Custom Origins (comma-separated)' ) . ':</label>
         <input type="text" size="40" name="admin_MCP_CORS_CUSTOM" id="admin_MCP_CORS_CUSTOM" value="'
-        . htmlspecialchars ( (!empty($s['MCP_CORS_ORIGINS']) && $s['MCP_CORS_ORIGINS'] !== '*' && strpos($s['MCP_CORS_ORIGINS'], ',') !== false) ? $s['MCP_CORS_ORIGINS'] : '' ) . '" placeholder="https://example.com,https://another.com"></div>' )
+        . htmlspecialchars ( (!empty($s['MCP_CORS_ORIGINS']) && $s['MCP_CORS_ORIGINS'] !== '*' && strpos($s['MCP_CORS_ORIGINS'], ',') !== false) ? $s['MCP_CORS_ORIGINS'] : '' ) . '" placeholder="https://example.com,https://another.com"></div>'
+        . '<hr class="mt-2">'
+        . '<div class="mt-1"><strong>' . translate ( 'MCP Endpoint URL' ) . ':</strong> '
+        . '<code>' . htmlspecialchars ( getServerUrl() . 'mcp.php' ) . '</code></div>'
+        . '<p class="mt-1"><small>'
+        . translate ( 'Each user connects their AI agent with their own personal API token, generated on their Preferences MCP tab, where a ready-to-use sample configuration is shown.' )
+        . '</small></p>'
+        . '<details class="mt-1"><summary>' . translate ( 'Sample agent configuration' ) . '</summary>'
+        . '<pre class="border rounded p-2 mt-1" style="white-space:pre-wrap;">'
+        . htmlspecialchars ( '{
+  "mcpServers": {
+    "webcalendar": {
+      "url": "' . getServerUrl() . 'mcp.php",
+      "headers": {
+        "X-MCP-Token": "YOUR_MCP_TOKEN"
+      }
+    }
+  }
+}' )
+        . '</pre></details>' )
     . '</fieldset>
   </div></div>
 

--- a/pref.php
+++ b/pref.php
@@ -305,6 +305,7 @@ if ( $NONUSER_ENABLED == 'Y' || $PUBLIC_ACCESS == 'Y' ) {
 <?php if ( $ALLOW_COLOR_CUSTOMIZATION == 'Y' ) { ?>
   <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#colors"><?php etranslate('Colors');?></a></li>
 <?php } ?>
+<li class="nav-item"><a class="nav-link" data-toggle="tab" href="#mcp"><?php etranslate('MCP');?></a></li>
 
 </ul>
 
@@ -684,20 +685,6 @@ for ( $i = 0, $cnt = count ( $views ); $i < $cnt; $i++ ) {
   <nobr><input class="form-control" type="text" name="pref_AUTO_REFRESH_TIME" size="3" value="<?php echo ( empty ( $prefarray['AUTO_REFRESH_TIME'] ) ? 0 : $prefarray['AUTO_REFRESH_TIME'] ); ?>"> <?php etranslate ( 'minutes' )?></nobr>
  </td></tr>
 
- <tr><td data-toggle="tooltip" data-placement="top" title="<?php etooltip ("mcp-api-token-help");?>">
-  <label for="mcp_api_token"><?php etranslate ( 'MCP API Token' )?>:</label></td><td class="form-inline mt-1">
-<?php if ( ! empty ( $mcp_new_token ) ) { ?>
-  <input class="form-control" type="text" id="mcp_api_token_display" size="40" readonly value="<?php echo htmlspecialchars($mcp_new_token); ?>">
-  <div class="text-warning mt-1"><?php etranslate('Copy this token now. For security it is stored hashed and cannot be shown again.'); ?></div>
-<?php } else { ?>
-  <input class="form-control" type="text" id="mcp_api_token_display" size="40" readonly
-    value="<?php echo $mcp_token_is_set ? '************************ (token set)' : ''; ?>">
-<?php } ?>
-  <button type="button" class="btn btn-secondary ml-2" onclick="generateApiToken()"><?php etranslate('Generate New Token');?></button>
-<?php if ( $mcp_token_is_set || ! empty ( $mcp_new_token ) ) { ?>
-  <button type="button" class="btn btn-outline-danger ml-2" onclick="clearApiToken()"><?php etranslate('Clear Token');?></button>
-<?php } ?>
- </td></tr>
  </table>
 </fieldset>
 </div>
@@ -901,6 +888,46 @@ if ( $CUSTOM_TRAILER == 'Y' ) { ?>
 </div></div>
 <!-- END HEADER -->
 <?php } // if $ALLOW_USER_HEADER ?>
+
+<!-- BEGIN MCP -->
+<div class="tab-pane container fade" id="mcp"><div class="form-group">
+<fieldset class="border p-2">
+ <legend><?php etranslate ('MCP Server')?></legend>
+ <table style="border-collapse: separate; border-spacing: 1px; padding: 2px;">
+ <tr><td data-toggle="tooltip" data-placement="top" title="<?php etooltip ("mcp-api-token-help");?>">
+  <label for="mcp_api_token"><?php etranslate ( 'MCP API Token' )?>:</label></td><td class="form-inline mt-1">
+<?php if ( ! empty ( $mcp_new_token ) ) { ?>
+  <input class="form-control" type="text" id="mcp_api_token_display" size="40" readonly value="<?php echo htmlspecialchars($mcp_new_token); ?>">
+  <div class="text-warning mt-1"><?php etranslate('Copy this token now. For security it is stored hashed and cannot be shown again.'); ?></div>
+<?php } else { ?>
+  <input class="form-control" type="text" id="mcp_api_token_display" size="40" readonly
+    value="<?php echo $mcp_token_is_set ? '************************ (token set)' : ''; ?>">
+<?php } ?>
+  <button type="button" class="btn btn-secondary ml-2" onclick="generateApiToken()"><?php etranslate('Generate New Token');?></button>
+<?php if ( $mcp_token_is_set || ! empty ( $mcp_new_token ) ) { ?>
+  <button type="button" class="btn btn-outline-danger ml-2" onclick="clearApiToken()"><?php etranslate('Clear Token');?></button>
+<?php } ?>
+ </td></tr>
+ </table>
+<?php $mcp_endpoint = getServerUrl() . 'mcp.php'; ?>
+ <div class="mt-2"><strong><?php etranslate('MCP Endpoint URL')?>:</strong>
+  <code><?php echo htmlspecialchars($mcp_endpoint); ?></code></div>
+ <div class="mt-2"><strong><?php etranslate('Sample agent configuration')?>:</strong>
+  <div class="text-muted"><small><?php etranslate('Paste this into your AI agent MCP settings file (for example, mcp_settings.json).')?></small></div>
+<?php
+  $mcp_sample_token = ! empty ( $mcp_new_token ) ? $mcp_new_token : 'YOUR_MCP_TOKEN';
+  $mcp_sample = "{\n  \"mcpServers\": {\n    \"webcalendar\": {\n      \"url\": \""
+    . $mcp_endpoint . "\",\n      \"headers\": {\n        \"X-MCP-Token\": \""
+    . $mcp_sample_token . "\"\n      }\n    }\n  }\n}";
+?>
+  <pre class="border rounded p-2 mt-1" style="white-space:pre-wrap;"><?php echo htmlspecialchars($mcp_sample); ?></pre>
+<?php if ( empty ( $mcp_new_token ) ) { ?>
+  <div class="text-muted"><small><?php etranslate('Replace YOUR_MCP_TOKEN with a token generated above.')?></small></div>
+<?php } ?>
+ </div>
+</fieldset>
+</div></div>
+<!-- END MCP -->
 
 <!-- BEGIN COLORS -->
 


### PR DESCRIPTION
## Summary

Makes it easy to connect an AI agent to the WebCalendar MCP server without hand-writing client config.

**Admin → System Settings → MCP:** when the MCP server is available, shows the resolved **endpoint URL** and a collapsible **sample agent configuration** (HTTP transport with `X-MCP-Token`). Admin-facing reference only — token is a `YOUR_MCP_TOKEN` placeholder, never a real secret.

**Preferences:** moves the **MCP API Token** controls out of Settings → Miscellaneous into a dedicated **MCP** tab, and adds the endpoint URL plus a copy-paste `mcp_settings.json` sample.

## Details

- Endpoint URL derived via `getServerUrl()` (honors admin-configured `SERVER_URL`, falls back to request-derived) — same source the rest of the app uses.
- **Token handling preserved exactly:** masked when set, one-time reveal on generate, Generate/Clear buttons unchanged. Right after generation the sample is rendered with the real token inlined (same one-time reveal as the field); on normal loads it shows the placeholder, so no secret is persisted into the page.
- Featured **HTTP + `X-MCP-Token`** (the recommended transport per `mcp.php`). The STDIO `command`/`args` variant is intentionally omitted — its absolute filesystem path isn't reliably derivable across deploy setups (symlinks/fpm/containers), so a wrong path would be worse than none.

## Placement note

The new pane is inserted **before** the colors block so it is a direct child of `.tab-content` regardless of the `ALLOW_COLOR_CUSTOMIZATION` setting. (The colors pane's second closing `</div>` sits outside its `if`, so inserting after it would nest the new pane inside `#colors` when color customization is enabled.)

## Test plan

- [x] `php -l admin.php`, `php -l pref.php` — clean
- [x] Div-balance verified: `#mcp` opens at `.tab-content` depth 1 (sibling of other panes); overall balance unchanged
- [ ] Manual: Preferences → MCP tab switches correctly with color customization **on** and **off**
- [ ] Manual: Generate token → sample shows real token once; reload → masked + `YOUR_MCP_TOKEN`
- [ ] Manual: Admin MCP tab shows endpoint URL + sample when SDK available

## Follow-ups

- New `translate()` strings render as English until added to translation files (consistent with other untranslated phrases).
- The pre-existing fragile colors `</div>` placement is left as-is (out of scope) but is a trap for future tabs.