### PR TITLE
test: remove vacuous testMemoryUsagePatterns from McpTest

### DIFF
--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -537,44 +537,12 @@ final class McpTest extends TestCase
     // what actually catch a regression. See issue #698.
   }
 
-  /**
-   * Test memory usage patterns under load.
-   */
-  public function testMemoryUsagePatterns() {
-    $userLogin = 'testuser';
-    $token = 'test_token_12345';
-    $this->testDb->createApiToken($userLogin, $token);
-    
-    $baselineMemory = memory_get_usage();
-    
-    // Create events in batches and measure memory
-    $memoryMeasurements = [];
-    for ($batch = 1; $batch <= 5; $batch++) {
-      $batchStartMemory = memory_get_usage();
-      
-      // Create 10 events in this batch
-      for ($i = 1; $i <= 10; $i++) {
-        $eventId = $this->testDb->createEvent($userLogin, 20240601 + ($batch * 10) + $i, "Memory Batch $batch Event $i");
-        $this->testDb->associateUserWithEvent($eventId, $userLogin);
-      }
-      
-      $batchEndMemory = memory_get_usage();
-      $batchMemoryUsed = $batchEndMemory - $batchStartMemory;
-      $memoryMeasurements[] = $batchMemoryUsed;
-    }
-    
-    // Memory usage should grow linearly, not exponentially
-    $avgMemoryPerBatch = array_sum($memoryMeasurements) / count($memoryMeasurements);
-    
-    // No single batch should use excessive memory (more than 2MB)
-    foreach ($memoryMeasurements as $memoryUsed) {
-      $this->assertLessThan(2 * 1024 * 1024, $memoryUsed, "Single batch used too much memory: {$memoryUsed} bytes");
-    }
-    
-    // Total memory increase should be reasonable
-    $totalMemoryIncrease = memory_get_usage() - $baselineMemory;
-    $this->assertLessThan(20 * 1024 * 1024, $totalMemoryIncrease, 'Total memory increase too high');
-  }
+  // NOTE: testMemoryUsagePatterns was removed here. It created events in five
+  // batches of ten and asserted each batch used under 2MB, but every batch
+  // measured exactly 0 bytes -- the rows go to SQLite and PHP frees the
+  // per-iteration allocations, so nothing accumulates on the heap. The
+  // assertions could not fail. testPerformanceBaselines above still bounds
+  // memory during event creation. See issue #698.
 
   /**
    * Test performance impact of rate limiting.


### PR DESCRIPTION
Fixes #698. Follow-up to #699, which handled the flaky half of that issue.

## Why

`testMemoryUsagePatterns` created events in five batches of ten and asserted each batch stayed under 2MB, with a 20MB ceiling on the total. Instrumented across three runs, the numbers were byte-identical every time:

```
batches=0,0,0,0,0  total=19904  avg=0
```

Every batch measures **exactly 0 bytes**. The rows go to SQLite and PHP frees the per-iteration allocations, so nothing accumulates on the heap. `assertLessThan(2 * 1024 * 1024, 0)` cannot fail. The total is ~19KB against a 20MB ceiling — roughly 1000x headroom.

`$avgMemoryPerBatch` was computed under a comment reading *"Memory usage should grow linearly, not exponentially"* and then never asserted on, which suggests the test was never finished.

A test that cannot fail is worse than no test: it reports coverage that does not exist. If this ever needs to come back, it has to measure something that actually varies — peak memory via `memory_get_peak_usage()`, or SQLite page count — rather than resident heap after the allocator has already reclaimed it.

## Coverage impact

None that is real. `testPerformanceBaselines` still bounds memory during event creation:

```php
$this->assertLessThan(10 * 1024 * 1024, $memoryUsed, 'Memory usage during event creation was too high');
```

A comment is left at the removal site recording what was there and why it went, so nobody re-adds the same thing.

## Test plan

- [x] `vendor/bin/phpunit tests/McpTest.php` — 55 tests, 237 assertions (was 56 / 243: one test and its six assertions removed)
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 658 tests, 2121 assertions, all passing
- [x] `./tests/compile_test.sh` — 273 files ok
- [x] Grepped for dangling references to the removed method — none outside the explanatory comment
- [ ] CI green