### PR TITLE
docs: describe week_ssi.php as it actually behaves, drop unreachable block (#721)

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -9,7 +9,6 @@
  * <b>Comments:</b>
  * The following scripts do not use this file:
  *   - login.php
- *   - week_ssi.php
  *   - upcoming.php
  *   - tools/send_reminders.php
  *

--- a/login.php
+++ b/login.php
@@ -166,13 +166,11 @@ if ($single_user == 'Y' || $use_http_auth) {
         ? time() + 31536000 : 0);
       sendCookie('webcalendar_session', $encoded_login, $timeStr, $cookie_path);
 
-      // The cookie "webcalendar_login" is provided as a convenience to other
-      // apps that may wish to know what was the last calendar login,
-      // so they can use week_ssi.php as a server-side include.
-      // As such, it's not a security risk to have it un-encoded since it is not
-      // used to allow logins within this app. It is used to load user
-      // preferences on the login page (before anyone has logged in)
-      // if $REMEMBER_LAST_LOGIN is set to "Y" (in admin.php).
+      // The cookie "webcalendar_login" records the last calendar login. It is
+      // not a security risk to have it un-encoded since it is not used to
+      // allow logins within this app. It is used to load user preferences on
+      // the login page (before anyone has logged in) if $REMEMBER_LAST_LOGIN
+      // is set to "Y" (in admin.php).
       sendCookie('webcalendar_login', $login, $timeStr, $cookie_path);
 
       if (!empty($GLOBALS['newUserUrl'])) {

--- a/week_ssi.php
+++ b/week_ssi.php
@@ -2,10 +2,11 @@
 /**
  * This page is intended to be used as a server-side include for another page.
  * (Such as an intranet home page or something.)
- * As such, no login is required. Instead, the login id is either passed in the
- * URL "week_ssi.php?login=cknudsen". Unless, of course, we are in
- * single-user mode, where no login info is needed.
- * If no login info is passed, we check for the last login used.
+ *
+ * It shows the week belonging to whoever is viewing it: the logged-in user,
+ * or the public user when $PUBLIC_ACCESS is enabled. There is no way to embed
+ * some other user's calendar. A "login" URL parameter is ignored, because
+ * includes/init.php has already established the login before this page runs.
  */
 
 require_once 'includes/init.php';
@@ -15,20 +16,6 @@ load_global_settings();
 $WebCalendar->setLanguage();
 
 $user = '__none__'; // Don't let user specify in URL.
-
-if ( strlen ( $login ) == 0 ) {
-  if ( $single_user == 'Y' )
-    $login = $user = $single_user_login;
-  else
-  if ( strlen ( $webcalendar_login ) > 0 )
-    $login = $user = $webcalendar_login;
-  else {
-    echo '<span style="color:#F00;"><span class="bold colon">' .
-      translate ( 'Error' ) . '</span>'
-     . translate( 'No user specified.' ) . '</span>';
-    exit;
-  }
-}
 
 $view = 'week';
 // TODO This is suspect


### PR DESCRIPTION
Fixes #721.

## Problem

`week_ssi.php`'s docblock still described the pre-2006 design — a `?login=`
URL parameter naming whose calendar to embed, a `webcalendar_login` cookie
fallback, and a single-user branch:

```php
 * As such, no login is required. Instead, the login id is either passed in the
 * URL "week_ssi.php?login=cknudsen". Unless, of course, we are in
 * single-user mode, where no login info is needed.
 * If no login info is passed, we check for the last login used.
```

None of it has worked since `af78db72` (2006-02-03) moved the bootstrap to the
top of the file. `includes/init.php` now establishes `$login` first — session
(`WebCalendar.php:564`), `__public__` (`:763`), single-user (`:539`) or HTTP
auth (`:546`) — and redirects to `login.php` when it cannot. So the check
below it is never true:

```php
if ( strlen ( $login ) == 0 ) {     // unreachable
```

and the whole block, including the "No user specified." error, is dead.
Nothing reads `login` from `$_GET` for this page either. Anonymous responses
are byte-identical for `?login=admin`, `?login=bogususer` and an empty value.

## Which side gives

Restoring the documented behaviour would let any anonymous visitor read any
user's week by guessing a login, which is very likely why it did not survive
the move to a real auth bootstrap. So this corrects the documentation to match
the code rather than the reverse, and removes the unreachable block.

If per-user embedding is ever wanted back it should be a deliberate feature
with its own opt-in, not a bare URL parameter.

## Deliberately kept

`$user = '__none__';` stays. It reads like part of the dead block but is not:
`$user` is populated from the request at `WebCalendar.php:184`, and that line
is what stops a URL-supplied value reaching the globals downstream.

The `webcalendar_login` cookie stays too. `login.php:46-50` and
`WebCalendar.php:413-414` still use it for `$REMEMBER_LAST_LOGIN`; only its
comment's claim about week_ssi.php is dropped.

## Two related comments corrected

* `includes/init.php:12` listed `week_ssi.php` among scripts that "do not use
  this file", though it has required `init.php` since 2006. The other three
  entries — `login.php`, `upcoming.php`, `tools/send_reminders.php` — were
  checked and are still accurate, so only that one line changed.
* `login.php:169-176` said the cookie exists "so they can use week_ssi.php as
  a server-side include". Reworded to its real remaining purpose.

## Verification

No behaviour change is intended and none was observed. Live instance,
PHP 8.1 + MariaDB, with an `admin` event and a `__public__` event in the same
week:

| | before | after |
|---|---|---|
| anonymous embed (`PUBLIC_ACCESS=Y`) | 200, public event, 7 day headers | identical |
| logged-in embed | 200, admin event, 7 day headers | identical |
| `login.php` | 200 | identical |
| `webcalendar_login` cookie set at login | yes | yes |

The `No user specified.` translation phrase is **not** orphaned — `publish.php`
and `freebusy.php` still use it, so the 85 translation files that carry it are
untouched.

## Test plan

- [x] `php -l` clean on all three files
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (691 tests, 2414 assertions)
- [x] Manual before/after as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
