### PR TITLE
fix: upgrade from pre-v1.9.11 no longer fatals on undefined translate() (#714)

### DIFF
--- a/includes/dbi4php.php
+++ b/includes/dbi4php.php
@@ -474,10 +474,6 @@ function dbi_affected_rows( $conn, $res ) {
 function dbi_update_blob( $table, $column, $key, $data ) {
   global $db_connection_info;
 
-  $notAvailable = str_replace ( ['XXX', 'YYY'],
-    ['dbi_update_blob', $GLOBALS['db_type']],
-    translate( 'Unfortunately, XXX is not implemented for YYY' ) );
-
   assert( ! empty( $table ) );
   assert( ! empty( $column ) );
   assert( ! empty( $key ) );
@@ -520,7 +516,9 @@ elseif( strcmp( $GLOBALS['db_type'], 'postgresql' ) == 0 )
     return ( $ret == FALSE ? FALSE : TRUE );
   } else
     // TODO!
-    die_miserable_death( $notAvailable );
+    die_miserable_death( str_replace ( ['XXX', 'YYY'],
+        ['dbi_update_blob', $GLOBALS['db_type']],
+        translate( 'Unfortunately, XXX is not implemented for YYY' ) ) );
 }
 
 /**
@@ -534,10 +532,6 @@ elseif( strcmp( $GLOBALS['db_type'], 'postgresql' ) == 0 )
  */
 function dbi_get_blob( $table, $column, $key ) {
   global $db_connection_info;
-
-  $notAvailable = str_replace ( ['XXX', 'YYY'],
-    ['dbi_get_blob', $GLOBALS['db_type']],
-    translate( 'Unfortunately, XXX is not implemented for YYY' ) );
 
   assert( ! empty( $table ) );
   assert( ! empty( $column ) );
@@ -563,7 +557,9 @@ function dbi_get_blob( $table, $column, $key ) {
       $ret = $row[0];
     } else {
       // TODO!
-      die_miserable_death( $notAvailable );
+      die_miserable_death( str_replace ( ['XXX', 'YYY'],
+        ['dbi_get_blob', $GLOBALS['db_type']],
+        translate( 'Unfortunately, XXX is not implemented for YYY' ) ) );
     }
   }
   dbi_free_result( $res );

--- a/tests/UpgradeFunctionsSmokeTest.php
+++ b/tests/UpgradeFunctionsSmokeTest.php
@@ -96,4 +96,42 @@ final class UpgradeFunctionsSmokeTest extends TestCase
       @rmdir($emptyDir);
     }
   }
+
+  /**
+   * Regression test for #714.
+   *
+   * The two tests above both return early -- missing dir, empty dir -- so
+   * nothing in the suite ever reached dbi_update_blob(), which is where the
+   * upgrade died with "Call to undefined function translate()".  This one
+   * puts a real icon in place so the migration actually runs.
+   */
+  public function test_do_v1_9_11_updates_migrates_an_icon_file(): void
+  {
+    $iconDir = sys_get_temp_dir() . '/wcsmoke_icons_' . uniqid();
+    mkdir($iconDir);
+    // Smallest valid GIF: 1x1 transparent.
+    $gif = base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+    $iconFile = $iconDir . '/cat-7.gif';
+    file_put_contents($iconFile, $gif);
+
+    dbi_execute("INSERT INTO webcal_categories (cat_id, cat_name, cat_owner)"
+      . " VALUES (7, 'Smoke', 'admin')");
+
+    try {
+      $this->assertTrue(do_v1_9_11_updates(null, null, $iconDir));
+
+      $res = dbi_execute('SELECT cat_icon_mime, cat_icon_blob'
+        . ' FROM webcal_categories WHERE cat_id = 7');
+      $row = dbi_fetch_row($res);
+      dbi_free_result($res);
+
+      $this->assertSame('image/gif', $row[0], 'mime type should be recorded');
+      $this->assertSame($gif, $row[1], 'icon bytes should be stored in the blob');
+      $this->assertFileDoesNotExist($iconFile,
+        'source file should be removed so a re-run does not repeat the work');
+    } finally {
+      @unlink($iconFile);
+      @rmdir($iconDir);
+    }
+  }
 }

--- a/wizard/shared/upgrade-functions.php
+++ b/wizard/shared/upgrade-functions.php
@@ -35,6 +35,10 @@
  */
 
 require_once __DIR__ . '/../../includes/dbi4php.php';
+// dbi4php reports errors through translate().  The wizard deliberately
+// avoids config.php, so pull in translate.php on its own: with $LANGUAGE
+// unset translate() just returns the string it was given.
+require_once __DIR__ . '/../../includes/translate.php';
 
 /**
  * Ensure dbi4php is connected using the wizard's current database
@@ -232,6 +236,9 @@ function do_v1_9_11_updates($connection = null, $state = null, ?string $iconDir 
 
   // wizard/shared/ -> repo root -> wc-icons/ (overridable for tests)
   $icon_path = $iconDir ?? __DIR__ . '/../../wc-icons/';
+  // Normalize: an injected path without a trailing slash would make every
+  // glob() below silently match nothing.
+  $icon_path = rtrim($icon_path, '/') . '/';
   if (!is_dir($icon_path)) {
     // No icon directory on disk; nothing to migrate.
     return true;


### PR DESCRIPTION
Fixes #714.

## Problem

Upgrading a database from before v1.9.11 died partway through:

```
Step 3: Creating/upgrading database tables...

Fatal error: Uncaught Error: Call to undefined function translate() in includes/dbi4php.php:479
#0 wizard/shared/upgrade-functions.php(270): dbi_update_blob('webcal_categori...', 'cat_icon_blob', 'cat_id = 10', ...)
#1 wizard/WizardDatabase.php(620): do_v1_9_11_updates(Object(mysqli), Object(WizardState))
```

No rollback, so the schema was left half-migrated: the v1.9.11 columns
existed but `WEBCAL_PROGRAM_VERSION` never advanced.

## Fix

**`includes/dbi4php.php`** — `dbi_update_blob()` and `dbi_get_blob()` both
built their "XXX is not implemented for YYY" message unconditionally at the
top of the function, even though it is only used in the unsupported-db-type
branch. So the `translate()` call fired on *every* invocation, not just on
failure. Both messages are now built at the point of use.

**`wizard/shared/upgrade-functions.php`** — also loads `includes/translate.php`
directly. The wizard deliberately avoids `config.php` (see the file header),
and does not need it here: with `$LANGUAGE` unset `translate()` returns its
argument untouched. That is enough to make every *other* error path in the DB
layer (`dbi_query`, `dbi_error`, `dbi_fatal_error` — roughly 20 `translate()`
call sites) report properly instead of fataling.

**`do_v1_9_11_updates()`** — normalizes its injectable icon path. Without a
trailing slash every `glob()` below it silently matched nothing.

## Test gap this closes

`tests/UpgradeFunctionsSmokeTest.php` had two tests for this function and both
returned early — missing icon dir, empty icon dir — so nothing in the suite
ever reached `dbi_update_blob()`. The new test puts a real `cat-7.gif` in
place and asserts the MIME type, the stored blob bytes, and that the source
file is consumed.

Written test-first. Against unfixed code it reproduces the issue exactly:

```
1) UpgradeFunctionsSmokeTest::test_do_v1_9_11_updates_migrates_an_icon_file
Error: Call to undefined function translate()
/var/www/html/webcalendar/includes/dbi4php.php:479
```

(The path normalization was needed to get there — without it the new test
passed while exercising none of the migration, which is the same blind spot
that hid the bug in the first place.)

## Test plan

- [x] `php -l` clean on all three files
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (686 tests, 2404 assertions)
- [x] New test fails with the reported fatal before the fix, passes after
- [x] End to end, PHP 8.1 + MariaDB in Docker: restored a real v1.9.10
      database, ran `php wizard/headless.php --use-env`, upgrade completed to
      v1.9.23 and migrated 12 category icons into `webcal_categories` blobs
      with correct MIME types and byte counts, consuming the source files

## Note

The unsupported-db-type branch still calls `die_miserable_death()`, which
lives in `config.php` and is therefore not loaded in the wizard. That branch
is unreachable for the backends the wizard offers, so I left it rather than
pull `config.php` into the wizard and undo the separation the file header
describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
