### PR TITLE
test: verify admin form input actually landed (#728)

### DIFF
--- a/tests/web-install-mysql.py
+++ b/tests/web-install-mysql.py
@@ -47,6 +47,27 @@ def wait_for_text(driver, selector, text, timeout=45):
         time.sleep(0.5)
     raise TimeoutException(f"Timed out waiting for text '{text}' in element '{selector}'")
 
+def type_value(driver, element_id, value, attempts=3):
+    """Type into a field and confirm the value actually landed (#728).
+
+    send_keys can drop characters while the page is still settling. When that
+    happened to the two password fields they ended up holding different text,
+    the wizard refused to leave the Admin User step with "Passwords do not
+    match", and the run then died in the unrelated wait for the Finish step.
+    Verifying here fails fast with a useful message instead.
+    """
+    for _ in range(attempts):
+        field = driver.find_element(By.ID, element_id)
+        field.clear()
+        field.send_keys(value)
+        actual = field.get_attribute("value")
+        if actual == value:
+            return
+        print(f"  retyping {element_id}: got {actual!r}, wanted {value!r}")
+    raise AssertionError(
+        f"{element_id} would not accept {value!r} after {attempts} attempts")
+
+
 def dump_failure_context(driver):
     """Print enough to diagnose a CI-only failure without a local repro (#728).
 
@@ -286,11 +307,9 @@ def test_new_installation(driver):
         # wizard no longer auto-skips the Admin User step.
         try:
             wait_for_text(driver, "stepTitle", "Admin", timeout=45)
-            login_field = driver.find_element(By.ID, "admin_login")
-            login_field.clear()
-            login_field.send_keys("admin")
-            driver.find_element(By.ID, "admin_password").send_keys("admin123")
-            driver.find_element(By.ID, "admin_password2").send_keys("admin123")
+            type_value(driver, "admin_login", "admin")
+            type_value(driver, "admin_password", "admin123")
+            type_value(driver, "admin_password2", "admin123")
             click_button(driver, "form[data-action='create-admin-user'] button[type='submit']")
             time.sleep(2)
         except TimeoutException:

--- a/tests/web-install-postgresql.py
+++ b/tests/web-install-postgresql.py
@@ -46,6 +46,27 @@ def wait_for_text(driver, selector, text, timeout=45):
         time.sleep(0.5)
     raise TimeoutException(f"Timed out waiting for text '{text}' in element '{selector}' (current text: '{driver.find_element(By.ID, selector).text if driver.find_elements(By.ID, selector) else 'N/A'}')")
 
+def type_value(driver, element_id, value, attempts=3):
+    """Type into a field and confirm the value actually landed (#728).
+
+    send_keys can drop characters while the page is still settling. When that
+    happened to the two password fields they ended up holding different text,
+    the wizard refused to leave the Admin User step with "Passwords do not
+    match", and the run then died in the unrelated wait for the Finish step.
+    Verifying here fails fast with a useful message instead.
+    """
+    for _ in range(attempts):
+        field = driver.find_element(By.ID, element_id)
+        field.clear()
+        field.send_keys(value)
+        actual = field.get_attribute("value")
+        if actual == value:
+            return
+        print(f"  retyping {element_id}: got {actual!r}, wanted {value!r}")
+    raise AssertionError(
+        f"{element_id} would not accept {value!r} after {attempts} attempts")
+
+
 def dump_failure_context(driver):
     """Print enough to diagnose a CI-only failure without a local repro (#728).
 
@@ -240,12 +261,10 @@ def test_new_installation(driver):
         # data-action is on the form, not the button.
         try:
             wait_for_text(driver, "stepTitle", "Admin", timeout=45)
-            login_field = driver.find_element(By.ID, "admin_login")
-            login_field.clear()
-            login_field.send_keys("admin")
-            driver.find_element(By.ID, "admin_password").send_keys("admin123")
-            driver.find_element(By.ID, "admin_password2").send_keys("admin123")
-            driver.find_element(By.ID, "admin_email").send_keys("admin@example.com")
+            type_value(driver, "admin_login", "admin")
+            type_value(driver, "admin_password", "admin123")
+            type_value(driver, "admin_password2", "admin123")
+            type_value(driver, "admin_email", "admin@example.com")
             click_button(driver, "form[data-action='create-admin-user'] button[type='submit']")
             time.sleep(2)
         except TimeoutException:

--- a/tests/web-install-sqlite.py
+++ b/tests/web-install-sqlite.py
@@ -43,6 +43,27 @@ def wait_for_text(driver, selector, text, timeout=15):
         time.sleep(0.5)
     raise TimeoutException(f"Timed out waiting for text '{text}' in element '{selector}'")
 
+def type_value(driver, element_id, value, attempts=3):
+    """Type into a field and confirm the value actually landed (#728).
+
+    send_keys can drop characters while the page is still settling. When that
+    happened to the two password fields they ended up holding different text,
+    the wizard refused to leave the Admin User step with "Passwords do not
+    match", and the run then died in the unrelated wait for the Finish step.
+    Verifying here fails fast with a useful message instead.
+    """
+    for _ in range(attempts):
+        field = driver.find_element(By.ID, element_id)
+        field.clear()
+        field.send_keys(value)
+        actual = field.get_attribute("value")
+        if actual == value:
+            return
+        print(f"  retyping {element_id}: got {actual!r}, wanted {value!r}")
+    raise AssertionError(
+        f"{element_id} would not accept {value!r} after {attempts} attempts")
+
+
 def dump_failure_context(driver):
     """Print enough to diagnose a CI-only failure without a local repro (#728).
 
@@ -263,12 +284,10 @@ def test_new_installation(driver):
         # data-action is on the form, not the button.
         try:
             wait_for_text(driver, "stepTitle", "Admin", timeout=15)
-            login_field = driver.find_element(By.ID, "admin_login")
-            login_field.clear()
-            login_field.send_keys("admin")
-            driver.find_element(By.ID, "admin_password").send_keys("admin123")
-            driver.find_element(By.ID, "admin_password2").send_keys("admin123")
-            driver.find_element(By.ID, "admin_email").send_keys("admin@example.com")
+            type_value(driver, "admin_login", "admin")
+            type_value(driver, "admin_password", "admin123")
+            type_value(driver, "admin_password2", "admin123")
+            type_value(driver, "admin_email", "admin@example.com")
             click_button(driver, "form[data-action='create-admin-user'] button[type='submit']")
             time.sleep(2)
         except TimeoutException:


### PR DESCRIPTION
Fixes #728.

## Cause

The diagnostic added in #731 caught the flake on its first run and named the
cause outright:

```
FAILED on page: http://web/wizard/index.php?step=adminuser
  page title: 'WebCalendar Install Wizard - WebCalendar v1.9.23'
  stepTitle: 'Admin User'
  .invalid-feedback: 'Passwords do not match'
```

**The wizard was behaving correctly.** It refused to advance because the two
password fields did not match — even though the test types the same string
into both:

```python
driver.find_element(By.ID, "admin_password").send_keys("admin123")
driver.find_element(By.ID, "admin_password2").send_keys("admin123")
```

`send_keys` can drop characters while the page is still settling, leaving the
fields with different contents. Everything previously observed follows from
that: the run stayed on Admin User, and the *later* wait for the Finish step
timed out 45 seconds afterwards with a message pointing at the wrong stage.

The distribution fits too — MySQL is the slowest backend in CI and failed 8
times in 40 runs, against 1 for PostgreSQL and 0 for SQLite.

## Fix

Adds `type_value()`, which clears the field, types, reads the value back, and
retries up to three times before failing with a message naming the field and
what it actually contains:

```python
type_value(driver, "admin_login", "admin")
type_value(driver, "admin_password", "admin123")
type_value(driver, "admin_password2", "admin123")
```

Applied to every admin field in all three variants.

Two deliberate choices:

* **Real typing is preserved.** Setting the values via `execute_script` would
  remove the race outright, but would stop the test covering the input path at
  all.
* **A typing failure now surfaces itself.** `AssertionError` is not a
  `TimeoutException`, so it propagates past the `except TimeoutException: pass`
  that guards the optional Admin User step, reaching the handler from #731 —
  a clear failure with full diagnostics instead of a 45-second timeout blamed
  on the wrong step.

## Supersedes #729

That change adjusted the Summary step timing, which was the wrong stage. It is
left in place: polling to a deadline is still better than a fixed iteration
count, it just was not the bug.

## Test plan

- [x] `python3 -m py_compile` clean on all three files
- [x] No bare `send_keys` left on any admin field in any variant
- [ ] CI green

Honest limitation: at an 80% baseline pass rate, one green run does not prove
this fixed anything. The evidence is the captured `'Passwords do not match'`
plus a mechanism that explains the MySQL/PostgreSQL/SQLite split. Confirmation
is the failure rate over the next stretch of PRs — and if it recurs, the #731
diagnostic will now say so directly, since a genuine typing failure raises a
named `AssertionError` rather than timing out somewhere unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vqscQtk31Kkt8FWmpcvbx
