### PR TITLE
test: assert add_event is blocked when MCP write access is off

### DIFF
--- a/tests/McpWriteAccessDisabledTest.php
+++ b/tests/McpWriteAccessDisabledTest.php
@@ -110,6 +110,19 @@ final class McpWriteAccessDisabledTest extends TestCase
         return $n;
     }
 
+    public function test_add_event_is_blocked_and_creates_nothing(): void
+    {
+        $before = $this->entryCount();
+        $resp = $this->callTool('add_event', [
+            'name' => 'Should Not Persist',
+            'date' => '20260803',
+        ]);
+        $result = $resp['result'] ?? [];
+        $this->assertArrayHasKey('error', $result, json_encode($resp));
+        $this->assertStringContainsStringIgnoringCase('write access', $result['error']);
+        $this->assertSame($before, $this->entryCount(), 'no event may be created when write access is off');
+    }
+
     public function test_add_recurring_event_is_blocked_and_creates_nothing(): void
     {
         $before = $this->entryCount();


### PR DESCRIPTION
## Gap

`McpWriteAccessDisabledTest` guards the `MCP_WRITE_ACCESS` admin setting: with
MCP enabled but write access off, every write tool must refuse and change
nothing. It covered three of the four write tools:

| tool | covered before |
|---|---|
| **`add_event`** | **no** |
| `add_recurring_event` | yes |
| `update_event` | yes |
| `delete_event` | yes |

`add_event` is the most commonly used of the four and was the one without a
case.

## Change

Adds `test_add_event_is_blocked_and_creates_nothing`, following the same shape
as its neighbours in the class:

* call the tool through the running MCP server
* require an `error` in the result, mentioning "write access" — so an
  unrelated failure (a missing parameter, say) will not satisfy it
* assert `entryCount()` is unchanged, so a refusal that still wrote an event
  would fail

The class is self-contained: `setUpBeforeClass()` headless-installs a SQLite
schema, sets `MCP_SERVER_ENABLED=Y` with `MCP_WRITE_ACCESS=N`, and runs a real
server on port 8104.

## Test plan

- [x] `php -l` clean
- [x] `--filter McpWriteAccessDisabledTest` — OK (5 tests, 12 assertions)
- [x] `./tests/compile_test.sh` — 276 files ok, 0 errors
- [x] `vendor/bin/phpunit -c tests/phpunit.xml` — OK (693 tests, 2426 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
