### PR TITLE
fix: emit an empty inputSchema.properties as a JSON object, not an array

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -6887,7 +6887,11 @@ function mcp_list_tools() {
       'description' => 'Get basic information about the authenticated user',
       'inputSchema' => [
         'type' => 'object',
-        'properties' => []
+        // new stdClass(), not []: json_encode turns an empty PHP array into `[]`,
+        // but JSON Schema requires `properties` to be an object. MCP clients that
+        // validate tools/list against the spec reject the whole response over it,
+        // so this one tool made every other tool undiscoverable too.
+        'properties' => new stdClass()
       ]
     ],
     [

--- a/tests/McpTest.php
+++ b/tests/McpTest.php
@@ -101,6 +101,35 @@ final class McpTest extends TestCase
     }
   }
 
+  /**
+   * An empty `properties` must serialize as a JSON object, not an array.
+   *
+   * json_encode() turns an empty PHP array into `[]`, but JSON Schema requires
+   * `properties` to be an object. A client that validates tools/list against
+   * the spec rejects the entire response, so a single parameterless tool makes
+   * every other tool undiscoverable too.
+   *
+   * test_tools_list_schemas() above cannot catch this: an empty array
+   * satisfies assertArrayHasKey() and still encodes as `[]`.
+   */
+  public function test_tools_list_properties_encode_as_json_objects() {
+    foreach (mcp_list_tools() as $tool) {
+      $this->assertStringContainsString(
+        '"properties":{', json_encode($tool['inputSchema']),
+        $tool['name'] . ': inputSchema.properties must encode as a JSON'
+         . ' object, not an array'
+      );
+    }
+  }
+
+  public function test_parameterless_tool_encodes_empty_properties_as_object() {
+    $schema = get_mcp_tool_schema('get_user_info');
+    $this->assertNotNull($schema);
+    $this->assertCount(0, (array)$schema['properties'],
+      'get_user_info takes no parameters');
+    $this->assertStringContainsString('"properties":{}', json_encode($schema));
+  }
+
   // ---------------------------------------------------------------
   // MCP Tool Schema Validation Tests
   // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

`mcp_list_tools()` declared `get_user_info` — the one tool that takes no
parameters — with an empty PHP array:

```php
'inputSchema' => [
  'type' => 'object',
  'properties' => []
]
```

`json_encode()` turns an empty PHP array into `[]`, so the tool went out on
the wire as:

```json
{"type":"object","properties":[]}
```

JSON Schema requires `properties` to be an object. An MCP client that
validates `tools/list` against the spec rejects the **whole** response, so
this single tool made every other tool undiscoverable — not just itself.

## Fix

`new stdClass()` encodes as `{}` while staying an empty property bag.

## Test coverage

`test_tools_list_schemas()` already walked every tool, but its check was

```php
$this->assertArrayHasKey('properties', $tool['inputSchema']);
```

which an empty array satisfies while still encoding as `[]`. So nothing in
the suite would have caught this, or would catch it returning the next time a
parameterless tool is added.

Two tests are added:

* `test_tools_list_properties_encode_as_json_objects` — walks every tool from
  `mcp_list_tools()` and asserts its encoded `inputSchema` contains
  `"properties":{`, naming the offending tool in the failure message
* `test_parameterless_tool_encodes_empty_properties_as_object` — pins
  `get_user_info` specifically, since it is currently the only tool with no
  parameters

Both were confirmed to fail against the unfixed code:

```
1) McpTest::test_tools_list_properties_encode_as_json_objects
get_user_info: inputSchema.properties must encode as a JSON object, not an array
Failed asserting that '{"type":"object","properties":[]}' contains '"properties":{'.

2) McpTest::test_parameterless_tool_encodes_empty_properties_as_object
Failed asserting that '{"type":"object","properties":[]}' contains '"properties":{}'.
```

## Scope check

All 9 tools were swept by encoding each `inputSchema` and inspecting the
output rather than reading the source, since `'properties' => [` looks the
same whether or not it is empty:

| tool | properties | encodes as |
|---|---|---|
| `list_events` | 2 | `{...}` |
| **`get_user_info`** | **0** | **`{}`** (fixed here) |
| `search_events` | 2 | `{...}` |
| `add_event` | 6 | `{...}` |
| `get_availability` | 2 | `{...}` |
| `check_conflicts` | 3 | `{...}` |
| `add_recurring_event` | 7 | `{...}` |
| `update_event` | 7 | `{...}` |
| `delete_event` | 1 | `{...}` |

`get_user_info` was the only one affected. `mcp_initialize_result()` was
checked for the same `[]`-vs-`{}` trap and is clean — every nested value there
is non-empty, so it already encodes as
`{"capabilities":{"tools":{"listChanged":true}},"serverInfo":{...}}`.

## Test plan

- [x] `php -l` clean
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — 692 tests, 2411 assertions,
      3 skipped (the usual MySQL-credential skips)
- [x] `--filter McpTest` — OK (57 tests, 249 assertions)
- [x] Both new tests fail with the fix reverted, pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
