### PR TITLE
fix: stop sharing one LDAP link via global $ds (#703)

### DIFF
--- a/includes/user-ldap.php
+++ b/includes/user-ldap.php
@@ -34,11 +34,11 @@ $ldap_admin_group_type = strtolower($ldap_admin_group_type);
 //   $dn - complete dn for the user
 //   TRUE if the user is found, FALSE in other case
 function user_search_dn ( $login ) {
-  global $ds, $error, $ldap_base_dn, $ldap_login_attr,
+  global $error, $ldap_base_dn, $ldap_login_attr,
   $ldap_user_attr, $ldap_user_filter;
 
   $ret = false;
-  if ($r = connect_and_bind ()) {
+  if ($ds = connect_and_bind ()) {
     $sr = @ldap_search ( $ds, $ldap_base_dn,
       "(&($ldap_login_attr=$login)$ldap_user_filter )", $ldap_user_attr );
     if (!$sr) {
@@ -82,6 +82,7 @@ function user_valid_login ( $login, $password ) {
     if ($ldap_start_tls) {
       if (!ldap_start_tls($ds)) {
         $error = 'Could not start TLS for LDAP connection';
+        @ldap_close ( $ds );
         return $ret;
       }
     }
@@ -121,7 +122,7 @@ function user_valid_crypt ( $login, $crypt_password ) {
 //   $user - user login
 //   $prefix - variable prefix to use
 function user_load_variables ( $login, $prefix ) {
-  global $cached_user_var, $ds, $error, $ldap_base_dn, $ldap_login_attr,
+  global $cached_user_var, $error, $ldap_base_dn, $ldap_login_attr,
   $ldap_user_attr, $ldap_user_filter, $NONUSER_PREFIX, $PUBLIC_ACCESS_FULLNAME;
 
   if ( ! empty ( $cached_user_var[$login][$prefix] ) )
@@ -145,7 +146,7 @@ function user_load_variables ( $login, $prefix ) {
   }
 
   $ret = false;
-  if ($r = connect_and_bind ()) {
+  if ($ds = connect_and_bind ()) {
     $sr = @ldap_search ( $ds, $ldap_base_dn,
       "(&($ldap_login_attr=$login)$ldap_user_filter )", $ldap_user_attr );
 
@@ -347,8 +348,8 @@ function user_delete_user ( $user ) {
 // Get a list of users and return info in an array.
 // returns: array of users
 function user_get_users ( $publicOnly=false ) {
-  global $ds, $error, $ldap_base_dn, $ldap_user_attr,
-  $ldap_user_filter, $PUBLIC_ACCESS_FULLNAM, $PUBLIC_ACCESS;
+  global $error, $ldap_base_dn, $ldap_user_attr,
+  $ldap_user_filter, $PUBLIC_ACCESS_FULLNAME, $PUBLIC_ACCESS;
 
   $Admins = get_admins ();
   $count = 0;
@@ -363,7 +364,7 @@ function user_get_users ( $publicOnly=false ) {
        'cal_password' => '',
        'cal_fullname' => $PUBLIC_ACCESS_FULLNAME];
   if ( $publicOnly ) return $ret;
-  if ($r = connect_and_bind ()) {
+  if ($ds = connect_and_bind ()) {
     $sr = @ldap_search ( $ds, $ldap_base_dn, $ldap_user_filter, $ldap_user_attr );
     if (!$sr) {
       $error = 'Error searching LDAP server: ' . ldap_error( $ds );
@@ -406,13 +407,13 @@ function user_is_admin ($values,$Admins) {
 // Do this search only once per request.
 // returns: array of admins
 function get_admins () {
-  global $cached_admins, $ds, $error, $ldap_admin_group_attr,
+  global $cached_admins, $error, $ldap_admin_group_attr,
   $ldap_admin_group_name, $ldap_admin_group_type;
 
   if ( ! empty ( $cached_admins ) ) return $cached_admins;
   $cached_admins = [];
 
-  if ($r = connect_and_bind ()) {
+  if ($ds = connect_and_bind ()) {
     $search_filter = "($ldap_admin_group_attr=*)";
     $sr = @ldap_search ( $ds, $ldap_admin_group_name, $search_filter, [$ldap_admin_group_attr] );
     if (!$sr) {
@@ -447,44 +448,52 @@ function stripdn( $dn ) {
 
 // Connects and binds to the LDAP server
 // Tries to connect as $ldap_admin_dn if we set it.
-//  returns: bind result or false
+//
+// The connection is returned rather than stored in a global. Sharing one
+// global link between functions let a nested call (get_admins()) overwrite
+// and close its caller's link; on PHP 8 the caller's later ldap_close() then
+// throws "LDAP connection has already been closed", which is fatal. Each
+// caller must keep the link it is given in a local variable and close that.
+//
+//  returns: LDAP connection on success, false on failure
 function connect_and_bind () {
-  global $ds, $error, $ldap_admin_dn, $ldap_admin_pwd, $ldap_port,
+  global $error, $ldap_admin_dn, $ldap_admin_pwd, $ldap_port,
   $ldap_server, $ldap_start_tls, $ldap_version, $set_ldap_version;
 
   if ( ! function_exists ( 'ldap_connect' ) ) {
     die_miserable_death ( 'Your installation of PHP does not support LDAP' );
   }
 
-  $ret = false;
   $ds = @ldap_connect ( $ldap_server, $ldap_port );
-  if ( $ds ) {
-    if ($set_ldap_version || $ldap_start_tls)
-      ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $ldap_version);
-
-    if ($ldap_start_tls) {
-      if (!ldap_start_tls($ds)) {
-        $error = 'Could not start TLS for LDAP connection';
-        return $ret;
-      }
-    }
-
-    if ( $ldap_admin_dn != '') {
-      $r = @ldap_bind ( $ds, $ldap_admin_dn, $ldap_admin_pwd );
-    } else {
-      $r = @ldap_bind ( $ds );
-    }
-
-    if (!$r) {
-      $error = 'Invalid Admin login for LDAP Server';
-    } else {
-      $ret = $r;
-    }
-  } else {
+  if ( ! $ds ) {
     $error = 'Error connecting to LDAP server';
-    $ret = false;
+    return false;
   }
-  return $ret;
+
+  if ($set_ldap_version || $ldap_start_tls)
+    ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $ldap_version);
+
+  if ($ldap_start_tls) {
+    if (!ldap_start_tls($ds)) {
+      $error = 'Could not start TLS for LDAP connection';
+      @ldap_close ( $ds );
+      return false;
+    }
+  }
+
+  if ( $ldap_admin_dn != '') {
+    $r = @ldap_bind ( $ds, $ldap_admin_dn, $ldap_admin_pwd );
+  } else {
+    $r = @ldap_bind ( $ds );
+  }
+
+  if (!$r) {
+    $error = 'Invalid Admin login for LDAP Server';
+    @ldap_close ( $ds );
+    return false;
+  }
+
+  return $ds;
 }
 
 ?>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -170,12 +170,6 @@ parameters:
 			path: includes/translate.php
 
 		-
-			message: '#^Undefined variable\: \$PUBLIC_ACCESS_FULLNAME$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/user-ldap.php
-
-		-
 			message: '#^Cannot unset offset ''Until'' on array\{Exceptions\: array\{\}, Inclusions\: array\{\}\}\|array\{Exceptions\: list, Inclusions\: list, Frequency\: 7\}\.$#'
 			identifier: unset.offset
 			count: 1

--- a/tests/LdapConnectionLifecycleTest.php
+++ b/tests/LdapConnectionLifecycleTest.php
@@ -1,0 +1,356 @@
+<?php
+
+/*
+ * Regression tests for GitHub issue #703 -- "LDAP multiple calls to unbind".
+ *
+ * includes/user-ldap.php used to keep the LDAP link in a global $ds that was
+ * shared by user_search_dn(), user_load_variables(), user_get_users() and
+ * get_admins(). Because user_load_variables() calls get_admins() while its own
+ * link is still open, the nested call overwrote the caller's $ds with a second
+ * link and then closed it. The caller's trailing ldap_close($ds) therefore ran
+ * against an already-closed link.
+ *
+ * On PHP 8 that is fatal: ldap_connect() returns an LDAP\Connection object
+ * (it used to return a resource) and closing one twice throws
+ * "Error: LDAP connection has already been closed". The @ operator does not
+ * suppress a thrown Error, so LDAP logins died with an HTTP 500.
+ *
+ * The fix makes connect_and_bind() return the link so every caller owns a
+ * local one. These tests exercise the real functions from user-ldap.php
+ * against a fake LDAP layer, so they need neither an LDAP server nor the
+ * php-ldap extension.
+ *
+ * Note: strict_types is deliberately not declared here -- the code under test
+ * is legacy and untyped, and eval()'d code inherits the caller's setting.
+ */
+
+namespace WebCalendarTest\LdapStub;
+
+use PHPUnit\Framework\TestCase;
+
+// user_get_users() sorts with the string callable 'sort_users', which resolves
+// in the global namespace.
+require_once __DIR__ . '/../includes/functions.php';
+
+/** Stand-in for PHP 8's LDAP\Connection object. */
+final class FakeLdapLink
+{
+  public $id;
+  public $closed = false;
+
+  public function __construct($id)
+  {
+    $this->id = $id;
+  }
+}
+
+/** Records what the code under test did to the directory. */
+final class FakeLdap
+{
+  public static $opened = 0;
+  /** @var array<int,int> link id => number of times ldap_close() was called */
+  public static $closeCounts = [];
+  public static $bindSucceeds = true;
+  public static $tlsSucceeds = true;
+  public static $adminMembers = [];
+
+  public static function reset()
+  {
+    self::$opened = 0;
+    self::$closeCounts = [];
+    self::$bindSucceeds = true;
+    self::$tlsSucceeds = true;
+    self::$adminMembers = ['jdoe'];
+  }
+
+  public static function leakedLinks()
+  {
+    return self::$opened - count(self::$closeCounts);
+  }
+
+  public static function doubleClosedLinks()
+  {
+    return array_keys(array_filter(self::$closeCounts, function ($n) {
+      return $n > 1;
+    }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake LDAP layer. Unqualified calls inside this namespace resolve here before
+// falling back to the global (real) functions, which is what lets us drive the
+// unmodified code in user-ldap.php.
+// ---------------------------------------------------------------------------
+
+function function_exists($name)
+{
+  // user-ldap.php guards on this before doing anything; keep the tests
+  // runnable on builds without the php-ldap extension.
+  return $name === 'ldap_connect' ? true : \function_exists($name);
+}
+
+function ldap_connect($host = null, $port = null)
+{
+  return new FakeLdapLink(++FakeLdap::$opened);
+}
+
+function ldap_close($link)
+{
+  if (!$link instanceof FakeLdapLink) {
+    throw new \Error('ldap_close(): argument is not an LDAP connection');
+  }
+  // Mirrors PHP 8 behaviour, which is the whole point of issue #703.
+  FakeLdap::$closeCounts[$link->id] =
+    (FakeLdap::$closeCounts[$link->id] ?? 0) + 1;
+  if ($link->closed) {
+    throw new \Error('LDAP connection has already been closed');
+  }
+  $link->closed = true;
+  return true;
+}
+
+function ldap_bind($link, $dn = null, $password = null)
+{
+  require_open($link);
+  return FakeLdap::$bindSucceeds;
+}
+
+function ldap_set_option($link, $option, $value)
+{
+  require_open($link);
+  return true;
+}
+
+function ldap_start_tls($link)
+{
+  require_open($link);
+  return FakeLdap::$tlsSucceeds;
+}
+
+function ldap_error($link)
+{
+  return 'fake ldap error';
+}
+
+function ldap_free_result($result)
+{
+  return true;
+}
+
+function ldap_search($link, $base, $filter, $attributes = [])
+{
+  require_open($link);
+  return ['filter' => $filter];
+}
+
+function ldap_get_entries($link, $result)
+{
+  require_open($link);
+
+  // The admin-group lookup in get_admins() searches "(memberuid=*)".
+  if (strpos($result['filter'], 'memberuid') !== false) {
+    $members = ['count' => count(FakeLdap::$adminMembers)];
+    foreach (FakeLdap::$adminMembers as $i => $member) {
+      $members[$i] = $member;
+    }
+    return ['count' => 1, 0 => ['memberuid' => $members]];
+  }
+
+  return ['count' => 1, 0 => [
+    'dn' => 'uid=jdoe,dc=example,dc=org',
+    'uid' => [0 => 'jdoe'],
+    'sn' => [0 => 'Doe'],
+    'givenname' => [0 => 'John'],
+    'cn' => [0 => 'John Doe'],
+    'mail' => [0 => 'jdoe@example.org'],
+  ]];
+}
+
+function require_open($link)
+{
+  if ($link->closed) {
+    throw new \Error('LDAP connection has already been closed');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load the real user-ldap.php into this namespace so its unqualified ldap_*
+// calls bind to the fakes above.
+// ---------------------------------------------------------------------------
+
+$ldapSource = file_get_contents(__DIR__ . '/../includes/user-ldap.php');
+$stripped = 0;
+$ldapSource = preg_replace('/^<\?php/', '', $ldapSource, 1, $stripped);
+if ($stripped !== 1) {
+  throw new \RuntimeException('user-ldap.php: could not strip opening tag');
+}
+$ldapSource = preg_replace('/\?>\s*\z/', '', $ldapSource);
+$ldapSource = preg_replace("/^defined \\( '_ISVALID' \\).*$/m", '', $ldapSource, 1, $stripped);
+if ($stripped !== 1) {
+  throw new \RuntimeException('user-ldap.php: could not strip _ISVALID guard');
+}
+$ldapSource = preg_replace("/^include_once 'auth-settings.php';$/m", '', $ldapSource, 1, $stripped);
+if ($stripped !== 1) {
+  throw new \RuntimeException('user-ldap.php: could not strip auth-settings include');
+}
+
+// user-ldap.php lower-cases these two at file scope; seed them so evaluating
+// the file scope does not read undefined variables.
+$ldap_admin_group_attr = 'memberUid';
+$ldap_admin_group_type = 'posixGroup';
+eval('namespace WebCalendarTest\LdapStub;' . $ldapSource);
+
+final class LdapConnectionLifecycleTest extends TestCase
+{
+  protected function setUp(): void
+  {
+    FakeLdap::reset();
+
+    foreach ([
+      'error' => '',
+      'ldap_server' => 'localhost',
+      'ldap_port' => '389',
+      'ldap_start_tls' => false,
+      'set_ldap_version' => false,
+      'ldap_version' => 3,
+      'ldap_admin_dn' => '',
+      'ldap_admin_pwd' => '',
+      'ldap_base_dn' => 'dc=example,dc=org',
+      'ldap_login_attr' => 'uid',
+      'ldap_user_filter' => '(objectClass=person)',
+      'ldap_user_attr' => ['uid', 'sn', 'givenname', 'cn', 'mail'],
+      'ldap_admin_group_name' => 'cn=admins,dc=example,dc=org',
+      'ldap_admin_group_attr' => 'memberuid',
+      'ldap_admin_group_type' => 'posixgroup',
+      'NONUSER_PREFIX' => '',
+      'PUBLIC_ACCESS' => 'N',
+      'PUBLIC_ACCESS_FULLNAME' => 'Public Access',
+      // Both caches are request-scoped globals; clear them between tests.
+      'cached_admins' => [],
+      'cached_user_var' => [],
+    ] as $name => $value) {
+      $GLOBALS[$name] = $value;
+    }
+  }
+
+  private function assertLinksBalanced(): void
+  {
+    self::assertSame(
+      [],
+      FakeLdap::doubleClosedLinks(),
+      'An LDAP link was closed more than once (issue #703).'
+    );
+    self::assertSame(
+      0,
+      FakeLdap::leakedLinks(),
+      'An LDAP link was opened but never closed.'
+    );
+  }
+
+  /**
+   * The issue #703 crash: user_load_variables() calls get_admins() while its
+   * own link is open. Before the fix this threw
+   * "LDAP connection has already been closed" and LDAP login returned a 500.
+   */
+  public function testLoginPathDoesNotCloseTheSameLinkTwice(): void
+  {
+    $loaded = user_load_variables('jdoe', 'i703');
+
+    self::assertTrue($loaded);
+    self::assertSame('John Doe', $GLOBALS['i703fullname']);
+    self::assertSame('jdoe@example.org', $GLOBALS['i703email']);
+    // 'Y' only if the nested get_admins() call actually ran and returned.
+    self::assertSame('Y', $GLOBALS['i703is_admin']);
+    self::assertGreaterThan(
+      1,
+      FakeLdap::$opened,
+      'Expected a nested get_admins() lookup on its own link.'
+    );
+    $this->assertLinksBalanced();
+  }
+
+  public function testNonAdminLoginStillResolves(): void
+  {
+    FakeLdap::$adminMembers = ['someone-else'];
+
+    self::assertTrue(user_load_variables('jdoe', 'i703b'));
+    self::assertSame('N', $GLOBALS['i703bis_admin']);
+    $this->assertLinksBalanced();
+  }
+
+  /**
+   * The fix: the link is handed back to the caller instead of being published
+   * through a shared global, so nested calls cannot clobber it.
+   */
+  public function testConnectAndBindReturnsTheLinkNotABoolean(): void
+  {
+    $ds = connect_and_bind();
+
+    self::assertInstanceOf(FakeLdapLink::class, $ds);
+    self::assertArrayNotHasKey(
+      'ds',
+      $GLOBALS,
+      'connect_and_bind() must not publish the link as a global.'
+    );
+
+    ldap_close($ds);
+    $this->assertLinksBalanced();
+  }
+
+  public function testConnectAndBindClosesTheLinkWhenBindFails(): void
+  {
+    FakeLdap::$bindSucceeds = false;
+
+    self::assertFalse(connect_and_bind());
+    self::assertSame('Invalid Admin login for LDAP Server', $GLOBALS['error']);
+    $this->assertLinksBalanced();
+  }
+
+  public function testConnectAndBindClosesTheLinkWhenTlsFails(): void
+  {
+    $GLOBALS['ldap_start_tls'] = true;
+    FakeLdap::$tlsSucceeds = false;
+
+    self::assertFalse(connect_and_bind());
+    self::assertSame('Could not start TLS for LDAP connection', $GLOBALS['error']);
+    $this->assertLinksBalanced();
+  }
+
+  public function testUserGetUsersClosesEveryLinkExactlyOnce(): void
+  {
+    $users = user_get_users();
+
+    self::assertCount(1, $users);
+    self::assertSame('jdoe', $users[0]['cal_login']);
+    self::assertSame('Y', $users[0]['cal_is_admin']);
+    $this->assertLinksBalanced();
+  }
+
+  /**
+   * user_get_users() declared `global $PUBLIC_ACCESS_FULLNAM` (missing the
+   * trailing E), so the public entry's fullname resolved to an undefined
+   * local instead of the configured value.
+   */
+  public function testPublicAccessUserGetsTheConfiguredFullname(): void
+  {
+    $GLOBALS['PUBLIC_ACCESS'] = 'Y';
+
+    $users = user_get_users(true);
+
+    self::assertCount(1, $users);
+    self::assertSame('__public__', $users[0]['cal_login']);
+    self::assertSame('Public Access', $users[0]['cal_fullname']);
+  }
+
+  public function testUserSearchDnClosesItsOwnLink(): void
+  {
+    self::assertSame('uid=jdoe,dc=example,dc=org', user_search_dn('jdoe'));
+    $this->assertLinksBalanced();
+  }
+
+  public function testGetAdminsClosesItsOwnLink(): void
+  {
+    self::assertSame(['jdoe'], get_admins());
+    $this->assertLinksBalanced();
+  }
+}


### PR DESCRIPTION
Fixes #703 — LDAP login returns HTTP 500 on PHP 8.

## The bug

`ldap_connect()` returned a *resource* through PHP 7, but since PHP 8.1 it returns an `LDAP\Connection` object. Calling `ldap_close()` (alias of `ldap_unbind()`) on one that is already closed no longer emits a warning — it **throws** `Error: LDAP connection has already been closed`. The `@` operator does not suppress a thrown `Error`, so it escapes as an uncaught fatal and the request 500s.

`includes/user-ldap.php` kept the LDAP link in a **global `$ds`** shared by `user_search_dn()`, `user_load_variables()`, `user_get_users()` and `get_admins()`, while `connect_and_bind()` returned only the *bind result*. That made the double close reachable:

1. `user_load_variables()` declares `global $ds` and opens a link via `connect_and_bind()`.
2. It calls `get_admins()`, which also declares `global $ds`, calls `connect_and_bind()` — **overwriting the caller's link** — and closes that one.
3. Back in `user_load_variables()`, `@ldap_close($ds)` targets the link `get_admins()` already closed → fatal.

That nesting is on the login path, which is why logging in was the trigger. `user_get_users()` survived only by accident: it happens to call `get_admins()` *before* it connects.

## The fix

`connect_and_bind()` now **returns the link** instead of publishing it in a global, and every caller keeps it in a local variable:

```php
if ( $ds = connect_and_bind () ) {   // was: if ( $r = connect_and_bind () )
  ...
  @ldap_close ( $ds );
}
```

An `LDAP\Connection` is truthy, so the call sites behave exactly as before. `global $ds` is gone from all four functions.

I chose this over the reporter's suggested minimal patch (save/restore `$ds` around `get_admins()`) deliberately: the minimal version fixes the one nesting that happens to be reachable today and leaves the shared-global design — and the next nested call — in place. This removes the class of bug. The blast radius is one file; nothing outside `includes/user-ldap.php` references `connect_and_bind` or the `$ds` global.

Two related fixes rode along, both in code this PR already touches:

- `connect_and_bind()` now closes the link on the **TLS-failure and bind-failure** paths. Both previously returned `false` while leaving the connection open. Same for the TLS-failure path in `user_valid_login()`.
- `user_get_users()` declared `global $PUBLIC_ACCESS_FULLNAM` — missing the trailing `E` — so the public user's fullname resolved to an undefined variable instead of the configured value.

## Test

New `tests/LdapConnectionLifecycleTest.php` (9 tests, 37 assertions).

It loads the real `user-ldap.php` into a test-only namespace where the `ldap_*` functions are shadowed by fakes that reproduce PHP 8's throw-on-second-close semantics. PHP resolves unqualified function calls to the current namespace before falling back to global, so the **unmodified production functions** are what actually run. Consequently the test needs neither an LDAP server nor the php-ldap extension, and it can run in CI.

The tests were validated RED-before-GREEN. Against the pre-fix file (`git show HEAD~1:includes/user-ldap.php`):

```
3 errors:
  testLoginPathDoesNotCloseTheSameLinkTwice ....... Error: LDAP connection has already been closed
  testNonAdminLoginStillResolves .................. Error: LDAP connection has already been closed
  testPublicAccessUserGetsTheConfiguredFullname ... Undefined variable $PUBLIC_ACCESS_FULLNAME
3 failures:
  testConnectAndBindReturnsTheLinkNotABoolean ..... true is not an instance of FakeLdapLink
  testConnectAndBindClosesTheLinkWhenBindFails .... link opened but never closed
  testConnectAndBindClosesTheLinkWhenTlsFails ..... link opened but never closed
```

The first error is the exact fatal from the issue report.

## Test plan

- [x] `vendor/bin/phpunit --no-coverage tests/LdapConnectionLifecycleTest.php` — 9 tests, 37 assertions, passing
- [x] Same tests run against pre-fix `user-ldap.php` — 3 errors + 3 failures, reproducing the reported fatal
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 667 tests, 2158 assertions, passing
- [x] `./tests/compile_test.sh` — 274 files ok
- [x] Verified no `global $ds` declarations remain and all five `ldap_close()` call sites act on a local
- [x] Confirmed nothing outside `includes/user-ldap.php` references `connect_and_bind` or `$ds`
- [x] Confirmed `tests/` is not in `release-files`, so no manifest change is needed
- [ ] CI green
- [ ] **Verification against a real LDAP directory** — I have no LDAP server, so all coverage here is stubbed. @stierhofj has offered context on the issue; a confirmation from a live setup would be worth having before release.

## Risk

Low, and contained to LDAP authentication. Sites not using `user-ldap.php` are unaffected. The one behavioural change beyond the crash fix is that failed TLS/bind attempts now close their connection instead of leaking it, and the public-user fullname now populates where it previously came out empty.
