### PR TITLE
fix(colors): live-preview updates + admin JS/layout fixes

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -217,10 +217,16 @@ if ( ! $error ) {
 
   foreach ( $colors as $k => $v ) {
     $GLOBALS[$k] = $s[$k];
-    // Change the color in the current page
-    $cch .= "      function color_change_handler_$k() {\n        var color = $('#admin_' + $k).val();\n\n        $('body').get(0).style.setProperty('--' + $k.toLowerCase, color);\n      }\n";
+    // CSS custom-property name for this color (matches styles.php :root, e.g.
+    // POPUP_BG -> --popupbg). The id/value must be baked into the emitted JS
+    // strings (not concatenated with a bare $k, which would be an undefined JS
+    // identifier), and the color value must be quoted (an unquoted #ffffff is a
+    // JS syntax error that would break the whole <script>).
+    $vn = str_replace ( '_', '', strtolower ( $k ) );
+    // Change the color in the current page live as the user edits it.
+    $cch .= "      function color_change_handler_$k() {\n        var color = $('#admin_" . $k . "').val();\n        $('body').get(0).style.setProperty('--" . $vn . "', color);\n      }\n";
     $color_sets .= print_color_input_html ( $k, $v, '', '', 'p', '', 'color_change_handler_' . $k );
-    $rc .= "\n        $('#admin_' + $k).val(" . $GLOBALS[$k] . ");\n        $('body').get(0).style.setProperty('--' + $k.toLowerCase, '" . $GLOBALS[$k] . "');\n";
+    $rc .= "\n        $('#admin_" . $k . "').val('" . $GLOBALS[$k] . "');\n        $('body').get(0).style.setProperty('--" . $vn . "', '" . $GLOBALS[$k] . "');\n";
   }
 
   $csp = ( $s['CSP'] ?: 'none' );
@@ -898,10 +904,10 @@ if ( ! $error ) {
           <fieldset class="border p-2">
             <legend>' . translate ( 'Color options' ) . '</legend>
 <!-- BEGIN EXAMPLE MONTH -->
-            <p style="float:right; width:45%; margin:0; background: var(--background)">
+            <div style="float:right; width:45%; margin:0; background: var(--bgcolor)">
               <p id="monthtitle" class="bold" style="text-align:center; color: var(--h2color)">' . date_to_str ( date ( 'Ymd' ), $DATE_FORMAT_MY, false ) . '</p>'
    . display_month ( date ( 'm' ), date ( 'Y' ), true ) . '
-
+            </div>
 <!-- END EXAMPLE MONTH -->
             <p class="form-inline mt-1 mb-2"><label>' . translate ( 'Allow user to customize colors' )
    . ':</label>' . print_radio ( 'ALLOW_COLOR_CUSTOMIZATION' ) . '</p>

--- a/admin.php
+++ b/admin.php
@@ -904,7 +904,7 @@ if ( ! $error ) {
           <fieldset class="border p-2">
             <legend>' . translate ( 'Color options' ) . '</legend>
 <!-- BEGIN EXAMPLE MONTH -->
-            <div style="float:right; width:45%; margin:0; background: var(--bgcolor)">
+            <div class="colorpreview" style="float:right; width:45%; margin:0; background: var(--bgcolor)">
               <p id="monthtitle" class="bold" style="text-align:center; color: var(--h2color)">' . date_to_str ( date ( 'Ymd' ), $DATE_FORMAT_MY, false ) . '</p>'
    . display_month ( date ( 'm' ), date ( 'Y' ), true ) . '
             </div>

--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -670,6 +670,17 @@ tr.highlight td {
   background-color: var(--weeknumber) !important;
 }
 
+/* Color-picker live preview: strip the server-baked gradient images from the
+ * sample month so the var(--*) background-colors set in styles.php show through
+ * and update live as the user edits a color. Without this, when
+ * ENABLE_GRADIENTS is on, the gradient image overlays and masks the color
+ * change. Scoped to .colorpreview (the sample-month container in admin.php /
+ * pref.php) so the real calendar keeps its gradients. */
+.colorpreview .main td,
+.colorpreview .main th {
+  background-image: none !important;
+}
+
 #admin table,
 #pref table {
   vertical-align:top;

--- a/includes/css/styles.php
+++ b/includes/css/styles.php
@@ -186,7 +186,7 @@ if ( $DISPLAY_TASKS != 'Y' ) { ?>
 
 <?php if (  $MENU_ENABLED == 'N' ) { ?>
 #dateselector form {
-  border-top: 0.0625em solid <?php echo $GLOBALS['TABLEBG'];?>;
+  border-top: 0.0625em solid var(--tablebg, <?php echo $GLOBALS['TABLEBG'];?>);
 }
 <?php } ?>
 
@@ -196,52 +196,52 @@ body {
   background-repeats: '<?php echo$GLOBALS['BGREPEAT'];?>' );
 }
 .popup {
-  <?php echo background_css( $GLOBALS['POPUP_BG'], 200 ); ?>
+  <?php echo background_css( $GLOBALS['POPUP_BG'], 200, '', 'popupbg' ); ?>
 }
 <?php } ?>
 .main th,
 .main th.weekend {
-  <?php echo background_css( $GLOBALS['THBG'], 15 );?>
+  <?php echo background_css( $GLOBALS['THBG'], 15, '', 'thbg' );?>
 }
 .main td {
-  <?php echo background_css( $GLOBALS['CELLBG'], 100 ); ?>
+  <?php echo background_css( $GLOBALS['CELLBG'], 100, '', 'cellbg' ); ?>
 }
 .main td.weekend {
-  <?php echo background_css( $GLOBALS['WEEKENDBG'], 100 ); ?>
+  <?php echo background_css( $GLOBALS['WEEKENDBG'], 100, '', 'weekendbg' ); ?>
 }
 <?php if  ( $GLOBALS['HASEVENTSBG'] != $GLOBALS['CELLBG'] ) { ?>
 .main td.hasevents {
-  <?php echo background_css( $GLOBALS['HASEVENTSBG'], 100 ); ?>
+  <?php echo background_css( $GLOBALS['HASEVENTSBG'], 100, '', 'haseventsbg' ); ?>
 }
 <?php } ?>
 .main td.othermonth {
-  <?php echo background_css( $GLOBALS['OTHERMONTHBG'], 100 ); ?>
+  <?php echo background_css( $GLOBALS['OTHERMONTHBG'], 100, '', 'othermonthbg' ); ?>
 }
 .main td.today, #datesel td #today {
-  <?php echo background_css( $GLOBALS['TODAYCELLBG'], 100 ); ?>
+  <?php echo background_css( $GLOBALS['TODAYCELLBG'], 100, '', 'todaycellbg' ); ?>
 }
 #admin .main td.weekcell,
 #monthx .main td.weekcell,
 #pref .main td.weekcell,
 #viewl .main td.weekcell {
-  <?php echo background_css( $GLOBALS['THBG'], 50 ); ?>
+  <?php echo background_css( $GLOBALS['THBG'], 50, '', 'thbg' ); ?>
 }
 .glance td,
 .note {
-  <?php echo background_css( $GLOBALS['CELLBG'], 50 );?>
+  <?php echo background_css( $GLOBALS['CELLBG'], 50, '', 'cellbg' );?>
 }
 #viewt .main th.weekend {
-  <?php echo background_css( $GLOBALS['WEEKENDBG'], 15 );?>
+  <?php echo background_css( $GLOBALS['WEEKENDBG'], 15, '', 'weekendbg' );?>
 }
 #login table,
 #register table {
-  <?php echo background_css( $GLOBALS['CELLBG'], 200 );?>
+  <?php echo background_css( $GLOBALS['CELLBG'], 200, '', 'cellbg' );?>
 }
 #securityAuditNotes {
-  <?php echo background_css( $GLOBALS['CELLBG'], 150 );?>
+  <?php echo background_css( $GLOBALS['CELLBG'], 150, '', 'cellbg' );?>
 }
 #viewt td.entry {
-  <?php echo background_css( $GLOBALS['THBG'], 10 );?>
+  <?php echo background_css( $GLOBALS['THBG'], 10, '', 'thbg' );?>
 }
 #minicalendar th,
 #minicalendar td {

--- a/includes/gradient.php
+++ b/includes/gradient.php
@@ -151,7 +151,7 @@ function can_write_to_dir ($path)
 /**
  * background_css (needs description)
  */
-function background_css ( $base, $height = '', $percent = '' ) {
+function background_css ( $base, $height = '', $percent = '', $varname = '' ) {
   global $ENABLE_GRADIENTS;
 
   $ret = $type = '';
@@ -161,9 +161,17 @@ function background_css ( $base, $height = '', $percent = '' ) {
   elseif ( function_exists ( 'imagegif' ) )
     $type = '.gif';
 
+  // Live-preview support: when a CSS custom-property name is supplied, render
+  // the color as var(--name, <baked-color>). The baked color stays as the
+  // fallback, so normal rendering is unchanged, but a client-side color picker
+  // (see color_change_handler_* in pref.php/admin.php) can override --name to
+  // update the page without a reload. The gradient image (if enabled) is still
+  // generated from the baked color and does not update live.
+  $color = ( $varname != '' ? 'var(--' . $varname . ', ' . $base . ')' : $base );
+
   $ret = 'background';
   if ( $type != '' && $ENABLE_GRADIENTS == 'Y' ) {
-    $ret .= ': ' . $base . ' url( ';
+    $ret .= ': ' . $color . ' url( ';
     if ( ! file_exists ( 'images/cache' ) || ! can_write_to_dir ( 'images/cache/' ) )
       $ret .= 'includes/gradient.php?base=' . substr ( $base, 1 )
        . ( $height != '' ? '&height=' . $height : '' )
@@ -179,7 +187,7 @@ function background_css ( $base, $height = '', $percent = '' ) {
     }
     $ret .= ' ) repeat-x';
   } else
-    $ret .= '-color: ' . $base;
+    $ret .= '-color: ' . $color;
 
   return $ret . ';';
 }

--- a/pref.php
+++ b/pref.php
@@ -971,7 +971,7 @@ etranslate ( 'Save Preferences' )?></button>
 foreach ( $colors as $k => $v ) {
   echo "function color_change_handler_$k() {\n";
     echo "  var color = $('#pref_" . $k . "').val();\n";
-    echo "  $('body').get(0).style.setProperty('--" . strtolower($k) . "', color);\n";
+    echo "  $('body').get(0).style.setProperty('--" . str_replace( '_', '', strtolower( $k ) ) . "', color);\n";
   echo "}\n";
 }
 ?>
@@ -979,7 +979,7 @@ foreach ( $colors as $k => $v ) {
 function reset_colors() {
   <?php
     foreach ( $colors as $k => $v ) {
-      echo "  $('body').get(0).style.setProperty('--" . strtolower($k) . "', '$GLOBALS[$k]');\n";
+      echo "  $('body').get(0).style.setProperty('--" . str_replace( '_', '', strtolower( $k ) ) . "', '$GLOBALS[$k]');\n";
       echo "  $('#pref_" . $k . "').val('$GLOBALS[$k]');\n";
     }
   ?>

--- a/pref.php
+++ b/pref.php
@@ -939,7 +939,7 @@ if ( $CUSTOM_TRAILER == 'Y' ) { ?>
 <div><a href="#" class="btn btn-secondary" onclick="reset_colors(); return false;"><?php etranslate('Reset Colors');?></a></div>
 
 
-</td><td class="aligncenter aligntop" style="inline-size: 50%">
+</td><td class="aligncenter aligntop colorpreview" style="inline-size: 50%">
 <br>
 <!-- BEGIN EXAMPLE MONTH -->
 <p class="bold" style="text-align:center; color: var(--h2color)">


### PR DESCRIPTION
## Summary

The **color tab live preview** (change a color on the left → the sample month on the right updates) did not work in **either** `pref.php` or `admin.php`, and `admin.php` threw JS console errors.

### Root causes
1. **Dead preview (both pages).** `styles.php` (served via `css_cacher.php`) bakes the `.main td` family of backgrounds as literal colors through `background_css()`, and `styles.css` has no var-based override for those selectors — so the handler's `setProperty('--cellbg', …)` had nothing to affect. (`styles.css` is otherwise heavily var-based, so most other colors were already wired.)
2. **admin.php invalid JS (your console errors).** It emitted an unquoted color value — `.val(#ffffff)` → `SyntaxError: Private field '#ffffff'`, which aborted the whole `<script>` so **no** `color_change_handler_*` was defined (→ `ReferenceError: color_change_handler_MYEVENTS is not defined`). Also `+ $k` (undefined JS identifier) and `$k.toLowerCase` (undefined, never called).
3. **Var-name mismatch.** JS used `strtolower($k)` → `--popup_fg`/`--popup_bg`, but `:root`/`styles.css` use `--popupfg`/`--popupbg`.
4. **admin.php layout.** The preview was wrapped in `<p style="float:right">…<table>…`, which is invalid (a `<table>` auto-closes the `<p>`), collapsing the float so the month rendered *above* the inputs.

### Fixes
- `background_css()` gains an optional CSS-var-name arg and emits `var(--name, <baked-color>)`. **The baked color stays as the fallback, so normal rendering is byte-for-byte unchanged** — only live-updatability is added. (Gradient *images*, when enabled, are still baked and don't update live.)
- `styles.php` passes the var name to every `background_css()` call + the one direct border color.
- `pref.php`/`admin.php` derive the var name via `str_replace('_','',strtolower($k))` so `POPUP_*` matches `:root`/`styles.css`.
- `admin.php` JS: bake the id into the selector and quote the color value.
- `admin.php` layout: `<div>` wrapper so the float is valid; preview sits to the right with a full month.

## Test plan

- [x] `php -l` on all 4 changed files; `tests/compile_test.sh` → 272 files ok
- [x] `phpunit` → 656 tests pass
- [x] Verified `background_css(color,100,'','cellbg')` → `background-color: var(--cellbg, <color>)`; no-varname call unchanged
- [x] Verified admin JS now generates valid, quoted output (`--popupbg`, quoted `.val('#…')`)
- [ ] Manual: on both admin and pref color tabs, changing each color updates the preview live; Reset restores; page still renders identically on load

## Notes
- The one remaining non-live case is when **gradients are enabled** — the base color updates live but the generated gradient overlay image stays until save/reload. Called out in the code comment.
- Independent of #683 (colors-tab `<div>` structure); no file-region overlap.