### PR TITLE
chore: ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.class
 .DS_Store
+# Local environment overrides -- may hold credentials, never commit.
+.env
 .htaccess
 includes/htmlare*
 includes/settings.php


### PR DESCRIPTION
`.env` holds local environment overrides and can contain database credentials,
but it was not in `.gitignore` — one `git add -A` away from being committed.

It is untracked today, so nothing needs untracking; this only prevents it
being added by accident in future.

```diff
 .DS_Store
+# Local environment overrides -- may hold credentials, never commit.
+.env
 .htaccess
```

Verified: `git check-ignore -v .env` now reports `.gitignore:4:.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
