### PR TITLE
fix: render Month/Week/Year date selectors at the bottom when configured

### DIFF
--- a/includes/css/styles.css
+++ b/includes/css/styles.css
@@ -227,19 +227,10 @@ img.color {
 #cat {
   font-size:1.125rem;
 }
-#dateselector,
 #trailer {
   margin:0;
   padding:0;
 }
-#dateselector form {
-  float:left;
-  width:33%;
-  margin-top:.3125rem;
-  margin-bottom:1.5625rem;
-  padding-top:.3125rem;
-}
-#dateselector label,
 #trailer label {
   margin:0;
   padding:0;

--- a/includes/css/styles.php
+++ b/includes/css/styles.php
@@ -184,11 +184,10 @@ if ( $DISPLAY_TASKS != 'Y' ) { ?>
   ? '10em' : $GLOBALS['MINICALWIDTH']; ?>;
 }
 
-<?php if (  $MENU_ENABLED == 'N' ) { ?>
-#dateselector form {
+/* Only present when the date selectors are rendered below the calendar. */
+#dateselector {
   border-top: 0.0625em solid var(--tablebg, <?php echo $GLOBALS['TABLEBG'];?>);
 }
-<?php } ?>
 
 <?php if ( ! empty ( $GLOBALS['BGIMAGE'] ) ) { ?>
 body {

--- a/includes/date_selectors.php
+++ b/includes/date_selectors.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Month/Week/Year date selectors.
+ *
+ * Shared by the Bootstrap top menu (includes/menu.php) and by print_trailer()
+ * (includes/init.php) so the selectors can be placed at the top or the bottom
+ * of the page. Which one is used depends on the MENU_DATE_TOP setting, and on
+ * MENU_ENABLED: with the top menu switched off there is no navbar to hold the
+ * selectors, so they always fall through to the trailer.
+ *
+ * @author Craig Knudsen <cknudsen@cknudsen.com>
+ * @copyright Craig Knudsen, <cknudsen@cknudsen.com>, http://www.k5n.us/cknudsen
+ * @license https://gnu.org/licenses/old-licenses/gpl-2.0.html GNU GPL
+ * @package WebCalendar
+ */
+defined('_ISVALID') or die('You cannot access this file directly!');
+
+/**
+ * Generates the Month, Week and Year dropdowns.
+ *
+ * @return string  HTML for a navbar list holding the three dropdowns.
+ */
+function date_selectors_html()
+{
+  global $thisday, $thismonth, $thisyear;
+
+  $d = (empty($thisday) ? date('d') : $thisday);
+  $m = (empty($thismonth) ? date('m') : $thismonth);
+  $y = (empty($thisyear) ? date('Y') : $thisyear);
+
+  return '<ul class="navbar-nav flex-row mxr-auto">' . "\n"
+    . date_selector_month($m, $y)
+    . date_selector_week($d, $m, $y)
+    . date_selector_year($y)
+    . "</ul>\n";
+}
+
+/**
+ * Generates the Month dropdown: the tail of last year, all of this year and
+ * the start of next year.
+ *
+ * A dropdown-submenu version covering more years was attempted and abandoned
+ * because Bootstrap v4 does not position the submenu correctly. See the
+ * commented-out blocks removed from includes/menu.php in the commit that
+ * created this file, and the related TODO in print_trailer().
+ *
+ * @param int $thismonth  Month currently being viewed (1-12)
+ * @param int $thisyear   Year currently being viewed
+ *
+ * @return string  HTML for a single navbar dropdown.
+ */
+function date_selector_month($thismonth, $thisyear)
+{
+  $ret = date_selector_open('Month', 'dateSelectorMonth');
+
+  // Last 4 months of the prior year.
+  $ret .= '<h6 class="dropdown-header">' . ($thisyear - 1) . "</h6>\n";
+  for ($i = 9; $i <= 12; $i++) {
+    $ret .= date_selector_item('month.php',
+      sprintf('%04d%02d01', $thisyear - 1, $i), month_name($i - 1));
+  }
+  // All of this year, with the current month in bold.
+  $ret .= '<div class="dropdown-divider"></div>' . "\n"
+    . '<h6 class="dropdown-header">' . $thisyear . "</h6>\n";
+  for ($i = 1; $i <= 12; $i++) {
+    $name = month_name($i - 1);
+    if ($i == $thismonth)
+      $name = '<b>' . $name . '</b>';
+
+    $ret .= date_selector_item('month.php',
+      sprintf('%04d%02d01', $thisyear, $i), $name);
+  }
+  // First 3 months of next year.
+  $ret .= '<div class="dropdown-divider"></div>' . "\n"
+    . '<h6 class="dropdown-header">' . ($thisyear + 1) . "</h6>\n";
+  for ($i = 1; $i <= 3; $i++) {
+    $ret .= date_selector_item('month.php',
+      sprintf('%04d%02d01', $thisyear + 1, $i), month_name($i - 1));
+  }
+
+  return $ret . date_selector_close();
+}
+
+/**
+ * Generates the Week dropdown: 5 weeks before and 9 weeks after the week
+ * currently being viewed.
+ *
+ * @param int $d  Day currently being viewed
+ * @param int $m  Month currently being viewed
+ * @param int $y  Year currently being viewed
+ *
+ * @return string  HTML for a single navbar dropdown.
+ */
+function date_selector_week($d, $m, $y)
+{
+  global $DISPLAY_WEEKENDS;
+
+  $ret = date_selector_open('Week', 'dateSelectorWeek');
+
+  $lastDay = ($DISPLAY_WEEKENDS == 'N' ? 4 : 6);
+  $thisdate = date('Ymd', mktime(0, 0, 0, $m, $d, $y));
+  $wkstart = get_weekday_before($y, $m, $d);
+  for ($i = -5; $i <= 9; $i++) {
+    $twkstart = bump_local_timestamp($wkstart, 0, 0, 0, 0, 7 * $i, 0);
+    $twkend = bump_local_timestamp($twkstart, 0, 0, 0, 0, $lastDay, 0);
+    // Skip weeks that fall outside the range we can represent.
+    if ($twkstart <= 0 || $twkend >= 2146021200)
+      continue;
+
+    $dateSYmd = date('Ymd', $twkstart);
+    $dateEYmd = date('Ymd', $twkend);
+    $name = (!empty($GLOBALS['PULLDOWN_WEEKNUMBER'])
+      && $GLOBALS['PULLDOWN_WEEKNUMBER'] == 'Y'
+      ? '(' . date('W', $twkstart + 86400) . ')&nbsp;&nbsp;' : '')
+      . sprintf('%s - %s',
+        date_to_str($dateSYmd, '__mon__ __dd__', false, true),
+        date_to_str($dateEYmd, '__mon__ __dd__', false, true));
+    if ($thisdate >= $dateSYmd && $thisdate <= $dateEYmd)
+      $name = '<b>' . $name . '</b>';
+
+    $ret .= date_selector_item('week.php', $dateSYmd, $name);
+  }
+
+  return $ret . date_selector_close();
+}
+
+/**
+ * Generates the Year dropdown: 5 years either side of the year currently
+ * being viewed.
+ *
+ * @param int $thisyear  Year currently being viewed
+ *
+ * @return string  HTML for a single navbar dropdown.
+ */
+function date_selector_year($thisyear)
+{
+  $ret = date_selector_open('Year', 'dateSelectorYear');
+
+  for ($i = -5; $i <= 5; $i++) {
+    $name = $thisyear + $i;
+    if ($i == 0)
+      $name = '<b>' . $name . '</b>';
+
+    $ret .= date_selector_item('year.php',
+      sprintf('%04d0101', $thisyear + $i), $name);
+  }
+
+  return $ret . date_selector_close();
+}
+
+/**
+ * Generates the opening tags of one navbar dropdown.
+ *
+ * @param string $label  Untranslated dropdown label
+ * @param string $id     Unique element id, used to label the dropdown menu
+ *
+ * @return string  HTML
+ */
+function date_selector_open($label, $id)
+{
+  return '<li class="nav-item dropdown">' . "\n"
+    . '<a class="nav-link dropdown-toggle" href="#" id="' . $id . '"'
+    . ' data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">'
+    . translate($label) . "</a>\n"
+    . '<ul class="dropdown-menu" aria-labelledby="' . $id . '">' . "\n";
+}
+
+/**
+ * Generates the closing tags of one navbar dropdown.
+ *
+ * @return string  HTML
+ */
+function date_selector_close()
+{
+  return "</ul>\n</li>\n";
+}
+
+/**
+ * Generates one entry within a date selector dropdown.
+ *
+ * @param string $page  Page to link to (month.php, week.php or year.php)
+ * @param string $date  Target date in YYYYMMDD format
+ * @param string $name  Text of the link (may contain markup)
+ *
+ * @return string  HTML
+ */
+function date_selector_item($page, $date, $name)
+{
+  global $login, $user;
+
+  return '<li><a class="dropdown-item" href="' . $page . '?date=' . $date
+    . (!empty($user) && $user != $login
+      ? '&amp;user=' . htmlspecialchars($user) : '')
+    . '">' . $name . "</a></li>\n";
+}
+?>

--- a/includes/init.php
+++ b/includes/init.php
@@ -383,6 +383,17 @@ function print_trailer( $include_nav_links = true, $closeDb = true,
   if ($MENU_ENABLED != 'N') {
     $ret .= '<script src="./includes/js/menu.js"></script>' . "\n";
   }
+  // The Month/Week/Year selectors live in the top menu by default. Put them
+  // here instead when the admin asked for that, or when the top menu is
+  // disabled entirely and so has nowhere to hold them. Installs predating the
+  // MENU_DATE_TOP setting have no webcal_config row for it, so default to top.
+  if( $include_nav_links && ! $friendly
+    && ( $MENU_ENABLED == 'N' || ( $MENU_DATE_TOP ?? 'Y' ) == 'N' ) ) {
+    require_once 'date_selectors.php';
+    $ret .= '<nav id="dateselector"'
+     . ' class="navbar navbar-expand-lg navbar-light bg-light">' . "\n"
+     . date_selectors_html() . "</nav>\n";
+  }
   if( $include_nav_links && ! $friendly ) {
     if( $MENU_ENABLED == 'N' )
       require_once 'includes/trailer.php';

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -4,6 +4,7 @@
  */
 defined('_ISVALID') or die('You cannot access this file directly!');
 
+require_once 'date_selectors.php';
 
 global $ALLOW_VIEW_OTHER, $BodyX, $CATEGORIES_ENABLED, $DISPLAY_TASKS_IN_GRID,
 $DISPLAY_TASKS, $fullname, $GROUPS_ENABLED, $has_boss, $HOME_LINK,
@@ -542,163 +543,12 @@ if (empty($thisday))
     </ul>
   </div>
 
-  <div class="mx-auto order-0">
-    <ul class="navbar-nav flex-row mxr-auto">
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <?php etranslate('Month'); ?>
-        </a>
-        <ul class="dropdown-menu" aria-labelledby="navbarDropdownLink">
-          <?php
-          /** I really like the submenus that allow us to add more years in here, but it does not display
-           *  the submenu correctly, so I am commenting it out for now... :-(
-          <!-- All 12 months for next 2 years in submenu -->
-          <li class="dropdown-submenu">
-            <a class="dropdown-item dropdown-toggle" href="#"><?php echo ($thisyear+2);?></a>
-            <ul class="dropdown-menu">
-            <h6 class="dropdown-header"><?php echo ($thisyear + 2); ?></h6>
-            <?php
-              for ( $i = 1; $i <= 12; $i++ ) {
-                $date = sprintf ("%04d%02d01", $thisyear + 2, $i);
-                $name = month_name($i - 1);
-                print_month_menu_item($name, $date);
-              }
-            ?>
-            </ul>
-          </li>
-          <!-- next year -->
-          <li class="dropdown-submenu">
-              <a class="dropdown-item dropdown-toggle" href="#"><?php echo ($thisyear+1);?></a>
-              <ul class="dropdown-menu">
-                <h6 class="dropdown-header"><?php echo ($thisyear + 1); ?></h6>
-                <?php
-                for ( $i = 1; $i <= 12; $i++ ) {
-                  $date = sprintf ("%04d%02d01", $thisyear + 1, $i);
-                  $name = month_name($i - 1);
-                  print_month_menu_item($name, $date);
-                }
-              ?>
-            </ul>
-          </li>
-           **/ ?>
-          <!-- 3 months of prior year -->
-          <h6 class="dropdown-header"><?php echo ($thisyear - 1); ?></h6>
-          <?php
-          for ($i = 9; $i <= 12; $i++) {
-            $date = sprintf("%04d%02d01", $thisyear - 1, $i);
-            $name = month_name($i - 1);
-            print_month_menu_item($name, $date);
-          } ?>
-          <!-- this year -->
-          <div class="dropdown-divider"></div>
-          <h6 class="dropdown-header"><?php echo $thisyear; ?></h6>
-          <?php for ($i = 1; $i <= 12; $i++) {
-            $date = sprintf("%04d%02d01", $thisyear, $i);
-            $name = month_name($i - 1);
-            if ($i == $thismonth)
-              $name = '<b>' . $name . '</b>';
-            print_month_menu_item($name, $date);
-          } ?>
-          <!-- 3 months next year -->
-          <div class="dropdown-divider"></div>
-          <h6 class="dropdown-header"><?php echo ($thisyear + 1); ?></h6>
-          <?php for ($i = 1; $i <= 3; $i++) {
-            $date = sprintf("%04d%02d01", $thisyear + 1, $i);
-            $name = month_name($i - 1);
-            print_month_menu_item($name, $date);
-          } ?>
-          <?php
-          /* Commenting out submenu for now... :-(
-        <!-- year before -->
-        <div class="dropdown-divider"></div>
-        <li class="dropdown-submenu">
-          <a class="dropdown-item dropdown-toggle" href="#"><?php echo ($thisyear-1);?></a>
-          <ul class="dropdown-menu">
-            <h6 class="dropdown-header"><?php echo ($thisyear - 1); ?></h6>
-            <?php
-              for ( $i = 1; $i <= 12; $i++ ) {
-                $date = sprintf ("%04d%02d01", $thisyear - 1, $i);
-                $name = month_name($i - 1);
-                print_month_menu_item($name, $date);
-              }
-            ?>
-          </ul>
-        </li>
-        <!-- 2 years before -->
-        <li class="dropdown-submenu">
-              <a class="dropdown-item dropdown-toggle" href="#"><?php echo ($thisyear-2);?></a>
-              <ul class="dropdown-menu">
-                <h6 class="dropdown-header"><?php echo ($thisyear - 2); ?></h6>
-                <?php
-                for ( $i = 1; $i <= 12; $i++ ) {
-                  $date = sprintf ("%04d%02d01", $thisyear - 2, $i);
-                  $name = month_name($i - 1, 'M');
-                  print_month_menu_item($name, $date);
-                }
-              ?>
-            </ul>
-          </li>
-        */ ?>
-        </ul>
-      </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <?php etranslate('Week'); ?>
-        </a>
-        <ul class="dropdown-menu" aria-labelledby="navbarDropdownLink">
-          <!-- 6 weeks prior and 8 weeks after -->
-          <?php
-          $d = (empty($thisday) ? date('d') : $thisday);
-          $m = (empty($thismonth) ? date('m') : $thismonth);
-          $y = (empty($thisyear) ? date('Y') : $thisyear);
-          $lastDay = ($DISPLAY_WEEKENDS == 'N' ? 4 : 6);
-          $thisdate = date('Ymd', mktime(0, 0, 0, $m, $d, $y));
-          $thisweek = date('W', mktime(0, 0, 0, $m, $d, $y));
-          $wkstart = get_weekday_before($y, $m, $d);
-          $y = (empty($thisyear) ? date('Y') : $thisyear);
-          for ($i = -5; $i <= 9; $i++) {
-            $twkstart = bump_local_timestamp($wkstart, 0, 0, 0, 0, 7 * $i, 0);
-            $twkend = bump_local_timestamp($twkstart, 0, 0, 0, 0, $lastDay, 0);
-            $dateSYmd = date('Ymd', $twkstart);
-            $dateEYmd = date('Ymd', $twkend);
-            $dateW = date('W', $twkstart + 86400);
-            if ($twkstart > 0 && $twkend < 2146021200) {
-              $name = (!empty($GLOBALS['PULLDOWN_WEEKNUMBER'])
-                && $GLOBALS['PULLDOWN_WEEKNUMBER'] == 'Y'
-                ? '(' . $dateW . ')&nbsp;&nbsp;' : '') .
-                sprintf(
-                  '%s - %s',
-                  date_to_str($dateSYmd, '__mon__ __dd__', false, true),
-                  date_to_str($dateEYmd, '__mon__ __dd__', false, true)
-                );
-              if ($thisdate >= $dateSYmd && $thisdate <= $dateEYmd)
-                $name = '<b>' . $name . '</b>';
-              print_week_menu_item($name, $dateSYmd);
-            }
-          }
-          ?>
-        </ul>
-      </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <?php etranslate('Year'); ?>
-        </a>
-        <div id="nav-project-menu" class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <!-- 5 years before, 5 years after -->
-          <?php for ($i = -5; $i <= 5; $i++) {
-            $date = sprintf("%04d%02d01", $thisyear + $i, 1, 1);
-            $name = ($thisyear + $i);
-            if ($i == 0)
-              $name = '<b>' . $name . '</b>';
-            print_year_menu_item($name, $date);
-          } ?>
-        </div>
-      </li>
-
-    </ul>
-  </div>
+  <?php // Installs predating this setting have no webcal_config row for it.
+  if (($MENU_DATE_TOP ?? 'Y') != 'N') { ?>
+    <div class="mx-auto order-0">
+      <?php echo date_selectors_html(); ?>
+    </div>
+  <?php } ?>
 
   <?php if (!$use_http_auth && $single_user != 'Y') { ?>
     <div class="navbar-collapse collapse order-3 dual-collapse2" id="navbarLogoutCollapse">
@@ -714,25 +564,6 @@ if (empty($thisday))
 </nav>
 
 <?php
-
-function print_year_menu_item($name, $date)
-{
-  global $login, $user;
-  echo '<a class="dropdown-item" href="year.php?date=' . $date .
-    ((!empty($user) && $user != $login) ? "&user=$user" : "") . '">' . $name . "</a>\n";
-}
-
-function print_month_menu_item($name, $date)
-{
-  global $login, $user;
-  echo '<li><a class="dropdown-item" href="month.php?date=' . $date . ((!empty($user) && $user != $login) ? "&user=$user" : "") . '">' . $name . "</a></li>\n";
-}
-
-function print_week_menu_item($name, $date)
-{
-  global $login, $user;
-  echo '<li><a class="dropdown-item" href="week.php?date=' . $date . ((!empty($user) && $user != $login) ? "&user=$user" : "") . '">' . $name . "</a></li>\n";
-}
 
 function print_menu_item($name, $url, $testCondition = true, $target = '')
 {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Path in require_once\(\) "install/default_config\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: admin.php
-
-		-
 			message: '#^Path in require_once\(\) "includes/classes/Event\.class" is not a file or it does not exist\.$#'
 			identifier: requireOnce.fileNotFound
 			count: 1
@@ -162,11 +156,6 @@ parameters:
 			count: 1
 			path: includes/init.php
 
-		-
-			message: '#^Call to sprintf contains 2 placeholders, 3 values given\.$#'
-			identifier: argument.sprintf
-			count: 1
-			path: includes/menu.php
 
 		-
 			message: '#^Array has 2 duplicate keys with value ''id'' \(''id'', ''id''\)\.$#'

--- a/release-files
+++ b/release-files
@@ -144,6 +144,7 @@ includes/css/rss-style.css
 includes/css/styles.css
 includes/css/styles.php
 includes/date_formats.php
+includes/date_selectors.php
 includes/dbi4php.php
 includes/dbtable.php
 includes/formvars.php


### PR DESCRIPTION
Fixes #695. Answers discussion #694.

## Problem

Commit fbb20be9 ("Replaced old menu with Bootstrap v4 nav bar menu", shipped in **v1.9.0**) removed `print_menu_dates()` and rebuilt the Month/Week/Year selectors as Bootstrap navbar items in `includes/menu.php`. Because `includes/init.php` only pulls in `menu.php` when `MENU_ENABLED == 'Y'`, two things broke:

- Turning off "Allow top menu" removed the date selectors entirely, with no bottom fallback. Prev/next arrows and the small-month links were all that remained.
- Admin → Appearance → **"Date Selectors position: Top / Bottom"** (`MENU_DATE_TOP`) became dead code. It was rendered, saved, and never read, so choosing "Bottom" did nothing.

## Change

Extract the three dropdowns from `includes/menu.php` into a new `includes/date_selectors.php` exposing `date_selectors_html()`, then render it from either the navbar or `print_trailer()`. That restores the pre-1.9.0 contract:

| `MENU_ENABLED` | `MENU_DATE_TOP` | Selectors |
|---|---|---|
| `Y` | `Y` | Top navbar (unchanged from today) |
| `Y` | `N` | Bottom of page |
| `N` | either | Bottom of page |

Bootstrap CSS/JS is already emitted unconditionally by `print_header()` (`includes/init.php:212` via `$ASSETS`), so the dropdowns work in the trailer with no extra assets.

The bottom bar renders above the "Go to:" trailer links, matching the v1.3.0 layout in the screenshot on #694. It is emitted outside the `ACCESS_TRAILER` check, which is deliberate — that is what the 2006 fix for SourceForge bug 1574432 ("date selectors missing at the bottom if using UAC") established.

## Fixes carried along

These are all inside the block being moved:

- **Unique dropdown ids.** All three toggles shared `id="navbarDropdownMenuLink"` and pointed `aria-labelledby` at `navbarDropdownLink`, which does not exist. Now `dateSelectorMonth` / `dateSelectorWeek` / `dateSelectorYear`.
- **URL escaping.** Selector links used `"&user=$user"` — raw `&` and an unescaped login. Now `&amp;user=` with `htmlspecialchars()`.
- **Dead CSS.** `#dateselector form`, `#dateselector label` and friends targeted the removed `<form>` markup. Left in place, `#dateselector { margin:0; padding:0 }` would have out-specified `.navbar` and collapsed the new bar's padding. Removed from `styles.css`; the top border in `styles.php` is retargeted at `#dateselector` itself and no longer gated on `MENU_ENABLED == 'N'`, since the bar can now appear with the top menu on.
- **Missing-setting default.** `load_global_settings()` copies `webcal_config` rows verbatim and does not merge `wizard/shared/default_config.php`, so installs predating `MENU_DATE_TOP` have no row for it. Both call sites use `?? 'Y'` to avoid a PHP 8.2 undefined-variable warning and to keep today's behavior as the default.
- **Year dropdown markup.** Was a `<div class="dropdown-menu">` holding bare `<a>` elements while Month and Week used `<ul>`/`<li>`. Normalized to `<ul>`/`<li>`; renders identically in Bootstrap 4.

## Removed

`print_year_menu_item()`, `print_month_menu_item()` and `print_week_menu_item()` are gone from `menu.php` — they were only used by the moved block. `print_menu_item()` stays; it is used throughout the rest of the menu.

**Please look at this one:** two large commented-out `dropdown-submenu` experiments went with the block. Rather than carry ~60 lines of dead code into the new file, I left a docblock note in `date_selector_month()` recording why the submenu approach was abandoned and pointing at this commit for the original. Say the word and I will restore them verbatim.

## Not changed

The Month/Week/Year dropdowns are still not gated on `ACCESS_MONTH` / `ACCESS_WEEK` / `ACCESS_YEAR`. The top menu never gated them either, and adding gating would change the top menu's behavior — out of scope here. Worth a follow-up issue if you want it.

## Test plan

- [x] `./tests/compile_test.sh` — 273 files ok
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 659 tests, 2128 assertions, all passing
- [x] Offline render check of `date_selectors_html()`: 19 month links (4 + 12 + 3), 15 week links, 11 year links; current month, week and year each bolded; balanced `<ul>`/`<li>`; parses as well-formed XML
- [ ] Top menu on, position Top — selectors in navbar, unchanged
- [ ] Top menu on, position Bottom — selectors below the calendar, navbar keeps its other items
- [ ] Top menu off — selectors below the calendar, above the "Go to:" links
- [ ] Dropdowns open and navigate correctly from the bottom position
- [ ] Printer-friendly view unaffected (`$friendly` short-circuits)
