### PR TITLE
fix: week_ssi.php never rendered any events (#719)

### DIFF
--- a/week_ssi.php
+++ b/week_ssi.php
@@ -49,16 +49,18 @@ $next = mktime( 0, 0, 0, $thismonth, $thisday + 7, $thisyear );
 $prev = mktime( 0, 0, 0, $thismonth, $thisday - 7, $thisyear );
 
 $wkstart = get_weekday_before ( $thisyear, $thismonth, $thisday + 1 );
-$wkend = $wkstart + 518400;
-
-$startdate = date ( 'Ymd', $wkstart );
-$enddate = date ( 'Ymd', $wkend );
+// End on the last second of the seventh day, not its midnight: read_events()
+// bounds the final day by time of day, so stopping at midnight drops every
+// event on it.  mktime() rather than a fixed offset so DST weeks still end on
+// the right day.
+$wkend = mktime ( 23, 59, 59, date ( 'm', $wkstart ),
+  date ( 'd', $wkstart ) + 6, date ( 'Y', $wkstart ) );
 
 /* Pre-Load the repeated events for quicker access */
-$repeated_events = read_repeated_events ( $login, $startdate, $enddate, '' );
+$repeated_events = read_repeated_events ( $login, $wkstart, $wkend, '' );
 
 /* Pre-load the non-repeating events for quicker access */
-$events = read_events ( $login, $startdate, $enddate );
+$events = read_events ( $login, $wkstart, $wkend );
 
 $first_hour = $WORK_DAY_START_HOUR;
 $last_hour = $WORK_DAY_END_HOUR;


### PR DESCRIPTION
Fixes #719.

## Problem

`week_ssi.php` has never displayed a single event. It converted its week
bounds to `Ymd` strings and passed those to `read_events()` and
`read_repeated_events()`, both of which treat their arguments as Unix
timestamps:

```php
// includes/functions.php, read_events()
$start_date = gmdate ( 'Ymd', $startdate );
```

`gmdate( 'Ymd', 20260906 )` is `19700823`, so the date filter asked for events
in **August 1970**. `get_entries()` only reads the preloaded `$events` global
and never queries on its own, so the page rendered its seven-day table with
every cell empty.

This page was the only one of the 21 `read_events()` call sites doing it —
every other passes `mktime()`/`time()` output, and `ws/get_events.php:82`
explicitly wraps its input in `date_to_epoch()`. `read_events()` began
treating its arguments as timestamps in `76305067` (2006-04-06, *"Total
revamp of timezone calculations"*); `week_ssi.php` dates to 2001 and was
never updated.

## Second bug, hidden behind the first

Fixing the arguments exposed the same boundary defect fixed for #715 in
#718 — `$wkend = $wkstart + 518400` lands on midnight of the seventh day
rather than the end of it, so events on the final day were dropped. Now ends
on the last second, built with `mktime()` so a week containing a DST
transition still ends on the right day.

The now-unused `$startdate`/`$enddate` locals are removed. Nothing else in
this page or its callees reads them (the only `global $enddate` in the tree
is `includes/xcal.php:690`, which is not in this page's include chain).

## Verification

Live instance, PHP 8.1 + MariaDB. `week.php` renders the same seeded data
correctly throughout, confirming the data is sound.

Logged in, current week plus both 2026 US DST transition weeks:

| week | | plain | repeats | last-day |
|---|---|---|---|---|
| current | before | **0** | **0** | **0** |
| current | after | 2 | 5 | 1 |
| Mar 8-14 (spring forward) | before / after | 0 / — | 0 / — | DST event **0 → 1** |
| Nov 1-7 (fall back) | before / after | 0 / — | 0 / 7 | DST event **0 → 1** |

Anonymous SSI embed with `PUBLIC_ACCESS=Y`, which is the documented use case
for this file — the public user's own event:

| | events rendered |
|---|---|
| before | **0** |
| after | **1** |

Seven day headers render correctly in every case, before and after.

## Test plan

- [x] `php -l` clean
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (685 tests, 2400 assertions)
- [x] Manual before/after as above

No automated test added: like `view_t.php`, this is a top-level procedural
page with no seam to call into.

## Two things found alongside, deliberately not in this PR

**The `?login=` parameter is ignored.** The file's docblock says the login id
"is either passed in the URL `week_ssi.php?login=cknudsen`", but anonymous
responses are byte-identical for `?login=admin`, `?login=bogususer` and an
empty value (same md5) — `$login` is already set by `init.php` before the
`strlen( $login ) == 0` check on line 19, so the URL value never applies. You
get the public user's calendar anonymously, or your own when logged in. That
is a behaviour/documentation mismatch that predates this change and deserves
its own decision about which side should give.

**Stale comment.** `includes/init.php:12` still lists `week_ssi.php` among
scripts that "do not use this file", but it has required `init.php` since
`af78db72` (2006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
