### PR TITLE
fix(css): lowercase <body> id so page-specific styles apply (needs visual QA)

### DIFF
--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -959,7 +959,7 @@ th.day_glance_time {
   font-size:.75rem;
 }
 #viewl .main td,
-#month .main td, #Month #month_main td {
+#month .main td, #month #month_main td {
   height:6.0rem;
   font-size:.75rem;
   vertical-align:top;
@@ -1063,10 +1063,10 @@ table#prevmonth {
 #viewt table.timebar th {
   width:10%;
 }
-#ViewT div table th {
+#viewt div table th {
   width:10%;
 }
-#ViewT div table td {
+#viewt div table td {
   width:90%;
 }
 #viewt table.timebar dh {

--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -1253,37 +1253,13 @@ table#prevmonth {
 .layertable td {
   padding:.3125rem 1.25rem;
 }
-#layers #layertable th {
-  background-color: #000080;
-  border: 2px outset #000060;
-  color: #ffffff;
-  font-size: 1.0rem;
-  padding: 4px;
-  /*padding-left: 20px;*/
-}
-#layers #layertable td.odd {
-  background-color: #c0c0c0;
-  border: 2px outset #c0c0c0;
-  color: #000000;
-  font-size: 1.0rem;
-  padding: 4px;
-  cursor:pointer;
-}
-#layers #layertable td.even {
-  background-color: #d8d8d8;
-  border: 2px outset #d8d8d8;
-  color: #000000;
-  font-size: 1.0rem;
-  padding: 4px;
-  cursor:pointer;
-}
-#layers #layertable .colorsample {
-  margin-left: 5px;
-  padding-left: 10px;
-  width: 20px;
-  height: 20px;
-  border: 1px solid #000000;
-}
+/* NOTE: the legacy #layers #layertable rules (navy outset header, gray
+ * odd/even cells) were removed here. The layer list is now a Bootstrap
+ * ".table table-striped" table (see the JS in layers.php) and the JS no longer
+ * emits td.odd/td.even, so those pre-Bootstrap rules only fought the Bootstrap
+ * styling (navy/outset header). They had been dormant for years because the
+ * body id was CamelCase; lowercasing it (so other page CSS works) revived them
+ * on this page, hence the removal. */
 .fakebutton {
    border:2px #d0d0d0 outset;
    /*border-color:#e0e0e0 #808080 #808080 #e0e0e0;*/

--- a/includes/init.php
+++ b/includes/init.php
@@ -330,12 +330,16 @@ function print_header ( $includes = '', $HeadX = '', $BodyX = '',
 
   $id = preg_replace ( '/.php/', '',
     substr ( $self, strrpos ( $self, '/' ) + 1 ) );
-  $id_ar = explode ( '_', $id );
 
-  // classes and ids are supposed to be UpperCamelCase, per Developer Guide
-  $id = array_map ( 'ucfirst', $id_ar );
+  // Body id mirrors the script name with underscores removed and forced to
+  // lowercase (admin.php -> "admin", view_t.php -> "viewt"). The page-specific
+  // selectors in includes/css/styles.css (#admin, #pref, #day, #viewt, ...) are
+  // lowercase, so this MUST stay lowercase for them to match. (Previously this
+  // used ucfirst() to produce UpperCamelCase ids, which silently disabled all
+  // of that page-specific CSS since CSS id selectors are case-sensitive.)
+  $id = strtolower ( str_replace ( '_', '', $id ) );
 
-  echo implode ( '', $id ) .
+  echo $id .
     ( translate ( 'direction' ) === 'rtl' ? '" dir="rtl"' : '"' )
     // Add any extra parts to the <body> tag.
     . " $BodyX>\n"


### PR DESCRIPTION
> **Draft — needs visual QA before merge.** The diff is 2 files / ~5 lines, but it reactivates ~164 dormant CSS rules across ~15 pages, so appearance changes must be eyeballed.

## Problem

`print_header()` (`includes/init.php`) built the `<body>` id with `ucfirst()`:
- `admin.php` → `<body id="Admin">`, `pref.php` → `Pref`, `view_t.php` → `ViewT`, etc.

But the page-specific selectors in `includes/css/styles.css` are **lowercase** (`#admin`, `#pref`, `#day`, `#viewt`, …). CSS id selectors are **case-sensitive**, so all of that page-specific CSS has been **silently dead since the `ucfirst()` was added** — commit `3c39b14c`, **2024-06-18** (~2 years). It's also why the color-picker sample month couldn't use its intended flat-override rules.

## Fix

- `init.php`: emit the body id lowercase (underscores stripped) — `admin`, `pref`, `viewt`, …
- `styles.css`: lowercase the two selectors that had been hand-migrated to CamelCase to compensate: `#Month` → `#month`, `#ViewT` → `#viewt`.

## Blast radius

- **Activates ~164 dead rules** across: `#pref` (32), `#admin` (25), `#day` (19), `#viewt` (15+6 print), `#viewl` (8), `#adminhome` (8), `#week` (7), `#month` (7), `#viewv` (6), `#viewr` (6), `#year` (5), `#vieww` (5), `#viewm` (4), `#activitylog` (4), `#layers` (4).
- **No JS/PHP** references the body id in any casing → zero scripting impact.
- **Element ids** (`#month_main`, `#datesel`, …) are literal in the HTML → unaffected.

## Verification done

- [x] `php -l includes/init.php` clean
- [x] `tests/compile_test.sh` → 272 files ok
- [x] `phpunit` → 656 tests pass
- [x] Confirmed served body ids are now lowercase (`pref`/`month`/`admin`)
- [x] No CamelCase page-id selectors remain in any CSS

## Visual QA checklist (before un-drafting)

Spot-check layout/spacing/colors on each page — these had page-specific CSS dead for ~2 years, so watch for rules that now **collide** with newer Bootstrap styling:

- [ ] `admin.php` (System Settings — all tabs)
- [ ] `pref.php` (Preferences — all tabs, incl. color preview)
- [ ] `adminhome.php`
- [ ] `day.php`, `week.php`, `month.php`, `year.php`
- [ ] `view_t.php`, `view_l.php`, `view_v.php`, `view_r.php`, `view_w.php`, `view_m.php`
- [ ] `activity_log.php`
- [ ] `layers.php`

If any page regresses, the fix is to adjust that page's now-active rules (not to revert the id), since lowercase is the correct, consistent direction.