### PR TITLE
chore(deps-dev): bump squizlabs/php_codesniffer from 4.0.1 to 4.0.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4478,19 +4478,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
                 "shasum": ""
             },
             "require": {
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
@@ -4498,6 +4499,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
             },
             "bin": [
                 "bin/phpcbf",
@@ -4553,7 +4558,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-10T16:43:36+00:00"
+            "time": "2026-08-06T02:45:27+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
Gets the `build` job green again. It has been failing on master since 2026-08-05, when a new advisory landed against a package we already had pinned.

## Advisory

| | |
|---|---|
| Package | `squizlabs/php_codesniffer` (dev-only) |
| CVE | CVE-2026-67434 |
| GHSA | [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq) |
| Severity | High — OS command injection |
| Affected | `<3.13.6`, `>=4.0.0 <4.0.2` |
| Was on | 4.0.1 |
| Now on | 4.0.4 |

`composer audit` runs in the `build` job and exits non-zero on any advisory, which is what turned master red. The advisory was published 2026-08-05T23:53, roughly four hours after master's last green `build` run, so nothing in the codebase caused it.

## Scope

`composer.lock` only. The existing `"squizlabs/php_codesniffer": "^4.0"` constraint in `composer.json` already permits 4.0.4, so no constraint change was needed. One package updated, no transitive changes.

This was never a runtime exposure: php_codesniffer is in `require-dev`, and `vendor/` is not shipped in releases — the app loads its dependencies from `pub/`.

## Test plan

- [x] `composer update squizlabs/php_codesniffer` — single-package update, 4.0.1 => 4.0.4
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 659 tests, 2128 assertions, all passing
- [x] `vendor/bin/phpcs --version` — reports 4.0.4, binary still functional
- [x] Confirmed no workflow invokes phpcs, so no ruleset behavior to regress
- [ ] CI `build` job passes `composer audit`