### PR TITLE
chore(deps): bump mcp/sdk from 0.6.0 to 0.7.1 (CVE-2026-53965)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": "^8.2",
     "components/jquery": "3.5.*",
-    "mcp/sdk": "^0.6.0",
+    "mcp/sdk": "^0.7.1",
     "phpmailer/phpmailer": "7.0.*",
     "tinymce/tinymce": "^7.9.3",
     "twbs/bootstrap": "4.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d29054ae15041c73aa6c275334e210b2",
+    "content-hash": "8a09903dd456c48733179486b442b487",
     "packages": [
         {
             "name": "components/jquery",
@@ -105,16 +105,16 @@
         },
         {
             "name": "mcp/sdk",
-            "version": "v0.6.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/modelcontextprotocol/php-sdk.git",
-                "reference": "433c84b58af346dd32f15f9909679e96a46ebe23"
+                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/433c84b58af346dd32f15f9909679e96a46ebe23",
-                "reference": "433c84b58af346dd32f15f9909679e96a46ebe23",
+                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/785fc3b9b7006ecc8a73322c939d96a4a7154345",
+                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345",
                 "shasum": ""
             },
             "require": {
@@ -183,9 +183,9 @@
             "description": "Model Context Protocol SDK for Client and Server applications in PHP",
             "support": {
                 "issues": "https://github.com/modelcontextprotocol/php-sdk/issues",
-                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.6.0"
+                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.7.1"
             },
-            "time": "2026-06-02T15:47:04+00:00"
+            "time": "2026-08-10T20:09:23+00:00"
         },
         {
             "name": "opis/json-schema",


### PR DESCRIPTION
Clears the `composer audit` failure that is currently red on `master`.

## Why

The advisory was published 2026-08-14, after master's last CI run on 2026-08-12, so the `build` job started failing without any code change:

```
Package           | mcp/sdk
Severity          |
Advisory ID       | PKSA-p9gd-j6gr-6f9t
CVE               | CVE-2026-53965
Title             | Client HttpTransport SSE buffer grows unbounded when
                  | server withholds the event delimiter
Affected versions | >=0.5.0,<0.7.1
```

`composer.lock` pinned `v0.6.0`. Under caret semantics for `0.x`, `^0.6.0` does not admit `0.7.x`, so the constraint has to move rather than just re-locking: `^0.6.0` → `^0.7.1`.

Note the advisory is in the SDK's **client** `HttpTransport`. WebCalendar only runs the server side, so exposure looks nil in practice — but this is what is failing CI, and the fix is a one-line constraint change, so it is not worth carrying a suppression for.

## Compatibility

`0.6 → 0.7` is a breaking-change window under `0.x` semver, so I checked the actual surface rather than assuming. WebCalendar touches exactly two SDK symbols:

| Symbol | Used by |
|---|---|
| `Mcp\Server` | `includes/functions.php:6773`, `mcp.php:329` (both `class_exists()` guards) |
| `Mcp\Capability\Attribute\McpTool` | `mcp.php:344` |

Both still resolve under 0.7.1 through the hand-rolled PSR-4 autoloader in `includes/mcp-loader.php`, which hardcodes `vendor/mcp/sdk/src/` — that layout is unchanged. Verified directly:

```
$ php -r "require 'includes/mcp-loader.php';
          var_dump(class_exists('Mcp\Server', true));
          var_dump(class_exists('Mcp\Capability\Attribute\McpTool', true));"
bool(true)
bool(true)
```

The lock diff is `mcp/sdk` only — `0 installs, 1 update, 0 removals`, no transitive dependency churn.

## Test plan

- [x] `composer audit` — "No security vulnerability advisories found" (run with Composer 2.10.2; the `audit` subcommand does not exist in older releases)
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 658 tests, 2121 assertions, passing
- [x] `vendor/bin/phpunit tests/McpTest.php` — 55 tests, 237 assertions, passing
- [x] `./tests/mcp-integration-test.sh --cleanup` — 29 passed, 1 failed
- [x] `./tests/compile_test.sh` — 273 files ok
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] Confirmed `Mcp\Server` and `McpTool` still autoload via `includes/mcp-loader.php`
- [ ] CI green

### About that 1 integration-test failure

`Query param token auth should be rejected but was accepted` — **pre-existing and unrelated to this bump.** Two independent confirmations:

1. I re-ran the identical script on `master` with `v0.6.0` restored, in the same environment: same 29/1 result, same assertion, same message.
2. It passes in CI on #704, a branch that does not touch `composer.*`.

So it is a local-environment artifact, not a regression. Worth noting for whoever looks at it next: the assertion greps for `"API token required"` but the server actually answers

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid API token"}}
```

The request **is** rejected, so the security behaviour is correct — the failure text ("was accepted") is misleading and the assertion string is what is stale. Out of scope here; happy to file it separately.

## Risk

Low. One constraint plus its lock entry. Only affects deployments that run the MCP server and install dependencies with Composer — `vendor/` is not in `release-files`, so release ZIPs are unaffected.
