### PR TITLE
fix: timebar week view no longer drops events on the last day (#715)

### DIFF
--- a/view_t.php
+++ b/view_t.php
@@ -255,7 +255,12 @@ if ($view_type == 'S') {
   $next = mktime ( 0, 0, 0, $thismonth, $thisday + 7, $thisyear );
   $prev = mktime ( 0, 0, 0, $thismonth, $thisday - 7, $thisyear );
   $wkstart = get_weekday_before ( $thisyear, $thismonth, $thisday + 1 );
-  $wkend = $wkstart + 518400;
+  // End on the last second of the seventh day, not its midnight: read_events()
+  // bounds the final day by time of day, so stopping at midnight dropped every
+  // event on it.  mktime() rather than a fixed offset so DST weeks still end
+  // on the right day.
+  $wkend = mktime ( 23, 59, 59, date ( 'm', $wkstart ),
+    date ( 'd', $wkstart ) + 6, date ( 'Y', $wkstart ) );
   $val_boucle = 7;
 } else {
   $next = mktime ( 0, 0, 0, $thismonth + 1, $thisday, $thisyear );


### PR DESCRIPTION
Fixes #715.

## Problem

`view_t.php` rendering a **week** timebar (view type `S`) never showed events
on the final day of the displayed week. The day row rendered with its full
grid; it was just always empty.

## Cause

The week branch ended its fetch window six days after the start — midnight of
the last rendered day rather than the end of it:

```php
$wkend = $wkstart + 518400;                                  // was
$wkend = mktime ( 23, 59, 59, $thismonth + 1, 0, $thisyear ); // month branch, correct
```

`read_events()` (`includes/functions.php:5552`) bounds the final day by time
of day:

```php
... OR ( we.cal_date = ' . $end_date . ' AND we.cal_time <= '
  . gmdate ( 'His', $enddate ) . ' ) )'
```

so with `$wkend` at midnight the last day matched nothing. The render loop
still iterates `$date <= $wkend`, which is why the row appeared but stayed
empty. The month branch (type `T`) already used `mktime( 23, 59, 59, ... )`
and was unaffected.

## Fix

End on the last second of the seventh day, built with `mktime()` rather than
a fixed second count so a week containing a DST transition still ends on the
right day. The displayed date range is unchanged — `date( 'Ymd', $wkend )`
still resolves to the same day.

## Verification

Live instance, PHP 8.1 + MariaDB, one type `S` view and one type `T` view
sharing the same participants, with two events in the same week — one
mid-week (Wed Sep 2) and one on the last day (Sat Sep 5), identical apart
from the date:

| view | mid-week event | last-day event |
|---|---|---|
| type S — **before** | shown | **missing** |
| type S — **after** | shown | **shown** |
| type T — before/after | shown | shown |

Displayed range stayed `August 30, 2026 - September 5, 2026` throughout, and
type `T` is unchanged, so no regression there.

DST weeks checked too, since the fix leans on `mktime()`. Both 2026 US
transitions fall on a week-start Sunday:

| week | last-day event before | after | day rows | range |
|---|---|---|---|---|
| Mar 8-14 (spring forward) | missing | **shown** | 7 | correct |
| Nov 1-7 (fall back) | missing | **shown** | 7 | correct |

## Test plan

- [x] `php -l` clean
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (685 tests, 2400 assertions)
- [x] Manual before/after against a live instance, as above

No automated test added: `view_t.php` is a top-level procedural page with no
seam to call into, and extracting the boundary calculation purely to test it
would be a wider refactor than this fix warrants.

## Related, deliberately not in this PR

The issue also flagged `week_ssi.php:52` and `report.php:366` as carrying the
same `+ 518400` pattern. `week_ssi.php` turns out to have a different and
more serious problem — it passes `Ymd` integers to `read_events()`, which
expects timestamps — so it needs its own investigation rather than being
folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
