### PR TITLE
ci: make flaky MySQL/PostgreSQL Selenium wizard tests non-blocking

### DIFF
--- a/.github/workflows/test-web-wizard.yml
+++ b/.github/workflows/test-web-wizard.yml
@@ -74,6 +74,9 @@ jobs:
   test_web_wizard_mysql:
     name: Test WebCalendar wizard MySQL (Selenium)
     runs-on: ubuntu-latest
+    # TODO: Selenium wizard tests are flaky; kept non-blocking for now.
+    # Re-enable as a required check once the harness is stabilized.
+    continue-on-error: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -94,6 +97,9 @@ jobs:
   test_web_wizard_postgresql:
     name: Test WebCalendar wizard PostgreSQL (Selenium)
     runs-on: ubuntu-latest
+    # TODO: Selenium wizard tests are flaky; kept non-blocking for now.
+    # Re-enable as a required check once the harness is stabilized.
+    continue-on-error: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

The **MySQL** and **PostgreSQL** Selenium wizard jobs in
`test-web-wizard.yml` intermittently fail on PRs that have nothing to do with
installation (browser-automation flakiness, not real regressions). This has
forced `--admin` overrides to merge otherwise-green PRs (e.g. #683, #684).

This marks both jobs `continue-on-error: true`: they still run and still upload
failure screenshots, but they no longer block merges.

## What stays blocking

- **SQLite (Selenium)** — kept as a required gate; it has been reliable.
- All non-Selenium jobs (fresh install, upgrade, install+login, PHPUnit,
  PHPStan, lint, MCP, build).

## Reversibility

Temporary. Each job carries a `TODO` comment; remove the two
`continue-on-error: true` lines to restore them as required checks once the
Selenium harness is stabilized.

## Test plan

- [ ] This PR's own checks: MySQL/PostgreSQL Selenium show green (neutral) even
      if the underlying run fails; SQLite Selenium still gates.
