### PR TITLE
fix: drop redundant init.php require in view_d.php and view_l.php (#712)

### DIFF
--- a/view_d.php
+++ b/view_d.php
@@ -20,7 +20,6 @@
  * (except for nonuser calendars... which we allow regardless of group).
  */
 // $start = microtime();
-require_once 'includes/init.php';
 require_once 'includes/views.php';
 
 $error = '';

--- a/view_l.php
+++ b/view_l.php
@@ -21,7 +21,6 @@
  * groups (except for nonuser calendars... which we allow regardless of group).
  */
 
-require_once 'includes/init.php';
 require_once 'includes/views.php';
 $id=getValue('id');
 view_init ( $id );


### PR DESCRIPTION
Fixes #712.

## Problem

`includes/views.php:10` requires `includes/init.php`. Seven docroot pages
require `includes/views.php`, but only two of them also required `init.php`
directly:

| file | required init.php? |
|---|---|
| `view_d.php` | **yes (redundant)** |
| `view_l.php` | **yes (redundant)** |
| `view_m.php` | no |
| `view_r.php` | no |
| `view_t.php` | no |
| `view_v.php` | no |
| `view_w.php` | no |

## How it got there

1. `4d291661` (2023-10-07, *"includes/init.php called more than once"*) removed
   the `init.php` require from all seven view pages — but `includes/views.php`
   did not require it at that point, so all seven lost their bootstrap.
2. `2214b379` (2024-08-31 15:27, *"Fixes for errors in views"*) restored it in
   `view_d.php` and `view_l.php`.
3. `c6f266e0` (2024-08-31 15:48, *"PHP 8 deprecation fixes"*) added the require
   to `includes/views.php`, fixing the other five and making step 2 redundant.
   Those two lines were never cleaned up.

No released version was ever affected — v1.9.10 was tagged 2023-10-02, five
days before the removal, and the next tag (v1.9.13) came long after the fix.

## Change

Remove the two leftover `require_once 'includes/init.php';` lines. All seven
view pages now bootstrap identically, via `includes/views.php`.

`require_once` is idempotent and both paths resolved to the same realpath, so
this is a tidiness fix, not a behavior change.

## Not in scope

`includes/views.php` remains the only file under `includes/` that bootstraps
`init.php`, and it does so with a docroot-relative path written from inside
`includes/`. Moving the bootstrap back to the seven entry points would be more
consistent with the rest of the codebase, but that is the same shape of change
that caused the 2023 breakage, so it is left for a separate discussion.

## Test plan

- [x] `php -l` clean on both files
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (685 tests, 2400 assertions)
- [ ] Manual smoke test of all seven view types in a running instance (no
      automated coverage exists for these pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
