### PR TITLE
test: wait for the wizard Summary step on a deadline, not 10 iterations (#728)

### DIFF
--- a/tests/web-install-mysql.py
+++ b/tests/web-install-mysql.py
@@ -265,17 +265,26 @@ def test_new_installation(driver):
             pass  # No Admin User step (e.g. admins already exist)
 
         # Click through Summary if needed
-        for i in range(10):
+        #
+        # Poll to a deadline rather than a fixed iteration count. On a slow
+        # backend the Summary step can take longer than the old ~10s budget to
+        # appear; missing it meant Continue was never clicked, so the run sat on
+        # Admin User until the Finish wait below timed out (#728).
+        summary_deadline = time.time() + 45
+        summary_clicked = False
+        while time.time() < summary_deadline:
             try:
                 title = driver.find_element(By.ID, "stepTitle").text
-                if "Summary" in title:
+                if "Finish" in title:
+                    break
+                if "Summary" in title and not summary_clicked:
                     # Try save-settings-file first; if it doesn't exist (ENV mode), use Continue
                     save_btns = driver.find_elements(By.CSS_SELECTOR, "button[data-action='save-settings-file']")
                     if save_btns:
                         click_button(driver, "button[data-action='save-settings-file']")
                     else:
                         click_button(driver, "continueToFinishBtn", by=By.ID)
-                if "Finish" in title: break
+                    summary_clicked = True
             except Exception: pass
             time.sleep(1)
 

--- a/tests/web-install-postgresql.py
+++ b/tests/web-install-postgresql.py
@@ -220,17 +220,25 @@ def test_new_installation(driver):
             pass  # No Admin User step (e.g. admins already exist)
 
         # Click through Summary / Finish
-        for i in range(10):
+        #
+        # Poll to a deadline rather than a fixed iteration count. On a slow
+        # backend the Summary step can take longer than the old ~10s budget to
+        # appear; missing it meant Continue was never clicked, so the run sat on
+        # Admin User until the Finish wait below timed out (#728).
+        summary_deadline = time.time() + 45
+        summary_clicked = False
+        while time.time() < summary_deadline:
             try:
                 title = driver.find_element(By.ID, "stepTitle").text
-                if "Summary" in title:
+                if "Finish" in title:
+                    break
+                if "Summary" in title and not summary_clicked:
                     save_btns = driver.find_elements(By.CSS_SELECTOR, "button[data-action='save-settings-file']")
                     if save_btns:
                         click_button(driver, "button[data-action='save-settings-file']")
                     else:
                         click_button(driver, "continueToFinishBtn", by=By.ID)
-                elif "Finish" in title:
-                    break
+                    summary_clicked = True
             except Exception: pass
             time.sleep(1)
 

--- a/tests/web-install-sqlite.py
+++ b/tests/web-install-sqlite.py
@@ -243,17 +243,25 @@ def test_new_installation(driver):
             pass  # No Admin User step (e.g. admins already exist)
 
         # Click through Summary / Finish
-        for i in range(10):
+        #
+        # Poll to a deadline rather than a fixed iteration count. On a slow
+        # backend the Summary step can take longer than the old ~10s budget to
+        # appear; missing it meant Continue was never clicked, so the run sat on
+        # Admin User until the Finish wait below timed out (#728).
+        summary_deadline = time.time() + 45
+        summary_clicked = False
+        while time.time() < summary_deadline:
             try:
                 title = driver.find_element(By.ID, "stepTitle").text
-                if "Summary" in title:
+                if "Finish" in title:
+                    break
+                if "Summary" in title and not summary_clicked:
                     save_btns = driver.find_elements(By.CSS_SELECTOR, "button[data-action='save-settings-file']")
                     if save_btns:
                         click_button(driver, "button[data-action='save-settings-file']")
                     else:
                         click_button(driver, "continueToFinishBtn", by=By.ID)
-                elif "Finish" in title:
-                    break
+                    summary_clicked = True
             except Exception: pass
             time.sleep(1)
 


### PR DESCRIPTION
Fixes #728.

## Cause

Filing #728 I could only offer a hypothesis. Reading the test through, the
mechanism is clearer and it is not the one I guessed — the 45s `wait_for_text`
was never the problem.

All three Selenium installer tests advance past the Summary step like this:

```python
click_button(driver, "form[data-action='create-admin-user'] button[type='submit']")
time.sleep(2)
...
for i in range(10):
    title = driver.find_element(By.ID, "stepTitle").text
    if "Summary" in title:
        ...click save-settings-file or continueToFinishBtn...
    if "Finish" in title: break
    time.sleep(1)

wait_for_text(driver, "stepTitle", "Finish")
```

That is a fixed budget of roughly **12 seconds** — `sleep(2)` plus ten 1-second
polls — for the Summary step to appear after the admin user is submitted. If
the wizard takes longer, the loop runs out *without ever clicking Continue*.
The wizard is then stuck on Admin User, and the `wait_for_text` below spends
its full 45s waiting for a title that can no longer change.

That matches the observed failures exactly: `Timed out waiting for text
'Finish' in element 'stepTitle'`, reported while the browser was still on
`http://web/wizard/index.php?step=adminuser`.

## Fix

Poll to a **deadline** instead of an iteration count, so a slow Summary is
waited for rather than missed:

```python
summary_deadline = time.time() + 45
summary_clicked = False
while time.time() < summary_deadline:
    try:
        title = driver.find_element(By.ID, "stepTitle").text
        if "Finish" in title:
            break
        if "Summary" in title and not summary_clicked:
            ...click...
            summary_clicked = True
    except Exception: pass
    time.sleep(1)
```

The `summary_clicked` flag keeps the click firing once rather than on every
poll, now that the loop can run longer. Moving the `Finish` check above the
Summary branch also removes a small divergence — the MySQL variant checked it
after, against a stale `title`; PostgreSQL and SQLite used `elif`.

**No timeout is lengthened.** The Finish wait stays at 45s and the new
deadline matches it. The bug was a loop that gave up early, not a wait that
was too short — which is why raising the timeout, the obvious first guess,
would not have helped.

## Why all three files

MySQL is the only variant that has flaked, but all three carried the identical
pattern. MySQL is simply the slowest backend in CI, so it crosses 12 seconds
first. PostgreSQL and SQLite are the same bug waiting for a slow runner, so
they are fixed here too rather than left latent.

## Verification

Honest limitation: this is a load-dependent race, so I cannot prove locally
that it is gone — a passing run does not distinguish "fixed" from "did not
flake this time". What can be checked:

- [x] `python3 -m py_compile` clean on all three files
- [x] The change is confined to the Summary loop; no other step, timeout or
      assertion is touched
- [ ] CI green on this PR (the three wizard Selenium jobs are the real exercise)

The evidence that the diagnosis is right is that the failure page was
`step=adminuser` — the run never left the Admin step, which only happens if
Continue was never clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
