### PR TITLE
fix: keep admin.php working after wizard/ is removed (#707)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -86,7 +86,7 @@ Halt on any failure. Do not "fix and retry" — surface the failure to the user.
 ./bump_version.sh vX.Y.Z                            # explicit version
 ```
 
-This updates: `wizard/shared/default_config.php`, `wizard/shared/upgrade_matrix.php`, `includes/config.php` (`$PROGRAM_VERSION` + `$PROGRAM_DATE`), `composer.json`, `composer.lock`, `.npmrc`, `wizard/shared/tables-*.sql`, `wizard/shared/tables-sqlite*.php`, `wizard/shared/upgrade-sql.php` (adds empty placeholder entry), and the four wizard files (`index.php`, `headless.php`, `wizard.js`, `WizardState.php`).
+This updates: `includes/default_config.php`, `wizard/shared/upgrade_matrix.php`, `includes/config.php` (`$PROGRAM_VERSION` + `$PROGRAM_DATE`), `composer.json`, `composer.lock`, `.npmrc`, `wizard/shared/tables-*.sql`, `wizard/shared/tables-sqlite*.php`, `wizard/shared/upgrade-sql.php` (adds empty placeholder entry), and the four wizard files (`index.php`, `headless.php`, `wizard.js`, `WizardState.php`).
 
 Confirm by running `./bump_version.sh -p` — should show the new version.
 
@@ -213,7 +213,7 @@ Wait for explicit "go" / "yes" / equivalent confirmation. Do **not** assume.
 # stage only what actually changed (commonly just CHANGELOG.md).
 git add \
   CHANGELOG.md \
-  wizard/shared/default_config.php \
+  includes/default_config.php \
   wizard/shared/upgrade_matrix.php \
   includes/config.php \
   composer.json composer.lock \
@@ -328,7 +328,7 @@ Tell the user:
 
 | File | What's updated |
 |---|---|
-| `wizard/shared/default_config.php` | `WEBCAL_PROGRAM_VERSION` |
+| `includes/default_config.php` | `WEBCAL_PROGRAM_VERSION` |
 | `wizard/shared/upgrade_matrix.php` | `$PROGRAM_VERSION` |
 | `includes/config.php` | `$PROGRAM_VERSION`, `$PROGRAM_DATE` |
 | `composer.json` + `composer.lock` | `version` field |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Config defaults and `db_load_config()` moved from `wizard/shared/default_config.php` to `includes/default_config.php`. The wizard still reads it as the single source of truth, but it is no longer inside a directory administrators are told to delete (#707)
+
 ### Fixed
+
+- Admin Settings no longer returns a 500 error after following the security audit's advice to remove or `chmod 000` the `wizard/` directory. `admin.php` hard-required a file from `wizard/`, so either action made the page fatal (#707)
+- The security audit's "Wizard directory exists" check now passes when `wizard/` has been made unreadable. It only tested `is_dir()`, which still succeeds on a `chmod 000` directory, so the "restrict permissions" option the audit itself recommends could never clear the item (#707)
 
 ### Removed
 

--- a/admin.php
+++ b/admin.php
@@ -1,10 +1,12 @@
 <?php
 require_once 'includes/init.php';
 require_once 'includes/date_formats.php';
-// Provides db_load_config(). Do NOT load the obsolete pre-1.9.13
+// Provides db_load_config(). This lives in includes/ so that admin.php keeps
+// working after the wizard/ directory is removed or made unreadable, as the
+// security audit recommends. Do NOT load the obsolete pre-1.9.13
 // install/default_config.php here; leftover copies from old installs
 // use each(), which was removed in PHP 8.
-require_once 'wizard/shared/default_config.php';
+require_once 'includes/default_config.php';
 
 // Force the CSS cache to clear by incrementing webcalendar_csscache cookie.
 // admin.php will not use this cached CSS, but we want to make sure it's flushed.
@@ -63,7 +65,7 @@ if ( ! empty ( $_POST ) && empty ( $error ) ) {
 }
 
 // Load any new config settings. Existing ones will not be affected.
-// This function is in the wizard/shared/default_config.php file.
+// This function is in the includes/default_config.php file.
 if ( function_exists ( 'db_load_config' ) && empty ( $_POST ) )
   db_load_config();
 

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -8,7 +8,7 @@
 #   ./bump_version.sh -p          # Print current version and exit
 #
 # Run this script before making a release. It updates the version number in:
-#   - wizard/shared/default_config.php  (WEBCAL_PROGRAM_VERSION)
+#   - includes/default_config.php        (WEBCAL_PROGRAM_VERSION)
 #   - wizard/shared/upgrade_matrix.php  (PROGRAM_VERSION)
 #   - includes/config.php               (PROGRAM_VERSION and PROGRAM_DATE)
 #   - composer.json                     (version field)
@@ -33,10 +33,10 @@ bump_version() {
     echo "v$major.$minor.$patch"
 }
 
-# Function to update version in wizard/shared/default_config.php
+# Function to update version in includes/default_config.php
 update_default_config_version() {
     local new_version="$1"
-    sed -i -E "s/('WEBCAL_PROGRAM_VERSION' => ')[^']*(')/\1$new_version\2/" wizard/shared/default_config.php
+    sed -i -E "s/('WEBCAL_PROGRAM_VERSION' => ')[^']*(')/\1$new_version\2/" includes/default_config.php
 }
 
 # Function to update version and date in includes/config.php
@@ -130,7 +130,7 @@ update_wizard_files() {
 # Function to print current version
 print_version() {
     local version
-    version=$(grep 'WEBCAL_PROGRAM_VERSION' wizard/shared/default_config.php | sed -E "s/.*'WEBCAL_PROGRAM_VERSION' => '([^']*)'.*/\1/")
+    version=$(grep 'WEBCAL_PROGRAM_VERSION' includes/default_config.php | sed -E "s/.*'WEBCAL_PROGRAM_VERSION' => '([^']*)'.*/\1/")
     echo "$version" | tr -d v
 }
 
@@ -141,7 +141,7 @@ if [ "$1" == "-p" ]; then
     exit 0
 elif [ "$#" -eq 0 ]; then
     # No arguments provided, bump the version
-    current_version=$(grep 'WEBCAL_PROGRAM_VERSION' wizard/shared/default_config.php | sed -E "s/.*'WEBCAL_PROGRAM_VERSION' => '([^']*)'.*/\1/")
+    current_version=$(grep 'WEBCAL_PROGRAM_VERSION' includes/default_config.php | sed -E "s/.*'WEBCAL_PROGRAM_VERSION' => '([^']*)'.*/\1/")
     new_version=$(bump_version "$current_version")
 else
     # Argument provided, use it as the new version

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ Common settings (partial list):
 | `MCP_RATE_LIMIT` | integer | MCP requests per minute limit |
 
 Defaults for all settings are defined in
-`wizard/shared/default_config.php`.
+`includes/default_config.php`.
 
 ## User Preferences
 

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -55,7 +55,7 @@ For routine version upgrades within the 1.9.x line, see
 |----------------------------|-------------------|
 | `install/index.php` | `wizard/index.php` |
 | `install/sql/` | `wizard/shared/` |
-| `install/default_config.php` | `wizard/shared/default_config.php` |
+| `install/default_config.php` | `includes/default_config.php` |
 | `install/settings.php` (wizard password) | `includes/settings.php` (all config) |
 
 The old `install/` directory no longer exists. If your deployment scripts

--- a/includes/config.php
+++ b/includes/config.php
@@ -188,7 +188,7 @@ function do_config($callingFromInstall=false)
   // Define possible app settings and their types
   $possible_settings = $config_possible_settings;
 
-  // When changing PROGRAM VERSION, also change it in wizard/shared/default_config.php
+  // When changing PROGRAM VERSION, also change it in includes/default_config.php
   $PROGRAM_VERSION = 'v1.9.23';
   // Update PROGRAM_DATE with official release data
   $PROGRAM_DATE = '12 Aug 2026';

--- a/includes/default_config.php
+++ b/includes/default_config.php
@@ -2,6 +2,10 @@
 /**
  * The file contains a listing of all the current WebCalendar config settings
  * and their default values.
+ *
+ * This lives in includes/ rather than wizard/ because admin.php needs
+ * db_load_config() at runtime, and the security audit tells administrators
+ * they may delete or chmod 000 the wizard/ directory after installing.
  */
 $webcalConfig = [
   'ADD_LINK_IN_VIEWS' => 'N',
@@ -163,7 +167,7 @@ $webcalConfig = [
 ];
 
 /**
- * db_load_config (needs description)
+ * db_load_config
  *
  * This function is defined here because admin.php calls it during startup.
  * Load default configuration values into the webcal_config table but only

--- a/release-files
+++ b/release-files
@@ -147,6 +147,7 @@ includes/date_formats.php
 includes/date_selectors.php
 includes/dbi4php.php
 includes/dbtable.php
+includes/default_config.php
 includes/formvars.php
 includes/functions.php
 includes/gradient.php
@@ -472,7 +473,6 @@ wizard/WizardState.php
 wizard/WizardValidator.php
 wizard/headless.php
 wizard/index.php
-wizard/shared/default_config.php
 wizard/shared/tables-db2.sql
 wizard/shared/tables-ibase.sql
 wizard/shared/tables-mysql.sql

--- a/security_audit.php
+++ b/security_audit.php
@@ -57,10 +57,14 @@ print_header();
     translate('You should change the password of the default admin user.')
   );
 
-  // Is the wizard directory still present?
+  // Is the wizard directory still present and reachable?  A directory that
+  // has been chmod 000'd still passes is_dir(), so check readability too --
+  // otherwise the "restrict permissions" advice below could never clear this
+  // item.  admin.php no longer needs anything from wizard/, so either fix is
+  // safe (see issue #707).
   print_issue(
     translate('Wizard directory exists'),
-    (!is_dir('wizard')),
+    (!is_dir('wizard') || !is_readable('wizard')),
     translate('The wizard/ directory is still present. It is password-protected, but you may restrict access for extra security.') . ' '
     . translate('Options - restrict permissions') . ' (<code>chmod 000 wizard/</code>), '
     . translate('move outside web root, or remove it') . ' (<code>rm -rf wizard/</code>).'

--- a/tests/WizardRemovableTest.php
+++ b/tests/WizardRemovableTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #707 — the wizard/ directory must stay removable.
+ *
+ * security_audit.php tells administrators they may `chmod 000 wizard/` or
+ * `rm -rf wizard/` once the install is done.  Any runtime page that hard
+ * requires a file from wizard/ turns that advice into a fatal error (a 500
+ * on admin.php, in the reported case).
+ *
+ * These are source-structure regression tests: they fail the build if a
+ * future change reintroduces a runtime dependency on wizard/, moves the
+ * config defaults back under wizard/, or drops the new file from the
+ * release manifest (which would ship a release that cannot render
+ * admin.php at all).
+ */
+final class WizardRemovableTest extends TestCase
+{
+  private const ROOT = __DIR__ . '/..';
+
+  /**
+   * Runtime pages -- everything a browser can reach outside wizard/ itself.
+   */
+  private function runtimeSources(): array
+  {
+    $files = array_merge(
+      glob(self::ROOT . '/*.php') ?: [],
+      glob(self::ROOT . '/includes/*.php') ?: [],
+      glob(self::ROOT . '/includes/classes/*.php') ?: []
+    );
+
+    // run_install.php is an explicit wrapper around the installer, so it is
+    // allowed to depend on wizard/.
+    return array_values(array_filter($files, static function ($f) {
+      return basename($f) !== 'run_install.php';
+    }));
+  }
+
+  public function testNoRuntimePageIncludesFromWizard(): void
+  {
+    $offenders = [];
+
+    foreach ($this->runtimeSources() as $file) {
+      $src = file_get_contents($file);
+      self::assertNotFalse($src, "Could not read $file");
+
+      if (preg_match_all(
+        '/\b(?:require|include)(?:_once)?\s*\(?\s*[\'"][^\'"]*wizard\//',
+        $src,
+        $matches
+      )) {
+        $offenders[] = basename($file) . ' (' . count($matches[0]) . ')';
+      }
+    }
+
+    self::assertSame(
+      [],
+      $offenders,
+      'These runtime pages include a file from wizard/, so they fatal once '
+      . 'an admin follows the security audit advice to remove or chmod 000 '
+      . 'the wizard/ directory (issue #707): ' . implode(', ', $offenders)
+    );
+  }
+
+  public function testConfigDefaultsLiveOutsideWizard(): void
+  {
+    self::assertFileExists(
+      self::ROOT . '/includes/default_config.php',
+      'The config defaults and db_load_config() must live in includes/ so '
+      . 'admin.php keeps working without wizard/.'
+    );
+    self::assertFileDoesNotExist(
+      self::ROOT . '/wizard/shared/default_config.php',
+      'default_config.php must not be duplicated back under wizard/; the '
+      . 'wizard reads includes/default_config.php as the single source of '
+      . 'truth.'
+    );
+  }
+
+  public function testDefaultConfigDefinesSettingsAndLoader(): void
+  {
+    $webcalConfig = null;
+    require self::ROOT . '/includes/default_config.php';
+
+    self::assertIsArray($webcalConfig);
+    self::assertNotEmpty($webcalConfig);
+    self::assertArrayHasKey('WEBCAL_PROGRAM_VERSION', $webcalConfig);
+    self::assertTrue(
+      function_exists('db_load_config'),
+      'admin.php calls db_load_config() to seed config settings added by an '
+      . 'upgrade; includes/default_config.php must define it.'
+    );
+  }
+
+  public function testReleaseManifestShipsDefaultConfig(): void
+  {
+    $manifest = file(
+      self::ROOT . '/release-files',
+      FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+    );
+    self::assertNotFalse($manifest);
+
+    self::assertContains(
+      'includes/default_config.php',
+      $manifest,
+      'The release ZIP ships only files listed in release-files; omitting '
+      . 'includes/default_config.php would make admin.php fatal in every '
+      . 'released build.'
+    );
+    self::assertNotContains('wizard/shared/default_config.php', $manifest);
+  }
+
+  public function testAuditTreatsUnreadableWizardAsResolved(): void
+  {
+    $src = file_get_contents(self::ROOT . '/security_audit.php');
+    self::assertNotFalse($src);
+
+    self::assertStringContainsString(
+      "!is_dir('wizard') || !is_readable('wizard')",
+      $src,
+      'The audit recommends `chmod 000 wizard/`, but a 000 directory still '
+      . 'passes is_dir(), so the check must also test readability or the '
+      . 'recommendation can never clear the item (issue #707).'
+    );
+  }
+}

--- a/tests/web-install-mysql.py
+++ b/tests/web-install-mysql.py
@@ -374,7 +374,7 @@ def get_expected_version():
     
     # Fallback: parse directly from default_config.php
     try:
-        with open("/work/wizard/shared/default_config.php", "r") as f:
+        with open("/work/includes/default_config.php", "r") as f:
             content = f.read()
             match = re.search(r"'WEBCAL_PROGRAM_VERSION' => '([^']+)'", content)
             if match:

--- a/tests/web-install-postgresql.py
+++ b/tests/web-install-postgresql.py
@@ -329,7 +329,7 @@ def get_expected_version():
     
     # Fallback: parse directly from default_config.php
     try:
-        with open("/work/wizard/shared/default_config.php", "r") as f:
+        with open("/work/includes/default_config.php", "r") as f:
             content = f.read()
             match = re.search(r"'WEBCAL_PROGRAM_VERSION' => '([^']+)'", content)
             if match:

--- a/tests/web-install-sqlite.py
+++ b/tests/web-install-sqlite.py
@@ -373,7 +373,7 @@ def get_expected_version():
 
     # Fallback: parse directly from default_config.php
     try:
-        with open("/work/wizard/shared/default_config.php", "r") as f:
+        with open("/work/includes/default_config.php", "r") as f:
             content = f.read()
             match = re.search(r"'WEBCAL_PROGRAM_VERSION' => '([^']+)'", content)
             if match:

--- a/wizard/README.md
+++ b/wizard/README.md
@@ -105,8 +105,7 @@ wizard/
 │   ├── adminuser.php
 │   ├── summary.php
 │   └── finish.php
-└── shared/                # SQL schemas, config defaults, and upgrade logic
-    ├── default_config.php
+└── shared/                # SQL schemas and upgrade logic
     ├── tables-mysql.sql
     ├── tables-postgres.sql
     ├── tables-sqlite3.php

--- a/wizard/WizardDatabase.php
+++ b/wizard/WizardDatabase.php
@@ -588,12 +588,12 @@ class WizardDatabase
 
   /**
    * Insert default config values for fresh installs.
-   * Reads from shared/default_config.php (single source of truth).
+   * Reads from ../includes/default_config.php (single source of truth).
    * Skips WEBCAL_PROGRAM_VERSION since loadBaseSchema already inserts it.
    */
   private function loadDefaultConfig(): bool
   {
-    require __DIR__ . '/shared/default_config.php';
+    require __DIR__ . '/../includes/default_config.php';
 
     foreach ($webcalConfig as $key => $val) {
       if ($key === 'WEBCAL_PROGRAM_VERSION') continue;


### PR DESCRIPTION
Fixes #707.

## The bug

`security_audit.php` tells administrators they may `chmod 000 wizard/` or `rm -rf wizard/` once installation is done. But `admin.php:7` hard-required a file from that directory:

```php
require_once 'wizard/shared/default_config.php';   // provides db_load_config()
```

Either action turns Admin Settings into an uncaught `Error: Failed opening required` — a 500. `@` suppression does not help; `require_once` is fatal regardless.

**This is a regression from c8e40608** (the #693 fix). Before that commit the include was guarded with `file_exists()`.

## A second defect in the audit

The check is `(!is_dir('wizard'))`. After `chmod 000 wizard/`, `is_dir('wizard')` still returns **true** — the directory is stat-able, only traversal is denied. So the "restrict permissions" option the audit itself recommends:

- does **not** clear the audit item, and
- **does** break admin.php.

The advice and the check disagreed with each other.

## Why not just guard the include

`db_load_config()` is the only thing that seeds *newly added* config settings after an upgrade — `wizard/shared/upgrade-sql.php` contains no `INSERT INTO webcal_config` for defaults. And `admin.php` has 52 unguarded `$s['SETTING']` reads. Guarding the include would trade a 500 for a page full of `Undefined array key` warnings on some upgrade paths.

So instead the dependency moves out of the directory admins are told to delete.

## Changes

- **`wizard/shared/default_config.php` → `includes/default_config.php`.** `wizard/WizardDatabase.php` still reads it as the single source of truth. `admin.php` requires the new path. `wizard/` now has **no runtime consumers** — `includes/config.php`'s references were already `file_exists()`-guarded.
- **`security_audit.php`**: the check now treats an unreadable `wizard/` as resolved. Translation strings are untouched, so no locale regressions.
- **Followers of the move**: `release-files`, `bump_version.sh`, `.claude/skills/release/SKILL.md`, the three `tests/web-install-*.py` scripts, `docs/configuration.md`, `docs/migration-v2.md`, `wizard/README.md`. `bump_version.sh` matters most — it writes `WEBCAL_PROGRAM_VERSION` into this file, so a stale path would have silently shipped the wrong version.
- **`tests/WizardRemovableTest.php`** (new): fails the build if any runtime page reintroduces a `require` from `wizard/`, if the defaults move back under `wizard/`, if the new file is dropped from the release manifest, or if the audit check loses its readability test.

## Test plan

- [x] Full suite: 672 tests, 2310 assertions, all pass
- [x] PHPStan: no errors
- [x] `tests/compile_test.sh`: 275 files ok
- [x] New test verified to catch the regression (its regex matches the old `require_once` line, not the new one)
- [x] `McpIntegrationTest` exercises `wizard/headless.php` end-to-end, confirming the installer still resolves the moved file
- [x] **End-to-end reproduction**: headless SQLite install (156 config rows seeded from the new path, version `v1.9.23`), then `rm -rf wizard/`. `admin.php` → **200** with the full settings form. Reverting *only* the require line to the old path on that same tree → **500**.
- [x] Audit check verified against a real `chmod 000` directory: old check reports unresolved, new check reports resolved.

One pre-existing, unrelated warning surfaced during the manual test: `Undefined array key "SERVER_URL"` at `admin.php:273`. `SERVER_URL` is not in the defaults array on `master` either — it is normally written by the wizard's settings step, which `--use-env` headless installs skip. Not touched here.
