### PR TITLE
test: remove flaky wall-clock assertions from McpTest

### DIFF
--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -529,10 +529,12 @@ final class McpTest extends TestCase
     
     // No single operation should take more than 500ms
     $this->assertLessThan(0.5, $maxResponseTime, "Maximum response time too high: {$maxResponseTime}s");
-    
-    // Response times should be reasonably consistent (no extreme outliers)
-    $stdDev = $this->calculateStandardDeviation($responseTimes);
-    $this->assertLessThan(0.05, $stdDev, "Response times too inconsistent: std dev {$stdDev}s");
+
+    // NOTE: Deliberately no assertion on the spread of $responseTimes. A
+    // standard-deviation bound is dominated by whichever single sample landed
+    // during a scheduling hiccup on a shared CI runner, so it measures the
+    // runner rather than WebCalendar. The average and maximum bounds above are
+    // what actually catch a regression. See issue #698.
   }
 
   /**
@@ -592,9 +594,12 @@ final class McpTest extends TestCase
       
       $requestEnd = microtime(true);
       
-      // Rate limit check should be very fast
+      // Rate limit check should be fast with no history. Wall-clock bound, so
+      // it matches the generous with-history bound below rather than trying to
+      // measure true latency on a shared runner. The aggregate assertion on
+      // $noHistoryTime is what bounds the loop as a whole.
       $requestDuration = $requestEnd - $requestStart;
-      $this->assertLessThan(0.01, $requestDuration, "Rate limit check took too long: {$requestDuration}s");
+      $this->assertLessThan(0.5, $requestDuration, "Rate limit check took too long: {$requestDuration}s");
       
       // Result should be consistent
       $this->assertFalse($isRateLimited, "Should not be rate limited with no history");
@@ -656,20 +661,6 @@ final class McpTest extends TestCase
     // Even with more entries, 100 checks should complete quickly. Generous
     // wall-clock bound to stay green on slow CI while catching O(n^2) blowups.
     $this->assertLessThan(5.0, $scalingTime, "Rate limiting with scaling took too long: {$scalingTime}s");
-  }
-
-  // Helper method to calculate standard deviation
-  private function calculateStandardDeviation($array) {
-    if (count($array) === 0) return 0;
-    
-    $mean = array_sum($array) / count($array);
-    $variance = 0;
-    
-    foreach ($array as $value) {
-      $variance += pow($value - $mean, 2);
-    }
-    
-    return sqrt($variance / count($array));
   }
 
   // ---------------------------------------------------------------


### PR DESCRIPTION
Refs #698.

## The confirmed flake

`testMcpResponseTimeConsistency` asserted a standard-deviation bound on 20 timed DB operations:

```php
$stdDev = $this->calculateStandardDeviation($responseTimes);
$this->assertLessThan(0.05, $stdDev, "Response times too inconsistent: std dev {$stdDev}s");
```

Standard deviation across 20 samples is dominated by whichever single operation happened to land during a scheduling hiccup. One 300ms outlier in an otherwise 2ms population clears 0.05 by itself, so the assertion measures the runner, not WebCalendar.

It failed at `0.0779s` on #697 — a one-line `composer.lock` change bumping a dev-only linter. PHP 8.2 and 8.3 ran the identical suite in the same workflow and passed; 8.4 passed on re-run.

Removed, along with the now-unused `calculateStandardDeviation()` helper. The two assertions directly above it are kept — they are absolute rather than distributional, and are what catch a real regression:

```php
$this->assertLessThan(0.1, $avgResponseTime, ...);   // avg under 100ms
$this->assertLessThan(0.5, $maxResponseTime, ...);   // no op over 500ms
```

## A second, worse offender

While auditing the file I found `testRateLimitingPerformanceImpact` asserting **10ms** per rate-limit check, inside a 10-iteration loop:

```php
$this->assertLessThan(0.01, $requestDuration, ...);
```

An earlier pass over this file had already loosened the *with-history* loop to 0.5s, with a comment about staying green on slow CI. It missed the *no-history* loop 20 lines above — which was 50x tighter, for the same query against **less** data, with 10 chances per run to trip. 10ms is below routine scheduler jitter.

Raised to 0.5s to match its sibling. No coverage lost: the aggregate `assertLessThan(2.0, $noHistoryTime)` already bounds that loop as a whole, and a genuine hang still trips the per-iteration check.

## testMemoryUsagePatterns — checked, left alone

Not a flake risk, and I did not change it. Memory readings do not depend on the scheduler. Instrumented across three runs, the values were byte-identical every time:

```
batches=0,0,0,0,0  total=19904  avg=0
```

**However, those assertions are vacuous.** Every batch measures exactly 0 bytes, so `assertLessThan(2MB, 0)` can never fail — the events go to SQLite and PHP releases the per-iteration allocations, so nothing accumulates on the heap. The total is ~19KB against a 20MB threshold, roughly 1000x headroom. `$avgMemoryPerBatch` is computed under a comment reading "Memory usage should grow linearly, not exponentially" and then never asserted on.

That is a test-that-cannot-fail rather than a flaky test, so it is a different problem from #698 and out of scope here. Flagging it for a follow-up decision: either measure something real (peak memory, or SQLite page count) or delete it. I have not touched it.

## Other timing assertions audited

Everything else in the file uses aggregate bounds with at least 1s of headroom, or measures memory. Left as-is:

| Location | Bound | Verdict |
|---|---|---|
| `testPerformanceBaselines` | `< 1.0s` event creation | Generous, aggregate |
| `testMcpServerThroughput` | `> 10` and `> 5` events/sec | Aggregate over 50 events |
| `testRateLimitingPerformanceImpact` | `< 0.5s` with history | Already loosened previously |
| `testRateLimitingPerformanceImpact` | `< 2.0s` / `< 10.0s` / `< 5.0s` | Aggregate, generous |

## Test plan

- [x] `vendor/bin/phpunit tests/McpTest.php` — 56 tests, 243 assertions, passing (was 244; one removed)
- [x] `./tests/compile_test.sh` — 273 files ok
- [x] Confirmed `calculateStandardDeviation()` had no other callers before removing it
- [x] Temporary instrumentation used to measure memory values was reverted; diff contains no debug output
- [ ] CI green across the MCP matrix