### PR TITLE
fix(pref): close #colors tab-pane and .tab-content divs correctly

### DIFF
--- a/pref.php
+++ b/pref.php
@@ -950,10 +950,11 @@ if ( $CUSTOM_TRAILER == 'Y' ) { ?>
 ?>
 <!-- END EXAMPLE MONTH -->
 </td></tr></table>
-</div>
+</div><!-- .form-group -->
+</div><!-- #colors .tab-pane -->
 <!-- END COLORS -->
 <?php } // if $ALLOW_COLOR_CUSTOMIZATION ?>
-</div>
+</div><!-- .tab-content -->
 
 <!-- END TABS -->
 <br><br>


### PR DESCRIPTION
## Summary

Fixes a latent markup bug in the preferences tab structure that recently bit the new MCP tab (#682).

The **Colors** tab-pane opens two `<div>`s (`tab-pane` + `form-group`) but closed only **one** inside its `if ($ALLOW_COLOR_CUSTOMIZATION)` block. The second `</div>` sat **outside** the conditional, doing double duty:

- **Color customization ON:** it closed the `#colors` pane — leaving `.tab-content` never explicitly closed (browser auto-closed it later).
- **Color customization OFF:** it closed `.tab-content`.

Because that `</div>` meant different things at runtime, any tab-pane inserted just before it nested **inside** `#colors` (which is `display:none` unless the Colors tab is active) instead of being a sibling pane — the exact bug that hid the MCP tab in #682 until it was moved earlier in the container.

## Fix

- Move the second `</div>` **inside** the `if` so the colors block is self-balanced (3 opens / 3 closes).
- Make the trailing `</div>` **unconditionally** close `.tab-content`.
- Added HTML comments on the closing tags to prevent recurrence.

No visual change: net div balance is unchanged for the colors-off path and corrected (`.tab-content` now closes) for colors-on.

## Verification

- [x] `php -l pref.php` clean
- [x] Colors `if`-block is self-balanced: 3 `<div>` / 3 `</div>`
- [x] `.tab-content` depth at `END TABS` = 0 with colors present (was 1)
- [ ] Manual: all preference tabs switch correctly with color customization **on** and **off**