### PR TITLE
fix: repair Purge Events and the login page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Admin Settings no longer returns a 500 error after following the security audit's advice to remove or `chmod 000` the `wizard/` directory. `admin.php` hard-required a file from `wizard/`, so either action made the page fatal (#707)
 - The security audit's "Wizard directory exists" check now passes when `wizard/` has been made unreadable. It only tested `is_dir()`, which still succeeds on a `chmod 000` directory, so the "restrict permissions" option the audit itself recommends could never clear the item (#707)
+- Purge Events now works at all. Its Delete button carried no `value` attribute, so browsers submitted an empty `delete=`, the `! empty()` guard never fired, and clicking Delete silently redisplayed the form. Reported by Tom (shycat.net)
+- Purge Events reads the date field the form actually renders. It looked for `end_year`/`end_month`/`end_day`, but `date_selection()` emits a single `end__YMD` input, so the cutoff was always `00000000` and a date-based purge matched nothing. Reported by Tom (shycat.net)
+- **Purge Events no longer ignores "Purge deleted only" when All users is selected.** That branch overwrote the SQL tail instead of appending to it, discarding the status restriction — an admin asking to purge deleted events would have irreversibly purged every event before the cutoff. This was unreachable only because the Delete button was inert; fixing the button without this would have armed it
+- Purge Events reports accurate row counts. Its date query joined `webcal_entry_user` with no join condition, producing a cartesian product that multiplied every count by the number of participant rows. Reported by Tom (shycat.net)
+- Purge Events no longer errors when "Purge deleted only" is used with a named user. That query filtered on `weu.cal_status` without `webcal_entry_user` in its `FROM` clause. Reported by Tom (shycat.net)
+- A completed purge is no longer labelled `[Preview]`. The results line hardcoded the prefix, so an irreversible delete reported itself as a dry run
+- Login page layout is centered and no longer double-padded. `#login-container` was a Bootstrap `.container` nested inside another `.container`, and every wrapper in the form used `.row` with no column child, so the negative row margins pulled the form off-centre and toward the screen edge on narrow viewports. Reported by Tom (shycat.net)
+- Login page labels are associated with their inputs. "Username:" pointed at `login`, which resolved to `<body id="login">` rather than the text field, and "Remember me" pointed at `exampleCheck1`, a leftover from the Bootstrap docs that does not exist on the page. Neither label did anything when clicked
 
 ### Removed
 

--- a/login.php
+++ b/login.php
@@ -235,10 +235,11 @@ if ( ! empty ( $CUSTOM_HEADER ) && $CUSTOM_HEADER == 'Y' ) {
   echo load_template ( $login, 'H' );
 }
 ?>
-<div id="login-container" class="container">
-<div class="row pl-3">
+<div id="login-container">
+<div class="row justify-content-center">
+  <div class="col-12 col-sm-8 col-md-6 col-lg-4">
   <form id="login-form" class="form" action="login.php" method="post">
-    <div class="row justify-content-md-center">
+    <div class="text-center">
       <h3><?php echo htmlentities($appStr); ?> Login</h3>
     </div>
   <?php if ( ! empty ( $message )) { ?>
@@ -251,19 +252,19 @@ if ( ! empty ( $CUSTOM_HEADER ) && $CUSTOM_HEADER == 'Y' ) {
       <?php echo $error; ?>
     </div>
   <?php } ?>
-    <div class="form-group row">
-      <label for="login" class="text-info">Username:</label><br>
+    <div class="form-group">
+      <label for="user" class="text-info">Username:</label><br>
       <input type="text" name="login" id="user" class="form-control">
     </div>
-    <div class="form-group row">
+    <div class="form-group">
       <label for="password" class="text-info">Password:</label><br>
       <input type="password" name="password" id="password" class="form-control">
     </div>
-    <div class="form-group form-check row">
+    <div class="form-group form-check">
       <input type="checkbox" class="form-check-input" id="remember-me" name="remember" value="yes">
-      <label class="form-check-label" for="exampleCheck1">Remember me</label>
+      <label class="form-check-label" for="remember-me">Remember me</label>
     </div>
-    <div class="form-group row justify-content-md-center">
+    <div class="form-group text-center">
       <button class="btn btn-primary" type="submit"><?php
  etranslate ( 'Submit' )?></button>
     </div>
@@ -276,7 +277,7 @@ if ( ! empty ( $CUSTOM_HEADER ) && $CUSTOM_HEADER == 'Y' ) {
       $accessStr = translate ( 'Access XXX calendar' );
       for ( $i = 0, $cnt = count ( $cals ); $i < $cnt; $i++ ) {
         if ( $cals[$i]['cal_is_public'] == 'Y' ) {
-          echo '<li id="form_' . $cals[$i]['cal_login'] . '" class="form-group row">' .
+          echo '<li id="form_' . $cals[$i]['cal_login'] . '" class="form-group">' .
             '<a class="nav" href="nulogin.php?login=' . $cals[$i]['cal_login'] . '">'
             . str_replace ( 'XXX', $cals[$i]['cal_fullname'], $accessStr )
             . '</a></li>';
@@ -290,13 +291,14 @@ if ( ! empty ( $CUSTOM_HEADER ) && $CUSTOM_HEADER == 'Y' ) {
         $valid_ip = validate_domain();
 
         if ( ! empty ( $valid_ip ) ) {
-          echo '<div id="register-link" class="form-group row"><a href="register.php">'
+          echo '<div id="register-link" class="form-group"><a href="register.php">'
            . translate ( 'Not yet registered? Register here!' ) . '</a></div>';
         }
       }
     ?>
 
   </form>
+  </div>
 </div>
 </div>
 

--- a/purge.php
+++ b/purge.php
@@ -20,7 +20,6 @@ if ( ! $is_admin ) {
   exit;
 }
 
-$ALL = 0;
 // Set this to true do show the SQL at the bottom of the page
 $purgeDebug = false;
 $sqlLog     = '';
@@ -35,9 +34,10 @@ $do_purge = ( ! empty ( $delete ) );
 
 $purge_all = getPostValue ( 'purge_all' );
 $purge_deleted = getPostValue ( 'purge_deleted' );
-$end_year = getPostValue ( 'end_year' );
-$end_month = getPostValue ( 'end_month' );
-$end_day = getPostValue ( 'end_day' );
+// date_selection() renders a single HTML5 date input named "end__YMD"
+// (prefix "end_" + "_YMD"), not the three end_year/end_month/end_day
+// fields this page used to read.
+$end_date = str_replace ( '-', '', getPostValue ( 'end__YMD' ) );
 $username = getPostValue ( 'username' );
 $preview = ( ! empty ( getPostValue ( 'preview' ) ) );
 
@@ -65,37 +65,7 @@ if ( $do_purge ) {
     echo "$purgingStr: $username";
 
   echo "</h2>\n";
-  $end_date = sprintf ( "%04d%02d%02d", $end_year, $end_month, $end_day );
-  $ids = $tail = '';
-  if ( $purge_deleted == 'Y' )
-    $tail = " AND weu.cal_status = 'D' ";
-
-  if ( $purge_all == 'Y' ) {
-    if ( $username == 'ALL' ) {
-      $ids =  ['ALL'];
-    } else {
-      $ids = get_ids ( 'SELECT cal_id FROM webcal_entry '
-        . " WHERE cal_create_by = '$username' $tail" );
-    }
-  } elseif ( $end_date ) {
-    if ( $username != 'ALL' ) {
-      $tail = " AND we.cal_create_by = '$username' $tail";
-    } else {
-      $tail = '';
-      $ALL = 1;  // Need this to tell get_ids to ignore participant check
-    }
-    $E_ids = get_ids ( 'SELECT we.cal_id FROM webcal_entry we, webcal_entry_user weu ' .
-      "WHERE cal_type = 'E' AND cal_date < '$end_date' $tail",
-      $ALL );
-    $M_ids = get_ids ( 'SELECT DISTINCT(we.cal_id) FROM webcal_entry we,
-      webcal_entry_user weu, webcal_entry_repeats wer
-      WHERE we.cal_type = \'M\'
-      AND we.cal_id = wer.cal_id AND weu.cal_id = wer.cal_id '
-      . "AND cal_end IS NOT NULL AND cal_end < '$end_date' $tail",
-      $ALL );
-    $ids = array_merge ( $E_ids, $M_ids );
-  }
-  //echo "event ids: <ul><li>" . implode ( "</li><li>", $ids ) . "</li></ul>\n";
+  $ids = get_purge_ids ( $purge_all, $username, $end_date, $purge_deleted );
   if ( count ( $ids ) > 0 ) {
     purge_events ( $ids );
   } else {
@@ -153,7 +123,7 @@ if ( $do_purge ) {
   <input class="form-control-sm" type="checkbox" name="preview" value="Y" checked>
  </td></tr>
  <tr><td colspan="2">
-   <button class="btn btn-primary" name="delete" type="submit" onclick="return
+   <button class="btn btn-primary" name="delete" value="Y" type="submit" onclick="return
  confirm('<?php
  etranslate ( 'Are you sure you want to delete events for', true ) ?> ' +
  document.forms[0].username.value + '?')"><?php echo $deleteStr?></button>
@@ -164,6 +134,64 @@ if ( $do_purge ) {
 </td></tr></table>
 
 <?php echo print_trailer();
+/**
+ * get_purge_ids
+ *
+ * Work out which event ids a purge would affect.  Extracted from the page
+ * body so the selection rules can be regression-tested directly -- see
+ * tests/PurgeEventSelectionTest.php.
+ *
+ * @param  string $purge_all      'Y' to purge every event for the user
+ * @param  string $username       Calendar login, or 'ALL' for every user
+ * @param  string $end_date       YYYYMMDD cutoff; events before it are purged
+ * @param  string $purge_deleted  'Y' to restrict to events marked deleted
+ *
+ * @return array  Event ids, or the single entry 'ALL' to purge everything
+ */
+function get_purge_ids ( $purge_all, $username, $end_date, $purge_deleted ) {
+  $ALL = 0;  // Tells get_ids whether to skip the "no other participants" check
+  $tail = '';
+  // Every query below joins webcal_entry_user as weu, so this stays valid
+  // no matter which branch we take.
+  if ( $purge_deleted == 'Y' )
+    $tail = " AND weu.cal_status = 'D' ";
+
+  if ( $purge_all == 'Y' ) {
+    if ( $username == 'ALL' )
+      return ['ALL'];
+
+    return get_ids ( 'SELECT DISTINCT we.cal_id
+      FROM webcal_entry we, webcal_entry_user weu
+      WHERE weu.cal_id = we.cal_id AND we.cal_create_by = ?' . $tail,
+      [$username] );
+  }
+
+  if ( empty ( $end_date ) )
+    return [];
+
+  $params = [$end_date];
+  if ( $username == 'ALL' ) {
+    $ALL = 1;
+  } else {
+    // Append, never overwrite: $tail may already carry the "deleted only"
+    // restriction the admin asked for.
+    $tail .= ' AND we.cal_create_by = ?';
+    $params[] = $username;
+  }
+  $E_ids = get_ids ( 'SELECT DISTINCT we.cal_id
+    FROM webcal_entry we, webcal_entry_user weu
+    WHERE weu.cal_id = we.cal_id
+    AND we.cal_type = \'E\' AND we.cal_date < ?' . $tail,
+    $params, $ALL );
+  $M_ids = get_ids ( 'SELECT DISTINCT we.cal_id FROM webcal_entry we,
+    webcal_entry_user weu, webcal_entry_repeats wer
+    WHERE we.cal_type = \'M\'
+    AND we.cal_id = wer.cal_id AND weu.cal_id = wer.cal_id
+    AND wer.cal_end IS NOT NULL AND wer.cal_end < ?' . $tail,
+    $params, $ALL );
+
+  return array_merge ( $E_ids, $M_ids );
+}
 /**
  * purge_events
  *
@@ -217,9 +245,11 @@ function purge_events ( $ids ) {
     }
   }
   $xxxStr = translate( 'Records deleted from XXX' );
+  // Only a preview run may claim to be one -- a real purge is irreversible.
+  $prefix = ( $preview ? '[' . $previewStr . '] ' : '' );
   for ( $i = 0; $i < $cnt; $i++ ) {
     $table = $tables[$i][0];
-    echo '[' . $previewStr . '] ' .
+    echo $prefix .
       str_replace( 'XXX', " $table: {$num[$i]}" , $xxxStr ) .
       "<br>\n";
   }
@@ -227,15 +257,16 @@ function purge_events ( $ids ) {
 /**
  * get_ids
  *
- * @param  mixed  $sql
- * @param  mixed  $ALL
+ * @param  string $sql     Query returning cal_id in the first column
+ * @param  array  $params  Values to bind to the query's placeholders
+ * @param  mixed  $ALL     Set to 1 to skip the "no other participants" check
  */
-function get_ids ( $sql, $ALL = '' ) {
+function get_ids ( $sql, $params = [], $ALL = '' ) {
   global $sqlLog;
 
   $ids = [];
   $sqlLog .= $sql . "<br>\n";
-  $res = dbi_execute ( $sql );
+  $res = dbi_execute ( $sql, $params );
   if ( $res ) {
     while ( $row = dbi_fetch_row ( $res ) ) {
       if ($ALL == 1)

--- a/tests/PurgeEventSelectionTest.php
+++ b/tests/PurgeEventSelectionTest.php
@@ -1,0 +1,287 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for purge.php, covering a cluster of bugs that between
+ * them left the page unable to purge anything -- and, once it could, able to
+ * purge more than the admin asked for.  Reported by Tom (shycat.net).
+ *
+ * 1. The Delete button carried no value attribute, so browsers submitted
+ *    "delete=" and the $do_purge guard was never true: the page did nothing.
+ * 2. The page read end_year/end_month/end_day, but date_selection() renders a
+ *    single "end__YMD" input, so the date cutoff was always "00000000".
+ * 3. The purge-all query referenced weu.cal_status with no webcal_entry_user
+ *    in its FROM clause -- a SQL error whenever "purge deleted only" was set.
+ * 4. The date query joined webcal_entry_user with no join condition, so it
+ *    returned a cartesian product and reported inflated row counts.
+ * 5. The "ALL users" branch overwrote $tail instead of appending to it,
+ *    silently discarding the "deleted only" restriction. An admin asking to
+ *    purge deleted events would have purged every event before the cutoff.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class PurgeEventSelectionTest extends TestCase
+{
+  private string $dbFile;
+
+  protected function setUp(): void
+  {
+    $this->dbFile = tempnam(sys_get_temp_dir(), 'wc_purge_');
+
+    $GLOBALS['db_type'] = 'sqlite3';
+    $GLOBALS['db_persistent'] = false;
+    $GLOBALS['sqlLog'] = '';
+
+    require_once __DIR__ . '/../includes/dbi4php.php';
+
+    dbi_connect('', '', '', $this->dbFile, false);
+    $this->createSchema();
+    $this->seedFixture();
+    $this->loadPurgeFunctions();
+  }
+
+  protected function tearDown(): void
+  {
+    if (isset($GLOBALS['sqlite3_c']) && $GLOBALS['sqlite3_c'] instanceof SQLite3) {
+      @$GLOBALS['sqlite3_c']->close();
+    }
+    if (!empty($this->dbFile) && file_exists($this->dbFile)) {
+      @unlink($this->dbFile);
+    }
+  }
+
+  /**
+   * purge.php is a page, not a library: it redirects non-admins on include.
+   * Pull just the two functions under test out of the source so we exercise
+   * the real code rather than a copy of it.
+   */
+  private function loadPurgeFunctions(): void
+  {
+    if (function_exists('get_purge_ids')) {
+      return;
+    }
+    $src = file_get_contents(__DIR__ . '/../purge.php');
+    self::assertNotFalse($src);
+
+    $fns = '';
+    foreach (['get_purge_ids', 'get_ids'] as $name) {
+      $start = strpos($src, "function $name (");
+      self::assertNotFalse($start, "purge.php must define $name()");
+      // Walk braces from the function header to its matching close.
+      $open = strpos($src, '{', $start);
+      $depth = 0;
+      for ($i = $open; $i < strlen($src); $i++) {
+        if ($src[$i] === '{') $depth++;
+        if ($src[$i] === '}') {
+          $depth--;
+          if ($depth === 0) break;
+        }
+      }
+      $fns .= substr($src, $start, $i - $start + 1) . "\n";
+    }
+    eval($fns);
+  }
+
+  private function createSchema(): void
+  {
+    $ddl = [
+      'CREATE TABLE webcal_entry (
+         cal_id INTEGER PRIMARY KEY,
+         cal_create_by TEXT,
+         cal_date INTEGER,
+         cal_type TEXT,
+         cal_name TEXT
+       )',
+      'CREATE TABLE webcal_entry_user (
+         cal_id INTEGER,
+         cal_login TEXT,
+         cal_status TEXT
+       )',
+      'CREATE TABLE webcal_entry_repeats (
+         cal_id INTEGER,
+         cal_end INTEGER
+       )',
+    ];
+    foreach ($ddl as $sql) {
+      self::assertTrue((bool) dbi_execute($sql), 'schema DDL failed');
+    }
+  }
+
+  /**
+   * 101 old, alice only, accepted
+   * 102 old, alice + bob  -> shared, so a single-user purge must skip it
+   * 103 old, bob only, marked deleted
+   * 104 recent (2026), alice only -- must never match a 2021 cutoff
+   * 105 old repeating event ending 2020, alice only
+   */
+  private function seedFixture(): void
+  {
+    $events = [
+      [101, 'alice', 20200101, 'E'],
+      [102, 'alice', 20200102, 'E'],
+      [103, 'bob',   20200103, 'E'],
+      [104, 'alice', 20260101, 'E'],
+      [105, 'alice', 20200104, 'M'],
+    ];
+    foreach ($events as [$id, $by, $date, $type]) {
+      dbi_execute(
+        'INSERT INTO webcal_entry (cal_id, cal_create_by, cal_date, cal_type, cal_name)
+         VALUES (?, ?, ?, ?, ?)',
+        [$id, $by, $date, $type, "event $id"]
+      );
+    }
+
+    $participants = [
+      [101, 'alice', 'A'],
+      [102, 'alice', 'A'],
+      [102, 'bob',   'A'],
+      [103, 'bob',   'D'],
+      [104, 'alice', 'A'],
+      [105, 'alice', 'A'],
+    ];
+    foreach ($participants as [$id, $login, $status]) {
+      dbi_execute(
+        'INSERT INTO webcal_entry_user (cal_id, cal_login, cal_status)
+         VALUES (?, ?, ?)',
+        [$id, $login, $status]
+      );
+    }
+
+    dbi_execute('INSERT INTO webcal_entry_repeats (cal_id, cal_end) VALUES (?, ?)',
+      [105, 20200601]);
+  }
+
+  private function ids($purge_all, $username, $end_date, $purge_deleted): array
+  {
+    $ids = get_purge_ids($purge_all, $username, $end_date, $purge_deleted);
+    sort($ids);
+    return array_map('intval', $ids);
+  }
+
+  // ---- Bug 5: the dangerous one -------------------------------------
+
+  public function test_deleted_only_filter_survives_the_all_users_branch(): void
+  {
+    $ids = $this->ids('', 'ALL', '20210101', 'Y');
+
+    self::assertSame(
+      [103],
+      $ids,
+      'Only event 103 is marked deleted. Returning the others means an admin '
+      . 'who asked to purge deleted events would have purged every event '
+      . 'before the cutoff -- irreversibly.'
+    );
+  }
+
+  public function test_deleted_only_filter_survives_for_a_named_user(): void
+  {
+    self::assertSame([103], $this->ids('', 'bob', '20210101', 'Y'));
+  }
+
+  // ---- Bug 4: cartesian product -------------------------------------
+
+  public function test_each_event_is_returned_exactly_once(): void
+  {
+    $ids = $this->ids('', 'ALL', '20210101', '');
+
+    self::assertSame(
+      [101, 102, 103, 105],
+      $ids,
+      'Event 102 has two participants. Without a join condition the query '
+      . 'returns a cartesian product and each event repeats, inflating the '
+      . 'row counts shown to the admin.'
+    );
+    self::assertSame($ids, array_values(array_unique($ids)), 'duplicate ids');
+  }
+
+  public function test_events_after_the_cutoff_are_never_selected(): void
+  {
+    self::assertNotContains(104, $this->ids('', 'ALL', '20210101', ''));
+  }
+
+  public function test_repeating_events_are_selected_by_their_end_date(): void
+  {
+    self::assertContains(105, $this->ids('', 'ALL', '20210101', ''));
+    self::assertNotContains(105, $this->ids('', 'ALL', '20200101', ''));
+  }
+
+  // ---- Bug 3: purge-all query referenced weu with no join -----------
+
+  public function test_purge_all_for_a_user_with_deleted_filter_runs(): void
+  {
+    self::assertSame(
+      [103],
+      $this->ids('Y', 'bob', '', 'Y'),
+      'This combination used to reference weu.cal_status with no '
+      . 'webcal_entry_user in the FROM clause, producing a SQL error.'
+    );
+  }
+
+  public function test_purge_all_for_a_user_skips_shared_events(): void
+  {
+    // 102 is shared with bob, so the "no other participants" rule protects it.
+    // 105 is alice's repeating event and purge_all means every event she owns.
+    self::assertSame([101, 104, 105], $this->ids('Y', 'alice', '', ''));
+  }
+
+  public function test_purge_all_for_every_user_is_a_wildcard(): void
+  {
+    self::assertSame(['ALL'], get_purge_ids('Y', 'ALL', '', ''));
+  }
+
+  public function test_no_criteria_selects_nothing(): void
+  {
+    self::assertSame([], get_purge_ids('', 'alice', '', ''));
+  }
+
+  // ---- Parameter binding --------------------------------------------
+
+  public function test_username_is_bound_not_interpolated(): void
+  {
+    $ids = get_purge_ids('Y', "alice' OR '1'='1", '', '');
+
+    self::assertSame(
+      [],
+      $ids,
+      'A quote in the username must not break out of the query. If this '
+      . 'returns rows, the value is being interpolated rather than bound.'
+    );
+  }
+
+  // ---- Bugs 1 and 2: the form/handler contract ----------------------
+
+  public function test_delete_button_submits_a_non_empty_value(): void
+  {
+    $src = file_get_contents(__DIR__ . '/../purge.php');
+
+    self::assertMatchesRegularExpression(
+      '/<button[^>]*\bname="delete"[^>]*\bvalue="[^"]+"/',
+      $src,
+      'A submit button with no value attribute submits an empty string, so '
+      . 'the ! empty($delete) guard never fires and the page silently does '
+      . 'nothing when Delete is clicked.'
+    );
+  }
+
+  public function test_page_reads_the_field_that_date_selection_renders(): void
+  {
+    require_once __DIR__ . '/../includes/functions.php';
+
+    $html = date_selection('end_', '20260101');
+    self::assertMatchesRegularExpression('/name="([^"]+)"/', $html);
+    preg_match('/name="([^"]+)"/', $html, $m);
+    $rendered = $m[1];
+
+    $src = file_get_contents(__DIR__ . '/../purge.php');
+    self::assertStringContainsString(
+      "getPostValue ( '$rendered' )",
+      $src,
+      "purge.php must read the field date_selection() actually renders "
+      . "($rendered). It previously read end_year/end_month/end_day, which "
+      . 'the form has not contained since the date picker became a single '
+      . 'HTML5 date input.'
+    );
+  }
+}


### PR DESCRIPTION
Repairs the Purge Events page and the login page layout.

Both were **reported by Tom (shycat.net)**, who emailed patched copies of the two files after noticing that purge.php "didn't appear to be behaving as intended." His diagnosis was correct on every point, and following it up turned over a data-loss bug sitting underneath.

## purge.php was completely inert

The Delete button had no `value` attribute:

```html
<button class="btn btn-primary" name="delete" type="submit" ...>
```

Browsers submit `delete=` (empty string) for such a button — captured from Chrome:

```
csrf_form_key=850b4e…&username=ALL&end__YMD=2021-01-01&preview=Y&delete=
```

So `$do_purge = (! empty($delete))` was never true and clicking Delete silently redrew the form. **Nothing on this page has worked.**

Four more bugs sat behind that one, reachable only once the button was fixed:

| Bug | Effect |
|---|---|
| Read `end_year`/`end_month`/`end_day`, but `date_selection()` renders a single `end__YMD` input | Cutoff was always `"00000000"` — which is *truthy*, so the branch ran and matched nothing |
| Purge-all query filtered on `weu.cal_status` with no `webcal_entry_user` in `FROM` | "Error executing query." whenever "purge deleted only" was set for a named user |
| Date query joined `webcal_entry_user` with **no join condition** | Cartesian product: reported `webcal_entry_user: 9` when only 3 rows existed |
| **`ALL users` branch overwrote `$tail` instead of appending** | **Silently discarded "deleted only" — purging every event before the cutoff** |

That last one is the reason this needed care. It is a data-loss bug, it is not in Tom's patch, and it was harmless *only* because the button was inert. Fixing the button without fixing it would have armed it.

One more, found while testing: a finished purge printed `[Preview] Records deleted from webcal_entry_user: 3` on a **real** run — the prefix was hardcoded regardless of mode. The rows were already gone.

### Changes

- Button gets `value="Y"`; page reads `end__YMD`.
- All three selection queries get real join conditions and `DISTINCT`.
- `$tail` is appended to, never overwritten, so the status filter survives every branch.
- `[Preview]` prefix only when previewing.
- Event selection extracted into `get_purge_ids()` so it can be tested directly.
- `get_ids()` binds parameters instead of interpolating `$username` into SQL.

## login.php

`#login-container` was a Bootstrap `.container` nested inside another `.container` (double gutter), and every wrapper in the form used `.row` with no column child — `.row` applies negative side margins expecting `.col-*` children to compensate. That is what pushed the form off-centre. Removing the stray `pl-3` alone made it *worse* (form flush at x=0 on mobile), so the wrapper is now one real row/column pair.

Measured in Chrome:

| | master | this PR |
|---|---|---|
| desktop 1280px, form left / width | 101 / 252 | 465 / 350 (centred) |
| mobile 390px, form left / width | 31 / 252 | 15 / 360 |
| `#login-container` padding | 15px each side | 0 |
| horizontal overflow | none | none |

Two labels also pointed at nothing:

- `<label for="login">Username:</label>` — resolves to `<body id="login">`, not the input (`id="user"`). Inert, but not obviously so.
- `<label for="exampleCheck1">Remember me</label>` — left over from the Bootstrap docs; no such element exists.

Both now focus/toggle their controls.

## What was not taken from Tom's files

- His `'Records to be deleted from XXX'` rename introduces a key that exists in **no** translation file, so every non-English site would drop to raw English — and it makes the real-delete wording worse, not better. Kept the existing translated key and fixed the `[Preview]` prefix instead.
- His `login.php` hardcodes `https://shycat.net/hp.php` and ~70 lines of inline CSS with fixed colours that ignore the admin's theme.

## Test plan

- [x] `tests/PurgeEventSelectionTest.php` — 12 tests, 87 assertions, against a real SQLite fixture via `get_purge_ids()`
- [x] **Each of the five bugs reintroduced individually and confirmed to fail the suite** (bug 5 → 1 failure, bug 4 → 2, bug 3 → 1 error, bugs 1 and 2 → 1 each)
- [x] Full suite: 684 tests, 2397 assertions, all pass
- [x] PHPStan: no errors. `tests/compile_test.sh`: 276 files ok
- [x] End-to-end in Chrome on a fresh SQLite install: purge previews and real deletes produce correct counts; login succeeds at 1280x800 and 390x844; both labels wired

Before/after login screenshots attached below.
