### PR TITLE
fix(layers): open edit-layer dialog via Bootstrap modal API

### DIFF
--- a/layers.php
+++ b/layers.php
@@ -200,6 +200,7 @@ if ($single_user == 'N') {
         </div>
       </div>
     </div>
+  </div>
 
 <script>
   $(document).ready(function() {

--- a/layers.php
+++ b/layers.php
@@ -154,7 +154,7 @@ if ($single_user == 'N') {
   </form>
 
   <div id="edit-layer-dialog" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
+    <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 id="edit-layer-title" class="modal-title">Modal title</h5>

--- a/layers.php
+++ b/layers.php
@@ -158,7 +158,7 @@ if ($single_user == 'N') {
       <div class="modal-content">
         <div class="modal-header">
           <h5 id="edit-layer-title" class="modal-title">Modal title</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="$('#edit-layer-dialog').hide();">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
@@ -186,14 +186,14 @@ if ($single_user == 'N') {
             </table>
             <div class="modal-footer">
               <button class="btn btn-secondary" data-dismiss="modal"
- type="button" onclick="$('#edit-layer-dialog').hide();"><?php
+ type="button"><?php
  etranslate ( 'Cancel' ); ?></button>
               <button class="btn btn-danger" id="editLayerDeleteButton"
  type="button" onclick="if ( confirm ( '<?php echo $areYouSureStr; ?>' ) ) {
  $('#editLayerDelete').prop ('value', '1'); edit_window_closed();
- $('#edit-layer-dialog').hide(); }"><?php etranslate ( 'Delete' ); ?></button>
+ $('#edit-layer-dialog').modal('hide'); }"><?php etranslate ( 'Delete' ); ?></button>
               <button class="btn btn-primary" data-dismiss="modal" type="button"
- onclick="edit_window_closed(); $('#edit-layer-dialog').hide();"><?php
+ onclick="edit_window_closed();"><?php
  etranslate ( 'Save' ) ?></button>
             </div>
           </form>
@@ -377,7 +377,7 @@ if ($single_user == 'N') {
     else
       $('#editLayerDups').prop("checked", false);
 
-    $('#edit-layer-dialog').show();
+    $('#edit-layer-dialog').modal('show');
   }
 </script>
 


### PR DESCRIPTION
## Summary

The "Edit Layer" dialog in `layers.php` rendered with broken layout — no
backdrop, and the page content below it collapsed/displaced when the dialog
opened. Two independent bugs were responsible:

### 1. Unclosed modal `<div>` (structural — the primary cause)

The outer `<div id="edit-layer-dialog" class="modal">` was **never closed**.
Only `modal-dialog`, `modal-content`, `modal-body`, `modal-header`, and
`modal-footer` had matching `</div>` tags. As a result, everything after the
modal — the trailing `<script>` and all of `print_trailer()`'s output (the
"Page Last Updated" footer and remaining layout) — was nested *inside* the
modal element. While the modal was `display:none` the footer was hidden with
it; once shown, the whole page layout collapsed into the modal box and no
backdrop covered the page.

Fix: add the missing `</div>`.

### 2. Shown via jQuery `.show()` instead of Bootstrap's modal API (behavioral)

The dialog is Bootstrap 4 `.modal` markup but was opened with
`$('#edit-layer-dialog').show()` and closed with `.hide()`. Plain `.show()`
only sets `display:block` — it never engages Bootstrap's modal machinery, so
there is no backdrop, no body scroll-lock, and no ARIA state.

Fix: use `.modal('show')` / `.modal('hide')`. Save/Cancel/X already carry
`data-dismiss="modal"`, so their redundant `.hide()` onclicks were removed and
Bootstrap tears down the backdrop itself. Delete has no `data-dismiss` (its
close is gated on `confirm()`), so it uses an explicit `.modal('hide')`.

Bootstrap v4.6.2 (jQuery bundle) is loaded via `includes/load_assets.php`, so
`.modal()` is available on the page. The same API is already used successfully
for `#catModal` in `includes/js/edit_entry.php`.

## Scope

`layers.php` only. Pre-existing bug, independent of the body-id/CSS work in
the separate #685 branch. No CSS or new markup structure.

## Test plan

- [ ] Open `layers.php` (multi-user mode), click a layer → dialog is a centered
      overlay with a dimmed backdrop; page content behind is undisturbed.
- [ ] Save → dialog closes, backdrop gone, list reloads with the change.
- [ ] Cancel and X → dialog closes cleanly, no leftover backdrop.
- [ ] Delete → confirm prompt, then dialog closes and layer is removed.
- [ ] "Add Layer" (id < 0) → Delete button disabled, Save adds the layer.
