### PR TITLE
Typos

### DIFF
--- a/view_d.php
+++ b/view_d.php
@@ -20,7 +20,6 @@
  * (except for nonuser calendars... which we allow regardless of group).
  */
 // $start = microtime();
-require_once 'includes/init.php';
 require_once 'includes/views.php';
 
 $error = '';

--- a/view_l.php
+++ b/view_l.php
@@ -21,7 +21,6 @@
  * groups (except for nonuser calendars... which we allow regardless of group).
  */
 
-require_once 'includes/init.php';
 require_once 'includes/views.php';
 $id=getValue('id');
 view_init ( $id );


### PR DESCRIPTION
Use what we have instead of going the long way round.