### PR TITLE
fix: daily_matrix duplicated block, and repair the stray minute placeholder in 81 translations

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -614,17 +614,6 @@ function daily_matrix ( $date, $participants, $popup = '' ) {
         <th style="width:{$participant_pct};">
 EOT;
    $ret .= translate ( 'Participants' ) . '</th>';
-  $tentative = translate ( 'Tentative' );
-  $titleStr = ' title="' . translate ( 'Schedule an appointment for XXX.' ) . '">';
-  $viewMsg = translate ( 'View this entry' );
-
-  $hours = $last_hour - $first_hour;
-  $interval = intval ( 60 / $increment );
-  $cell_pct = intval ( 80 / ( $hours * $interval ) );
-  $cols = ( ( $hours * $interval ) + 1 );
-  $style_width = ( $cell_pct > 0 ? 'style="width:' . $cell_pct . '%;"' : '' );
-  $thismonth = date ( 'm', $dateTS );
-  $thisyear = date ( 'Y', $dateTS );
 
   // Build a master array containing all events for $participants.
   for ( $i = 0; $i < $cnt; $i++ ) {
@@ -695,10 +684,16 @@ EOT;
       $inc_x_j = $increment * $j;
       $str .= '
         <td id="C' . ( $j + 1 ) . '" class="dailymatrix" ';
+      $hourStr = sprintf ( $hourfmt, $hour );
+      $minStr = ( $inc_x_j <= 9 ? '0' : '' ) . $inc_x_j;
+      // Translations disagree on this phrase: most split the time into
+      // XXX:YYY (hour:minute), the rest use a single XXX for the whole time.
+      $timeStr = ( strpos ( $titleStr, 'YYY' ) === false
+        ? str_replace ( 'XXX', $hourStr . ':' . $minStr, $titleStr )
+        : str_replace ( ['XXX', 'YYY'], [$hourStr, $minStr], $titleStr ) );
       $tmpTitle = 'onmousedown="schedule_event( ' . $i . ','
        . sprintf ( "%02d", $inc_x_j ) . ' );"' . $MouseOver . $MouseOut
-       . str_replace ( 'XXX', sprintf ( $hourfmt, $hour ) . ':' .
-          ( $inc_x_j <= 9 ? '0' : '' ) . $inc_x_j, $titleStr );
+       . $timeStr;
       switch ( $j ) {
         case $halfway:
           $k = ( $hour <= 9 ? '0' : substr ( $hour, 0, 1 ) );

--- a/translations/Afrikaans.txt
+++ b/translations/Afrikaans.txt
@@ -1136,7 +1136,7 @@ Save login via cookies so I dont have to login next time.: Stoor aanmelding via 
 Save Preferences: Stoor voorkeure
 Save Settings: Stoor instellings
 Save: Stoor
-Schedule an appointment for XXX.: Skeduleer 'n afspraak vir XXX:YYY.
+Schedule an appointment for XXX.: Skeduleer 'n afspraak vir XXX.
 Scheduling Conflict: Skeduleer konflik
 Search for existing icons...: Soek vir bestaande ikone...
 Search Results: Soekresultate

--- a/translations/Amharic.txt
+++ b/translations/Amharic.txt
@@ -1410,7 +1410,7 @@ on: ላይ
 All Attendees: ሁሉም ተሳታፊዎች
 Busy: ስራ የሚበዛበት
 Tentative: ጊዜያዊ
-Schedule an appointment for XXX.: ለ XXX: YYY ቀጠሮ ይያዙ
+Schedule an appointment for XXX.: ለ XXX ቀጠሮ ይያዙ
 date_select: __dd__ __ ወር__ __yyyy__
 Event approved: ዝግጅት ፀድቋል
 Journal approved: ጆርናል ፀደቀ

--- a/translations/Azerbaijani.txt
+++ b/translations/Azerbaijani.txt
@@ -1410,7 +1410,7 @@ on: haqqında
 All Attendees: Bütün iştirakçılar
 Busy: Məşğul
 Tentative: Müvəqqəti
-Schedule an appointment for XXX.: XXX: YYY üçün görüş təyin edin.
+Schedule an appointment for XXX.: XXX üçün görüş təyin edin.
 date_select: __dd__ __ ay____yyyy__
 Event approved: Tədbir təsdiqləndi
 Journal approved: Jurnal təsdiqləndi

--- a/translations/Belarusian.txt
+++ b/translations/Belarusian.txt
@@ -1410,7 +1410,7 @@ on: далей
 All Attendees: Усе прысутныя
 Busy: Заняты
 Tentative: Папярэдні
-Schedule an appointment for XXX.: Заплануйце сустрэчу на XXX: ГГГ.
+Schedule an appointment for XXX.: Заплануйце сустрэчу на XXX.
 date_select: __dd__ __месяц__ __гггг__
 Event approved: Мерапрыемства зацверджана
 Journal approved: Часопіс зацверджаны

--- a/translations/Bengali.txt
+++ b/translations/Bengali.txt
@@ -1410,7 +1410,7 @@ on: চালু
 All Attendees: সকল উপস্থিত
 Busy: ব্যস্ত
 Tentative: সম্ভাব্য
-Schedule an appointment for XXX.: XXX এর জন্য অ্যাপয়েন্টমেন্টের সময়সূচী করুন: YYY Y
+Schedule an appointment for XXX.: XXX এর জন্য অ্যাপয়েন্টমেন্টের সময়সূচী করুন
 date_select: __d_____মাস__________
 Event approved: ইভেন্ট অনুমোদিত হয়েছে
 Journal approved: জার্নাল অনুমোদিত

--- a/translations/Bosnian.txt
+++ b/translations/Bosnian.txt
@@ -1410,7 +1410,7 @@ on: na
 All Attendees: Svi prisutni
 Busy: Zauzeto
 Tentative: Okvirno
-Schedule an appointment for XXX.: Zakažite sastanak za XXX: GGG.
+Schedule an appointment for XXX.: Zakažite sastanak za XXX.
 date_select: =
 Event approved: Događaj odobren
 Journal approved: Časopis odobren

--- a/translations/Bulgarian.txt
+++ b/translations/Bulgarian.txt
@@ -1361,7 +1361,7 @@ on: На
 All Attendees: Всички присъстващи
 Busy: Зает
 Tentative: Експериментален
-Schedule an appointment for XXX.: Насрочете среща за XXX: YYYГ.
+Schedule an appointment for XXX.: Насрочете среща за XXX.
 Event approved: Събитието е одобрено
 Journal approved: Вестникът е одобрен
 Task approved: Задачата е одобрена

--- a/translations/Burmese.txt
+++ b/translations/Burmese.txt
@@ -1290,7 +1290,7 @@ on: အပေါ်
 All Attendees: တက်ရောက်သူအားလုံး
 Busy: အလုပ်ရှုပ်သည်
 Tentative: သဘော
-Schedule an appointment for XXX.: XXX: YYY အတွက်ရက်ချိန်းယူရန်စီစဉ်ပါ။
+Schedule an appointment for XXX.: XXX အတွက်ရက်ချိန်းယူရန်စီစဉ်ပါ။
 Event approved: ဖြစ်ရပ်အတည်ပြုခဲ့သည်
 Journal approved: ဂျာနယ်အတည်ပြုခဲ့သည်
 Task approved: Task အတည်ပြုခဲ့သည်

--- a/translations/Cebuano.txt
+++ b/translations/Cebuano.txt
@@ -1409,7 +1409,7 @@ on: sa
 All Attendees: Tanan nga Nagtambong
 Busy: =
 Tentative: =
-Schedule an appointment for XXX.: Pag-eskedyul sa usa ka appointment alang sa XXX: YYY.
+Schedule an appointment for XXX.: Pag-eskedyul sa usa ka appointment alang sa XXX.
 date_select: =
 Event approved: Giaprubahan ang kalihokan
 Journal approved: Giuyonan ang journal

--- a/translations/Chichewa.txt
+++ b/translations/Chichewa.txt
@@ -1410,7 +1410,7 @@ on: kuyatsa
 All Attendees: Onse Opezekapo
 Busy: Tanganidwa
 Tentative: Kukonzekera
-Schedule an appointment for XXX.: Sanjani nthawi yokumana ndi XXX: YYY.
+Schedule an appointment for XXX.: Sanjani nthawi yokumana ndi XXX.
 date_select: =
 Event approved: Chochitika chovomerezeka
 Journal approved: Zolemba zivomerezedwa

--- a/translations/Chinese-Simplified.txt
+++ b/translations/Chinese-Simplified.txt
@@ -1309,7 +1309,7 @@ on: 在
 All Attendees: 所有参会者
 Busy: 忙
 Tentative: 塔塔尔族
-Schedule an appointment for XXX.: 安排XXX：YYY的约会。
+Schedule an appointment for XXX.: 安排XXX的约会。
 Event approved: 活动已获批准
 Journal approved: 期刊批准
 Task approved: 泰米尔语

--- a/translations/Chinese-Traditional.txt
+++ b/translations/Chinese-Traditional.txt
@@ -1309,7 +1309,7 @@ on: 在
 All Attendees: 所有參會者
 Busy: 忙
 Tentative: 暫定的
-Schedule an appointment for XXX.: 安排XXX：YYY的約會。
+Schedule an appointment for XXX.: 安排XXX的約會。
 Event approved: 活動已獲批准
 Journal approved: 期刊批准
 Task approved: 任務已批准

--- a/translations/Corsican.txt
+++ b/translations/Corsican.txt
@@ -1410,7 +1410,7 @@ on: nantu
 All Attendees: Tutti i Participanti
 Busy: Impegnatu
 Tentative: Pruvucatu
-Schedule an appointment for XXX.: Pianificate un appuntamentu per XXX: AAAA.
+Schedule an appointment for XXX.: Pianificate un appuntamentu per XXX.
 date_select: =
 Event approved: Avvenimentu appruvatu
 Journal approved: Ghjurnale appruvatu

--- a/translations/Croatian.txt
+++ b/translations/Croatian.txt
@@ -1410,7 +1410,7 @@ on: na
 All Attendees: Svi polaznici
 Busy: Zaposlen
 Tentative: Okvirno
-Schedule an appointment for XXX.: Zakažite sastanak za XXX: GGG.
+Schedule an appointment for XXX.: Zakažite sastanak za XXX.
 date_select: __dd__ __mjesec__ __yyy____
 Event approved: Događaj odobren
 Journal approved: Časopis odobren

--- a/translations/English-US.txt
+++ b/translations/English-US.txt
@@ -1579,7 +1579,7 @@ on: on
 All Attendees: All Attendees
 Busy: Busy
 Tentative: Tentative
-Schedule an appointment for XXX.: Schedule an appointment for XXX:YYY.
+Schedule an appointment for XXX.: Schedule an appointment for XXX.
 Event approved: Event approved
 Journal approved: Journal approved
 Task approved: Task approved

--- a/translations/Esperanto.txt
+++ b/translations/Esperanto.txt
@@ -1410,7 +1410,7 @@ on: plu
 All Attendees: Ĉiuj Ĉeestantoj
 Busy: Okupita
 Tentative: Provizora
-Schedule an appointment for XXX.: Aranĝu rendevuon por XXX: YYY.
+Schedule an appointment for XXX.: Aranĝu rendevuon por XXX.
 date_select: __dd__ __monato__ __yyyy__
 Event approved: Okazaĵo aprobita
 Journal approved: Journalurnalo aprobita

--- a/translations/Filipino.txt
+++ b/translations/Filipino.txt
@@ -1410,7 +1410,7 @@ on: sa
 All Attendees: Lahat ng Dadalo
 Busy: Abala
 Tentative: =
-Schedule an appointment for XXX.: Mag-iskedyul ng appointment para sa XXX: YYY.
+Schedule an appointment for XXX.: Mag-iskedyul ng appointment para sa XXX.
 date_select: =
 Event approved: Naaprubahan ang kaganapan
 Journal approved: Naaprubahan ang journal

--- a/translations/Frisian.txt
+++ b/translations/Frisian.txt
@@ -1410,7 +1410,7 @@ on: op
 All Attendees: Alle oanwêzigen
 Busy: Drok
 Tentative: Tentatyf
-Schedule an appointment for XXX.: Plan in ôfspraak foar XXX: JJJ.
+Schedule an appointment for XXX.: Plan in ôfspraak foar XXX.
 date_select: =
 Event approved: Event goedkard
 Journal approved: Journal goedkard

--- a/translations/Georgian.txt
+++ b/translations/Georgian.txt
@@ -1410,7 +1410,7 @@ on: ჩართული
 All Attendees: ყველა დამსწრე
 Busy: Დაკავებული
 Tentative: სავარაუდო
-Schedule an appointment for XXX.: დანიშნეთ შეხვედრა დანიშვნისთვის XXX: YYY.
+Schedule an appointment for XXX.: დანიშნეთ შეხვედრა დანიშვნისთვის XXX.
 date_select: __dd__ __ თვე__ __yyyy__
 Event approved: ღონისძიება დამტკიცებულია
 Journal approved: ჟურნალი დამტკიცებულია

--- a/translations/Greek.txt
+++ b/translations/Greek.txt
@@ -1344,7 +1344,7 @@ on: =
 All Attendees: Όλοι οι συμμετέχοντες
 Busy: Απασχολημένος
 Tentative: Προσωρινός
-Schedule an appointment for XXX.: Προγραμματισμός συνάντησης για XXX:XXX.
+Schedule an appointment for XXX.: Προγραμματισμός συνάντησης για XXX.
 Event approved: Αποδοχή γεγονότος
 Journal approved: Αποδοχή ημερολογίου
 Task approved: Αποδοχή εργασίας

--- a/translations/Gujarati.txt
+++ b/translations/Gujarati.txt
@@ -1410,7 +1410,7 @@ on: પર
 All Attendees: બધા ઉપસ્થિતો
 Busy: વ્યસ્ત
 Tentative: ટેન્ટિવ
-Schedule an appointment for XXX.: એક્સએક્સએક્સએક્સ માટે એપોઇન્ટમેન્ટનું સમયપત્રક: વાયવાય.
+Schedule an appointment for XXX.: XXX માટે એપોઇન્ટમેન્ટનું સમયપત્રક.
 date_select: __dd__ __મહેન_________
 Event approved: ઇવેન્ટ મંજૂર
 Journal approved: જર્નલ મંજૂર

--- a/translations/Haitian.txt
+++ b/translations/Haitian.txt
@@ -1410,7 +1410,7 @@ on: sou
 All Attendees: Tout patisipan yo
 Busy: Okipe
 Tentative: Pwovizwa
-Schedule an appointment for XXX.: Pran yon randevou pou XXX: AAAA.
+Schedule an appointment for XXX.: Pran yon randevou pou XXX.
 date_select: =
 Event approved: Evènman apwouve
 Journal approved: Jounal apwouve

--- a/translations/Hausa.txt
+++ b/translations/Hausa.txt
@@ -1410,7 +1410,7 @@ on: a kan
 All Attendees: Duk Mahalarta
 Busy: Aiki
 Tentative: Mai tsayi
-Schedule an appointment for XXX.: Tsara alƙawari don XXX: YYY
+Schedule an appointment for XXX.: Tsara alƙawari don XXX
 date_select: __dd__ __mon____ __yyyyyy__
 Event approved: An yarda da taron
 Journal approved: An amince da mujallar

--- a/translations/Hawaiian.txt
+++ b/translations/Hawaiian.txt
@@ -1410,7 +1410,7 @@ on: ma
 All Attendees: ʻO nā mea hele a pau
 Busy: ʻOihana
 Tentative: ʻĀkau
-Schedule an appointment for XXX.: E hoʻolālā i kahi manawa no XXX: YYY.
+Schedule an appointment for XXX.: E hoʻolālā i kahi manawa no XXX.
 date_select: =
 Event approved: Ua ʻae ʻia ka hanana
 Journal approved: Ua ʻae ʻia ka puke pai

--- a/translations/Hindi.txt
+++ b/translations/Hindi.txt
@@ -1410,7 +1410,7 @@ on: पर
 All Attendees: सभी उपस्थित लोग
 Busy: व्यस्त
 Tentative: जांच का
-Schedule an appointment for XXX.: XXX के लिए अपॉइंटमेंट शेड्यूल करें: YYY।
+Schedule an appointment for XXX.: XXX के लिए अपॉइंटमेंट शेड्यूल करें।
 date_select: =
 Event approved: घटना को मंजूरी दी
 Journal approved: जर्नल ने मंजूरी दे दी

--- a/translations/Hmong.txt
+++ b/translations/Hmong.txt
@@ -1415,7 +1415,7 @@ on: rau
 All Attendees: Txhua Tus Neeg Tuaj Koom
 Busy: Tibneeg hu tauj coob
 Tentative: Suab Nkauj Kho Siab
-Schedule an appointment for XXX.: Teem caij sib tham rau XXX: YYY.
+Schedule an appointment for XXX.: Teem caij sib tham rau XXX.
 date_select: dd ____ __ th__monmonmon __ __ __ __, __yyyy______ __yy__, yyyy________________, yy________________, yy___thth__________, yy_thth____,.
 Event approved: Kev pom zoo pom zoo
 Journal approved: Phau ntawv pom zoo raug

--- a/translations/Igbo.txt
+++ b/translations/Igbo.txt
@@ -1410,7 +1410,7 @@ on: na
 All Attendees: Ndị niile bịara
 Busy: Anọghị
 Tentative: Mgbatị
-Schedule an appointment for XXX.: Hazie oge maka XXX: YYY.
+Schedule an appointment for XXX.: Hazie oge maka XXX.
 date_select: __dd__ __month__ __yyyyyy__
 Event approved: Emere mmemme
 Journal approved: Edere akwụkwọ akụkọ

--- a/translations/Indonesian.txt
+++ b/translations/Indonesian.txt
@@ -1285,7 +1285,7 @@ on: di
 All Attendees: Semua Peserta
 Busy: Sibuk
 Tentative: Sebagian
-Schedule an appointment for XXX.: Jadwalkan janji temu untuk XXX: YYY.
+Schedule an appointment for XXX.: Jadwalkan janji temu untuk XXX.
 date_select: __dd__ __bulan__ __yyyy__
 Event approved: Menyetujui acara
 Journal approved: Jurnal disetujui

--- a/translations/Irish.txt
+++ b/translations/Irish.txt
@@ -1410,7 +1410,7 @@ on: ar
 All Attendees: Gach Freastalaí
 Busy: Gnóthach
 Tentative: Sealadach
-Schedule an appointment for XXX.: Déan coinne a sceidealú do XXX: BBBB.
+Schedule an appointment for XXX.: Déan coinne a sceidealú do XXX.
 date_select: =
 Event approved: Imeacht ceadaithe
 Journal approved: Iris ceadaithe

--- a/translations/Italian.txt
+++ b/translations/Italian.txt
@@ -1374,7 +1374,7 @@ on: attivo
 All Attendees: Tutti i partecipanti
 Busy: Occupato
 Tentative: Non definitivo
-Schedule an appointment for XXX.: Imposta un appuntamento per XXX:YYY.
+Schedule an appointment for XXX.: Imposta un appuntamento per XXX.
 Event approved: Evento approvato
 Journal approved: Giornale approvato
 Task approved: Compito approvato

--- a/translations/Javanese.txt
+++ b/translations/Javanese.txt
@@ -1410,7 +1410,7 @@ on: ing
 All Attendees: Kabeh Hadirin
 Busy: Sibuk
 Tentative: Tentatif
-Schedule an appointment for XXX.: Jadwal janjian kanggo XXX: YYY.
+Schedule an appointment for XXX.: Jadwal janjian kanggo XXX.
 date_select: =
 Event approved: Acara disetujoni
 Journal approved: Jurnal disetujoni

--- a/translations/Kannada.txt
+++ b/translations/Kannada.txt
@@ -1394,7 +1394,7 @@ on: ಆನ್
 All Attendees: ಎಲ್ಲಾ ಪಾಲ್ಗೊಳ್ಳುವವರು
 Busy: ನಿರತ
 Tentative: ತಾತ್ಕಾಲಿಕ
-Schedule an appointment for XXX.: XXX ಗಾಗಿ ನೇಮಕಾತಿಯನ್ನು ನಿಗದಿಪಡಿಸಿ: YYY.
+Schedule an appointment for XXX.: XXX ಗಾಗಿ ನೇಮಕಾತಿಯನ್ನು ನಿಗದಿಪಡಿಸಿ.
 date_select: __dd__ __ ತಿಂಗಳು__ __yyyy__
 Event approved: ಈವೆಂಟ್ ಅನುಮೋದಿಸಲಾಗಿದೆ
 Journal approved: ಜರ್ನಲ್ ಅನುಮೋದಿಸಲಾಗಿದೆ

--- a/translations/Kazakh.txt
+++ b/translations/Kazakh.txt
@@ -1410,7 +1410,7 @@ on: қосулы
 All Attendees: Барлық қатысушылар
 Busy: Бос емес
 Tentative: Болжалды
-Schedule an appointment for XXX.: ХХХ уақытына жоспарлаңыз: ЖЖЖ.
+Schedule an appointment for XXX.: XXX уақытына жоспарлаңыз.
 date_select: __dd__ __ай __ __yyyy__
 Event approved: Іс-шара мақұлданды
 Journal approved: Журнал мақұлданды

--- a/translations/Khmer.txt
+++ b/translations/Khmer.txt
@@ -1410,7 +1410,7 @@ on: បើក
 All Attendees: អ្នកចូលរួមទាំងអស់
 Busy: រវល់
 Tentative: ការសងសឹក
-Schedule an appointment for XXX.: កំណត់ពេលណាត់ជួបសម្រាប់ XXX: YYY ។
+Schedule an appointment for XXX.: កំណត់ពេលណាត់ជួបសម្រាប់ XXX ។
 date_select: __ ថែម __ __ ថ្ងៃទី __ __ ឆ្នាំទី __
 Event approved: បានអនុម័តព្រឹត្តិការណ៍
 Journal approved: ទិនានុប្បវត្តិត្រូវបានអនុម័ត

--- a/translations/Kinyarwanda.txt
+++ b/translations/Kinyarwanda.txt
@@ -1410,7 +1410,7 @@ on: ku
 All Attendees: Abitabiriye bose
 Busy: Irahuze
 Tentative: Ihema
-Schedule an appointment for XXX.: Teganya gahunda ya XXX: YYY.
+Schedule an appointment for XXX.: Teganya gahunda ya XXX.
 date_select: __dd__ __ ukwezi__ __yyyy__
 Event approved: Ibirori byemewe
 Journal approved: Ikinyamakuru cyemejwe

--- a/translations/Kiswahili.txt
+++ b/translations/Kiswahili.txt
@@ -1410,7 +1410,7 @@ on: kuwasha
 All Attendees: Wahudhuriaji wote
 Busy: Yuko busy
 Tentative: Kutazama
-Schedule an appointment for XXX.: Panga miadi ya XXX: YYY.
+Schedule an appointment for XXX.: Panga miadi ya XXX.
 date_select: __dd__ __mwezi__ __yyyy__
 Event approved: Tukio limeidhinishwa
 Journal approved: Jarida limeidhinishwa

--- a/translations/Kurdish.txt
+++ b/translations/Kurdish.txt
@@ -1410,7 +1410,7 @@ on: li
 All Attendees: Hemî Beşdarvan
 Busy: Bikar
 Tentative: Demok
-Schedule an appointment for XXX.: Ji bo XXX randevûyekê plansaz bikin: YYY.
+Schedule an appointment for XXX.: Ji bo XXX randevûyekê plansaz bikin.
 date_select: =
 Event approved: Bûyer hate pejirandin
 Journal approved: Kovar pejirand

--- a/translations/Kyrgyz.txt
+++ b/translations/Kyrgyz.txt
@@ -1410,7 +1410,7 @@ on: боюнча
 All Attendees: Бардык катышуучулар
 Busy: Алек
 Tentative: Болжолдуу
-Schedule an appointment for XXX.: XXX: YYY үчүн жолугушууну пландаштырыңыз.
+Schedule an appointment for XXX.: XXX үчүн жолугушууну пландаштырыңыз.
 date_select: __dd__ __ month__ __yyyy__
 Event approved: Иш-чара жактырылды
 Journal approved: Журнал жактырылды

--- a/translations/Lao.txt
+++ b/translations/Lao.txt
@@ -1410,7 +1410,7 @@ on: ສຸດ
 All Attendees: ຜູ້ເຂົ້າຮ່ວມທັງ ໝົດ
 Busy: ຄາ​ວຽກ
 Tentative: ແກ້ແຄ້ນ
-Schedule an appointment for XXX.: ຈັດຕາຕະລາງນັດ ໝາຍ ສຳ ລັບ XXX: YYY.
+Schedule an appointment for XXX.: ຈັດຕາຕະລາງນັດ ໝາຍ ສຳ ລັບ XXX.
 date_select: dd__ ____, monyy mon
 Event approved: ການອະນຸມັດເຫດການ
 Journal approved: ວາລະສານອະນຸມັດ

--- a/translations/Latin.txt
+++ b/translations/Latin.txt
@@ -1410,7 +1410,7 @@ on: in
 All Attendees: omnes Attendees
 Busy: occupatus
 Tentative: temptat
-Schedule an appointment for XXX.: Schedule constitutio pro XXX: YYY.
+Schedule an appointment for XXX.: Schedule constitutio pro XXX.
 date_select: __dd__ __mēness__ __yyyy__
 Event approved: res probatus
 Journal approved: Journal probatus

--- a/translations/Latvian.txt
+++ b/translations/Latvian.txt
@@ -1410,7 +1410,7 @@ on: ieslēgts
 All Attendees: Visi dalībnieki
 Busy: Aizņemts
 Tentative: Provizorisks
-Schedule an appointment for XXX.: Ieplānojiet tikšanos: XXX: YYY.
+Schedule an appointment for XXX.: Ieplānojiet tikšanos: XXX.
 date_select: __dd__ __mēness__ __yyyy__
 Event approved: Pasākums apstiprināts
 Journal approved: Žurnāls apstiprināts

--- a/translations/Luxembourgish.txt
+++ b/translations/Luxembourgish.txt
@@ -1410,7 +1410,7 @@ on: an
 All Attendees: All Participanten
 Busy: Beschäftegt                         
 Tentative: Tentativ
-Schedule an appointment for XXX.: Rendez-vous fir XXX: YYY.
+Schedule an appointment for XXX.: Rendez-vous fir XXX.
 date_select: =
 Event approved: Event ugeholl
 Journal approved: Journal guttgeheescht

--- a/translations/Macedonian.txt
+++ b/translations/Macedonian.txt
@@ -1410,7 +1410,7 @@ on: на
 All Attendees: Сите присутни
 Busy: Зафатен
 Tentative: Обично
-Schedule an appointment for XXX.: Закажете состанок за ХХХ: ГОСА.
+Schedule an appointment for XXX.: Закажете состанок за XXX.
 date_select: __dd__ __месец __yyyy__
 Event approved: Настанот е одобрен
 Journal approved: Весник е одобрен

--- a/translations/Malagasy.txt
+++ b/translations/Malagasy.txt
@@ -1410,7 +1410,7 @@ on: amin'ny
 All Attendees: Mpanatrika rehetra
 Busy: Be asa
 Tentative: Andrana
-Schedule an appointment for XXX.: Manome fotoana fanendrena ho an'i XXX: YYY.
+Schedule an appointment for XXX.: Manome fotoana fanendrena ho an'i XXX.
 date_select: =
 Event approved: Nekena ny hetsika
 Journal approved: Nankatoavina ny gazety

--- a/translations/Malay.txt
+++ b/translations/Malay.txt
@@ -1410,7 +1410,7 @@ on: pada
 All Attendees: Semua Hadirin
 Busy: Sibuk
 Tentative: Tentatif
-Schedule an appointment for XXX.: Jadualkan janji temu untuk XXX: YYY.
+Schedule an appointment for XXX.: Jadualkan janji temu untuk XXX.
 date_select: __dd__ __bulan__ __yyyy__
 Event approved: Acara diluluskan
 Journal approved: Jurnal diluluskan

--- a/translations/Malayalam.txt
+++ b/translations/Malayalam.txt
@@ -1410,7 +1410,7 @@ on: ഓണാണ്
 All Attendees: പങ്കെടുത്തവരെല്ലാം
 Busy: തിരക്ക്
 Tentative: താൽക്കാലികം
-Schedule an appointment for XXX.: XXX- നായി ഒരു കൂടിക്കാഴ്‌ച ഷെഡ്യൂൾ ചെയ്യുക: YYY.
+Schedule an appointment for XXX.: XXX- നായി ഒരു കൂടിക്കാഴ്‌ച ഷെഡ്യൂൾ ചെയ്യുക.
 date_select: __dd__ __ മാസം__ __yyyy__
 Event approved: ഇവന്റ് അംഗീകരിച്ചു
 Journal approved: ജേണൽ അംഗീകരിച്ചു

--- a/translations/Maltese.txt
+++ b/translations/Maltese.txt
@@ -1410,7 +1410,7 @@ on: fuq
 All Attendees: L-Attendenti Kollha
 Busy: Għandi x'nagħmel
 Tentative: Tentattiv
-Schedule an appointment for XXX.: Skeda appuntament għal XXX: SSSS.
+Schedule an appointment for XXX.: Skeda appuntament għal XXX.
 date_select: __dd__ __ xahar__ __yyyy__
 Event approved: Avveniment approvat
 Journal approved: Ġurnal approvat

--- a/translations/Maori.txt
+++ b/translations/Maori.txt
@@ -1410,7 +1410,7 @@ on: i runga i
 All Attendees: Katoa nga Kaitono
 Busy: Riu
 Tentative: =
-Schedule an appointment for XXX.: Whakaritehia he wa whakarite mo XXX: YYY.
+Schedule an appointment for XXX.: Whakaritehia he wa whakarite mo XXX.
 date_select: =
 Event approved: Kua whakaaetia te takahanga
 Journal approved: Whakaaetia te Tuhipoka

--- a/translations/Marathi.txt
+++ b/translations/Marathi.txt
@@ -1410,7 +1410,7 @@ on: चालू
 All Attendees: सर्व उपस्थिती
 Busy: व्यस्त
 Tentative: तंतोतंत
-Schedule an appointment for XXX.: एक्सएक्सएक्ससाठी एप्पॉइंटमेंटचे वेळापत्रकः YYY.
+Schedule an appointment for XXX.: XXXसाठी एप्पॉइंटमेंटचे वेळापत्रक.
 date_select: __d_____आमची________
 Event approved: कार्यक्रम मंजूर
 Journal approved: जर्नल मंजूर

--- a/translations/Mongolian.txt
+++ b/translations/Mongolian.txt
@@ -1410,7 +1410,7 @@ on: дээр
 All Attendees: Бүх оролцогчид
 Busy: Завгүй
 Tentative: Урьдчилсан
-Schedule an appointment for XXX.: XXX: YYY цаг товлоорой.
+Schedule an appointment for XXX.: XXX цаг товлоорой.
 date_select: __dd__ __ сар __ __yyyy__
 Event approved: Арга хэмжээг батлав
 Journal approved: Сэтгүүл батлав

--- a/translations/Nepali.txt
+++ b/translations/Nepali.txt
@@ -1410,7 +1410,7 @@ on: खुल्ला
 All Attendees: सबै सहभागीहरू
 Busy: व्यस्त
 Tentative: टेन्टेटिभ
-Schedule an appointment for XXX.: XXX: YYY को लागि अपोइन्टमेन्टको तालिका बनाउनुहोस्।
+Schedule an appointment for XXX.: XXX को लागि अपोइन्टमेन्टको तालिका बनाउनुहोस्।
 date_select: __dd__ __ महिना _________
 Event approved: कार्यक्रम स्वीकृत भयो
 Journal approved: जर्नल स्वीकृत

--- a/translations/Odia.txt
+++ b/translations/Odia.txt
@@ -1410,7 +1410,7 @@ on: ଉପରେ
 All Attendees: ସମସ୍ତ ଉପସ୍ଥିତ
 Busy: ବ୍ୟସ୍ତ
 Tentative: ଟେଣ୍ଟେଟିଭ୍ |
-Schedule an appointment for XXX.: XXX ପାଇଁ ଏକ ନିଯୁକ୍ତିର କାର୍ଯ୍ୟସୂଚୀ: YYY |
+Schedule an appointment for XXX.: XXX ପାଇଁ ଏକ ନିଯୁକ୍ତିର କାର୍ଯ୍ୟସୂଚୀ |
 date_select: =
 Event approved: ଇଭେଣ୍ଟ ଅନୁମୋଦିତ |
 Journal approved: ପତ୍ରିକା ଅନୁମୋଦିତ |

--- a/translations/Pashto.txt
+++ b/translations/Pashto.txt
@@ -1410,7 +1410,7 @@ on: په
 All Attendees: ټول ګډون وال
 Busy: بوخت
 Tentative: عصبي
-Schedule an appointment for XXX.: د XXX لپاره ناستې مهالویش: YYY.
+Schedule an appointment for XXX.: د XXX لپاره ناستې مهالویش.
 date_select: _د_د_م_م_____ه_
 Event approved: پیښه تصویب شوه
 Journal approved: ژورنال تصویب شو

--- a/translations/Persian.txt
+++ b/translations/Persian.txt
@@ -1410,7 +1410,7 @@ on: بر
 All Attendees: همه حاضران
 Busy: مشغول
 Tentative: آزمایشی
-Schedule an appointment for XXX.: قرار ملاقات برای XXX: YYY.
+Schedule an appointment for XXX.: قرار ملاقات برای XXX.
 date_select: __dd__ __ Month__ __yyyy__
 Event approved: رویداد تأیید شد
 Journal approved: مجله تأیید شده است

--- a/translations/Punjabi.txt
+++ b/translations/Punjabi.txt
@@ -1410,7 +1410,7 @@ on: ਚਾਲੂ
 All Attendees: ਸਾਰੇ ਹਾਜ਼ਰੀਨ
 Busy: ਵਿਅਸਤ
 Tentative: ਤੰਤੂਵਾਦੀ
-Schedule an appointment for XXX.: XXX ਲਈ ਇੱਕ ਮੁਲਾਕਾਤ ਦਾ ਸਮਾਂ ਤਹਿ ਕਰੋ: YYY.
+Schedule an appointment for XXX.: XXX ਲਈ ਇੱਕ ਮੁਲਾਕਾਤ ਦਾ ਸਮਾਂ ਤਹਿ ਕਰੋ.
 date_select: __dd__ __ਮੈਂ_________
 Event approved: ਇਵੈਂਟ ਨੂੰ ਪ੍ਰਵਾਨਗੀ ਦਿੱਤੀ ਗਈ
 Journal approved: ਜਰਨਲ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦਿੱਤੀ ਗਈ

--- a/translations/Samoan.txt
+++ b/translations/Samoan.txt
@@ -1410,7 +1410,7 @@ on: i luga
 All Attendees: Tagata Auai Uma
 Busy: Pisi
 Tentative: Fale Faʻalelotu
-Schedule an appointment for XXX.: Faʻatulaga se taimi mo XXX: YYY
+Schedule an appointment for XXX.: Faʻatulaga se taimi mo XXX
 date_select: =
 Event approved: Na faamaonia le mea na tupu
 Journal approved: Faamaonia le tusi talaaga

--- a/translations/Scots.txt
+++ b/translations/Scots.txt
@@ -1410,7 +1410,7 @@ on: air
 All Attendees: Gach neach-frithealaidh
 Busy: Trang
 Tentative: =
-Schedule an appointment for XXX.: Clàraich coinneamh airson XXX: BBBB.
+Schedule an appointment for XXX.: Clàraich coinneamh airson XXX.
 date_select: =
 Event approved: Tachartas air aontachadh
 Journal approved: Iris air aontachadh

--- a/translations/Serbian.txt
+++ b/translations/Serbian.txt
@@ -1306,7 +1306,7 @@ on: на
 All Attendees: Сви присутни
 Busy: Заузет
 Tentative: Оквирно
-Schedule an appointment for XXX.: Закажите састанак за КСКСКС: ГГГ.
+Schedule an appointment for XXX.: Закажите састанак за XXX.
 date_select: __дд__ __месец__ __иии____
 Event approved: Догађај одобрен
 Journal approved: Часопис одобрен

--- a/translations/Sesotho.txt
+++ b/translations/Sesotho.txt
@@ -1410,7 +1410,7 @@ on: bulela
 All Attendees: Batho bohle ba tlileng kopanong
 Busy: Phathahane
 Tentative: Ho ikoetlisa
-Schedule an appointment for XXX.: Rera nako ea kopano bakeng sa XXX: YYY.
+Schedule an appointment for XXX.: Rera nako ea kopano bakeng sa XXX.
 date_select: =
 Event approved: Ketsahalo e amohetsoe
 Journal approved: Sengoloa se amohetsoe

--- a/translations/Shona.txt
+++ b/translations/Shona.txt
@@ -1410,7 +1410,7 @@ on: =
 All Attendees: Vese Vanopinda
 Busy: Kubatikana
 Tentative: Kufungisisa
-Schedule an appointment for XXX.: Ronga musangano weXX: YYY.
+Schedule an appointment for XXX.: Ronga musangano weXXX.
 date_select: =
 Event approved: Chiitiko chakabvumidzwa
 Journal approved: Zvinyorwa zvinobvumidzwa

--- a/translations/Sindhi.txt
+++ b/translations/Sindhi.txt
@@ -1410,7 +1410,7 @@ on: جاري آهي
 All Attendees: سڀ حاضري ڏيندڙ
 Busy: مصروف
 Tentative: عارضي
-Schedule an appointment for XXX.: ايڪسينڪس لاء ملاقات جو وقت طئي ڪيو: YYY.
+Schedule an appointment for XXX.: XXX لاء ملاقات جو وقت طئي ڪيو.
 date_select: __d______ مهيني_ __yyy__
 Event approved: واقعي جي منظوري ڏني وئي
 Journal approved: جرنل منظور ٿيو

--- a/translations/Sinhala.txt
+++ b/translations/Sinhala.txt
@@ -1410,7 +1410,7 @@ on: මත
 All Attendees: සියලුම සහභාගිවන්නන්
 Busy: කාර්යබහුල
 Tentative: තාවකාලික
-Schedule an appointment for XXX.: XXX සඳහා හමුවීමක් උපලේඛනගත කරන්න: YYY.
+Schedule an appointment for XXX.: XXX සඳහා හමුවීමක් උපලේඛනගත කරන්න.
 date_select: __dd__ __ මාස__ __yyyy__
 Event approved: සිදුවීම අනුමත කර ඇත
 Journal approved: ජර්නලය අනුමත කර ඇත

--- a/translations/Slovak.txt
+++ b/translations/Slovak.txt
@@ -1288,7 +1288,7 @@ on: na
 All Attendees: Všetci účastníci
 Busy: Zaneprázdnený
 Tentative: Predbežne
-Schedule an appointment for XXX.: Naplánujte si schôdzku na XXX: RRRR.
+Schedule an appointment for XXX.: Naplánujte si schôdzku na XXX.
 date_select: __dd__ __month__ __rrrr__
 Event approved: Udalosť schválená
 Journal approved: Časopis bol schválený

--- a/translations/Somali.txt
+++ b/translations/Somali.txt
@@ -1410,7 +1410,7 @@ on: =
 All Attendees: Dhamaan Kaqeybgalayaasha
 Busy: Mashquul
 Tentative: Adkaysi
-Schedule an appointment for XXX.: Ballan u sameyso XXX: YYY.
+Schedule an appointment for XXX.: Ballan u sameyso XXX.
 date_select: __dd__ __ bishii________yy__
 Event approved: Dhacdada waa la ogolaaday
 Journal approved: Joornaal waa la ogolaaday

--- a/translations/Spanish.txt
+++ b/translations/Spanish.txt
@@ -1485,7 +1485,7 @@ on: en
 All Attendees: Todos los asistentes
 Busy: Ocupado
 Tentative: Tentativo
-Schedule an appointment for XXX.: Programar una cita para XXX: YYY.
+Schedule an appointment for XXX.: Programar una cita para XXX.
 Event approved: Evento aprobado
 Journal approved: Diario aprobado
 Task approved: Tarea aprobada

--- a/translations/Sundanese.txt
+++ b/translations/Sundanese.txt
@@ -1410,7 +1410,7 @@ on: asup
 All Attendees: Sadayana Hadirin
 Busy: Sibuk
 Tentative: Tentatif
-Schedule an appointment for XXX.: Jadwalkeun janji pikeun XXX: YYY.
+Schedule an appointment for XXX.: Jadwalkeun janji pikeun XXX.
 date_select: =
 Event approved: Acara disatujuan
 Journal approved: Jurnal disatujuan

--- a/translations/Tajik.txt
+++ b/translations/Tajik.txt
@@ -1410,7 +1410,7 @@ on: дар
 All Attendees: Ҳама ҳозирин
 Busy: Банд
 Tentative: Тахминӣ
-Schedule an appointment for XXX.: Таъинотро барои XXX: YYY таъин кунед.
+Schedule an appointment for XXX.: Таъинотро барои XXX таъин кунед.
 date_select: __dd__ __моҳ __ __yyyy__
 Event approved: Чорабинӣ тасдиқ карда шуд
 Journal approved: Маҷалла тасдиқ карда шуд

--- a/translations/Tamil.txt
+++ b/translations/Tamil.txt
@@ -1410,7 +1410,7 @@ on: ஆன்
 All Attendees: அனைத்து பங்கேற்பாளர்கள்
 Busy: பரபரப்பு
 Tentative: தற்காலிக
-Schedule an appointment for XXX.: XXX க்கான சந்திப்பைத் திட்டமிடுங்கள்: YYY.
+Schedule an appointment for XXX.: XXX க்கான சந்திப்பைத் திட்டமிடுங்கள்.
 date_select: __dd__ __ மாத__ __yyyy__
 Event approved: நிகழ்வு அங்கீகரிக்கப்பட்டது
 Journal approved: பத்திரிகை ஒப்புதல் அளித்தது

--- a/translations/Tatar.txt
+++ b/translations/Tatar.txt
@@ -1410,7 +1410,7 @@ on: өстендә
 All Attendees: Барлык катнашучылар
 Busy: Мәшгуль
 Tentative: Тентатив
-Schedule an appointment for XXX.: XXX өчен расписаниене раслагыз: YYY.
+Schedule an appointment for XXX.: XXX өчен расписаниене раслагыз.
 date_select: __dd__ __ ай__ __yyyy__
 Event approved: Чара расланды
 Journal approved: Журнал расланды

--- a/translations/Telugu.txt
+++ b/translations/Telugu.txt
@@ -1410,7 +1410,7 @@ on: పై
 All Attendees: హాజరైన వారందరూ
 Busy: బిజీగా
 Tentative: అస్థిరమైనదనే
-Schedule an appointment for XXX.: XXX కోసం నియామకాన్ని షెడ్యూల్ చేయండి: YYY.
+Schedule an appointment for XXX.: XXX కోసం నియామకాన్ని షెడ్యూల్ చేయండి.
 date_select: __dd__ __ నెల__ __yyyy__
 Event approved: ఈవెంట్ ఆమోదించబడింది
 Journal approved: జర్నల్ ఆమోదించబడింది

--- a/translations/Thai.txt
+++ b/translations/Thai.txt
@@ -1410,7 +1410,7 @@ on: บน
 All Attendees: ผู้เข้าร่วมทั้งหมด
 Busy: ไม่ว่าง
 Tentative: ไม่แน่นอน
-Schedule an appointment for XXX.: กำหนดเวลานัดหมายสำหรับ XXX: YYY
+Schedule an appointment for XXX.: กำหนดเวลานัดหมายสำหรับ XXX
 date_select: =
 Event approved: อนุมัติกิจกรรมแล้ว
 Journal approved: วารสารได้รับการอนุมัติ

--- a/translations/Turkmen.txt
+++ b/translations/Turkmen.txt
@@ -1410,7 +1410,7 @@ on: üstünde
 All Attendees: Gatnaşanlaryň hemmesi
 Busy: Işli
 Tentative: =
-Schedule an appointment for XXX.: XXX üçin duşuşygy meýilleşdiriň: YYY.
+Schedule an appointment for XXX.: XXX üçin duşuşygy meýilleşdiriň.
 date_select: __dd__ __ aý__ __yyy__
 Event approved: Waka tassyklandy
 Journal approved: Journalurnal tassyklandy

--- a/translations/Ukrainian.txt
+++ b/translations/Ukrainian.txt
@@ -1410,7 +1410,7 @@ on: на
 All Attendees: Усі присутні
 Busy: Зайнятий
 Tentative: Орієнтовний
-Schedule an appointment for XXX.: Заплануйте зустріч на XXX: РРР.
+Schedule an appointment for XXX.: Заплануйте зустріч на XXX.
 date_select: __dd__ __місяць__ __рррр__
 Event approved: Подія затверджена
 Journal approved: Журнал затверджено

--- a/translations/Urdu.txt
+++ b/translations/Urdu.txt
@@ -1410,7 +1410,7 @@ on: پر
 All Attendees: تمام شرکاء
 Busy: مصروف
 Tentative: عارضی
-Schedule an appointment for XXX.: XXX کے لئے ملاقات کا نظام الاوقات: YYY۔
+Schedule an appointment for XXX.: XXX کے لئے ملاقات کا نظام الاوقات۔
 date_select: __d_____ تاریخ________
 Event approved: واقعہ منظور
 Journal approved: جرنل کی منظوری

--- a/translations/Uyghur.txt
+++ b/translations/Uyghur.txt
@@ -1410,7 +1410,7 @@ on: =
 All Attendees: بارلىق قاتناشقۇچىلار
 Busy: ئالدىراش
 Tentative: =
-Schedule an appointment for XXX.: XXX: YYY ئۈچۈن ئۇچرىشىشنى ئورۇنلاشتۇرۇڭ.
+Schedule an appointment for XXX.: XXX ئۈچۈن ئۇچرىشىشنى ئورۇنلاشتۇرۇڭ.
 date_select: __dd__ __ ئاي __yyy__
 Event approved: پائالىيەت تەستىقلاندى
 Journal approved: ژۇرنال تەستىقلاندى

--- a/translations/Uzbek.txt
+++ b/translations/Uzbek.txt
@@ -1410,7 +1410,7 @@ on: kuni
 All Attendees: Barcha ishtirokchilar
 Busy: Band
 Tentative: Taxminiy
-Schedule an appointment for XXX.: XXX uchun uchrashuvni rejalashtiring: YYY.
+Schedule an appointment for XXX.: XXX uchun uchrashuvni rejalashtiring.
 date_select: __dd__ __mon____yyyyyy__
 Event approved: Tadbir tasdiqlandi
 Journal approved: Jurnal tasdiqlandi

--- a/translations/Vietnamese.txt
+++ b/translations/Vietnamese.txt
@@ -1410,7 +1410,7 @@ on: trên
 All Attendees: Tất cả người tham dự
 Busy: Bận
 Tentative: Mang tính thăm dò
-Schedule an appointment for XXX.: Lên lịch một cuộc hẹn cho XXX: YYY.
+Schedule an appointment for XXX.: Lên lịch một cuộc hẹn cho XXX.
 date_select: __dd__ __tháng _ __yyyy__
 Event approved: Sự kiện đã được phê duyệt
 Journal approved: Tạp chí đã được phê duyệt

--- a/translations/Xhosa.txt
+++ b/translations/Xhosa.txt
@@ -1410,7 +1410,7 @@ on: ivuliwe
 All Attendees: Bonke abezileyo
 Busy: Ndixakekile
 Tentative: Okwexeshana
-Schedule an appointment for XXX.: Cwangcisa idinga le-XXX: YYY.
+Schedule an appointment for XXX.: Cwangcisa idinga le-XXX.
 date_select: =
 Event approved: Umcimbi uvunyiwe
 Journal approved: Ijenali yamkelwe

--- a/translations/Yiddish.txt
+++ b/translations/Yiddish.txt
@@ -1410,7 +1410,7 @@ on: אויף
 All Attendees: כל אַטענדיז
 Busy: פאַרנומען
 Tentative: טענטאַטיוו
-Schedule an appointment for XXX.: פּלאַן אַ אַפּוינטמאַנט פֿאַר XXX: YYY.
+Schedule an appointment for XXX.: פּלאַן אַ אַפּוינטמאַנט פֿאַר XXX.
 date_select: =
 Event approved: געשעעניש באוויליקט
 Journal approved: זשורנאַל באוויליקט

--- a/translations/Yoruba.txt
+++ b/translations/Yoruba.txt
@@ -1410,7 +1410,7 @@ on: lori
 All Attendees: Gbogbo Awọn olukopa
 Busy: Nšišẹ
 Tentative: =
-Schedule an appointment for XXX.: Ṣeto ipinnu lati pade fun XXX: YYY.
+Schedule an appointment for XXX.: Ṣeto ipinnu lati pade fun XXX.
 date_select: __dd__ __ osu____ __yyyy__
 Event approved: Iṣẹlẹ ti a fọwọsi
 Journal approved: Iwe akọọlẹ ti a fọwọsi                                        

--- a/translations/Zulu.txt
+++ b/translations/Zulu.txt
@@ -1410,7 +1410,7 @@ on: vula
 All Attendees: Bonke Ababekhona
 Busy: Kubhizi
 Tentative: Okwesikhashana
-Schedule an appointment for XXX.: Hlela i-aphoyintimenti ye-XXX: YYY.
+Schedule an appointment for XXX.: Hlela i-aphoyintimenti ye-XXX.
 date_select: =
 Event approved: Umcimbi uvunyelwe
 Journal approved: Ijenali ivunyelwe


### PR DESCRIPTION
Two small defects in the daily matrix (`view_d.php`, `availability.php`),
found while smoke-testing #713.

## 1. Duplicated block in `daily_matrix()`

`includes/functions.php:617-627` re-ran eleven assignments that
`:596-606` had already made — `$tentative`, `$titleStr`, `$viewMsg`,
`$hours`, `$interval`, `$cell_pct`, `$cols`, `$style_width`, `$thismonth`,
`$thisyear`. Nothing between the two blocks changes any of their inputs, so
the second block computed identical values and was dead weight. Removed.

## 2. Cell tooltip leaked a literal `YYY`

Every cell in the matrix rendered:

```
title="Schedule an appointment for 8:00:YYY."
```

The source key declares a single placeholder — `'Schedule an appointment for
XXX.'` — but 81 of the 84 translated values carried a second, stray one that
nothing ever substituted.

Two separate problems in the translation data:

* **74 values** had a stray placeholder after the time. `YYY` in most, but
  also transliterated into the target script: `GGG` (Bosnian, Croatian),
  `ГГГ` (Belarusian, Serbian), `РРР` (Ukrainian), `ЖЖЖ` (Kazakh), `ГОСА`
  (Macedonian), `AAAA` (Corsican, Haitian), `JJJ` (Frisian), `RRRR`
  (Slovak), `BBBB` (Irish, Scots), `SSSS` (Maltese), `વાયવાય` (Gujarati),
  and a duplicated `XXX:XXX` in Greek. Removed with the separator joining it.

* **7 values** — Gujarati, Kazakh, Macedonian, Marathi, Serbian, Sindhi,
  Shona — had the `XXX` placeholder *itself* transliterated (`ХХХ`,
  `КСКСКС`, `एक्सएक्सएक्स`, `ايڪسينڪس`, and Shona's truncated `weXX`), so
  `str_replace( 'XXX', ... )` never matched and those locales showed **no
  time at all**. A literal `XXX` was restored in position; the surrounding
  wording is untouched.

The code was also made tolerant of both placeholder forms, so a translation
that reintroduces the split form renders correctly rather than leaking a
placeholder again. With the data cleaned this path is defensive only — happy
to drop it for a plain `str_replace` if you would rather keep the function
lean.

Before: `title="Schedule an appointment for 8:00:YYY."`
After:  `title="Schedule an appointment for 8:00."`

## Scope

Exactly one line changed in each of the 81 translation files (81 insertions,
81 deletions). Dutch, French and German were already correct and are
untouched. The 19 non-UTF-8 translation files do not carry this phrase, and
the 159 timestamped backup files under `translations/` are never loaded —
`includes/translate.php:157,179` only ever resolves `<lang>.txt`.

## Test plan

- [x] `php -l` clean
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (685 tests, 2400 assertions)
- [x] All 84 translated values re-checked: each now holds exactly one `XXX`
      and no stray token
- [x] Rendered live (PHP 8.1 + MariaDB, Docker): tooltips read
      `Schedule an appointment for 10:00.`, zero occurrences of `XXX` or
      `YYY` anywhere on the page

## Upgrade note

Sites running with a translation cache will keep serving the old strings
until it is cleared — `includes/translate.php:216` writes cached copies
under `$cachedir/translations/`. Worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
